### PR TITLE
fixes #373 save maximized mode before fullscreen

### DIFF
--- a/ImageLounge/src/DkNoMacs.cpp
+++ b/ImageLounge/src/DkNoMacs.cpp
@@ -1941,12 +1941,6 @@ void DkNoMacs::toggleFullScreen() {
 
 void DkNoMacs::enterFullScreen() {
 	
-	//// switch off fullscreen if it's in it already
-	//if (isFullScreen()) {
-	//	exitFullScreen();
-	//	return;
-	//}
-
 	DkSettings::app.currentAppMode += qFloor(DkSettings::mode_end*0.5f);
 	if (DkSettings::app.currentAppMode < 0) {
 		qDebug() << "illegal state: " << DkSettings::app.currentAppMode;
@@ -1959,8 +1953,9 @@ void DkNoMacs::enterFullScreen() {
 	statusbar->hide();
 	getTabWidget()->showTabs(false);
 
-	showFullScreen();
-
+	DkSettings::app.maximizedMode=isMaximized();
+	setWindowState(Qt::WindowFullScreen);
+	
 	if (viewport())
 		viewport()->setFullScreen(true);
 
@@ -1980,8 +1975,10 @@ void DkNoMacs::exitFullScreen() {
 		if (DkSettings::app.showToolBar) toolbar->show();
 		if (DkSettings::app.showStatusBar) statusbar->show();
 		if (DkSettings::app.showMovieToolBar) movieToolbar->show();
-		showNormal();
 
+		if(DkSettings::app.maximizedMode) setWindowState(Qt::WindowMaximized);
+		else setWindowState(Qt::WindowNoState);
+		
 		if (getTabWidget())
 			getTabWidget()->showTabs(true);
 

--- a/ImageLounge/src/DkSettings.h
+++ b/ImageLounge/src/DkSettings.h
@@ -151,6 +151,7 @@ public:
 		bool privateMode;
 		bool advancedSettings;
 		bool closeOnEsc;
+		bool maximizedMode;
 		QStringList browseFilters;
 		QStringList registerFilters;
 


### PR DESCRIPTION
Hi,

The problem of this issue was because of calling somefunctions like showNormal() only works on windows 
you can see this http://qt-project.org/doc/qt-4.8/qwidget.html#showNormal 
i save the maximized mode using a flag in the settings.h
also i removed some commented lines because you aready implemented it in toggleFullScreen


Thanks