### PR TITLE
Add Fujifilm RAF file recognition

### DIFF
--- a/ImageLounge/src/DkSettings.cpp
+++ b/ImageLounge/src/DkSettings.cpp
@@ -195,6 +195,7 @@ void DkSettings::initFileFilters() {
 	app_p.rawFilters.append("Leaf Raw (*.mos)");
 	app_p.rawFilters.append("Pentax Raw (*.pef)");
 	app_p.rawFilters.append("Phase One (*.iiq)");
+	app_p.rawFilters.append("Fujifilm Raw (*.raf)");
 
 	app_p.openFilters += app_p.rawFilters;
 #endif


### PR DESCRIPTION
Hi,

Nomacs was loading the embedded 1920x1280 previews from RAF files with no problems but was ignoring them when showing the list of files in thumbnail view.

This solves the problem for me on Linux. Please let me know if the `*.raf` extension needs to be registered in any other part of the source code.

Cheers
Szymon