### PR TITLE
Fix cancel button in filter dialog

### DIFF
--- a/ImageLounge/src/DkDialog.cpp
+++ b/ImageLounge/src/DkDialog.cpp
@@ -1039,8 +1039,7 @@ void DkSearchDialog::on_filterButton_pressed() {
 	done(filter_button);
 }
 
-void DkSearchDialog::on_cancelButtonSplash_pressed() {
-
+void DkSearchDialog::on_cancelButton_pressed() {
 	reject();
 }
 

--- a/ImageLounge/src/DkDialog.h
+++ b/ImageLounge/src/DkDialog.h
@@ -266,7 +266,7 @@ public slots:
 	void on_searchBar_textChanged(const QString& text);
 	void on_okButton_pressed();
 	void on_filterButton_pressed();
-	void on_cancelButtonSplash_pressed();
+	void on_cancelButton_pressed();
 	void on_resultListView_doubleClicked(const QModelIndex& modelIndex);
 	void on_resultListView_clicked(const QModelIndex& modelIndex);
 


### PR DESCRIPTION
QMetaObject::connectSlotsByName: No matching signal for on_cancelButtonSplash_pressed()