### PR TITLE
Use rsvg-convert for better SVG rendering

### DIFF
--- a/ImageLounge/src/DkCore/DkSettings.cpp
+++ b/ImageLounge/src/DkCore/DkSettings.cpp
@@ -969,7 +969,6 @@ void Settings::init() {
 	if (nmc::Settings::param().app().useLogFile)
 		std::cout << "log is saved to: " << nmc::DkUtils::getLogFilePath().toStdString() << std::endl;
 
-	qInfo() << "Hi there";
 	qInfoClean() << "my name is " << QApplication::organizationName() << " | " << QApplication::applicationName() 
 		<< " v " << QApplication::applicationVersion() << (nmc::Settings::param().isPortable() ? " portable" : " installed");
 

--- a/ImageLounge/src/DkGui/DkPreferenceWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkPreferenceWidgets.cpp
@@ -854,7 +854,7 @@ void DkFilePreference::createLayout() {
 
 	// cache size
 	int maxCache = qMax(qRound(DkMemory::getTotalMemory()*0.5), 1024);
-	qInfo() << "Cache size: " << maxCache;
+	qDebug() << "Cache size: " << maxCache;
 	QSpinBox* cacheBox = new QSpinBox(this);
 	cacheBox->setObjectName("cacheBox");
 	cacheBox->setMinimum(0);

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -1245,12 +1245,6 @@ void DkThumbScene::connectLoader(QSharedPointer<DkImageLoader> loader, bool conn
 }
 
 void DkThumbScene::showFile(const QString& filePath) {
-
-	if (filePath == QDir::currentPath() || filePath.isEmpty())
-		DkStatusBarManager::instance().setMessage(tr("").arg(QString::number(mThumbLabels.size())));
-	else
-		DkStatusBarManager::instance().setMessage(QFileInfo(filePath).fileName());
-
 	DkStatusBarManager::instance().setMessage(tr("%1 Images").arg(QString::number(mThumbLabels.size())), DkStatusBar::status_filenumber_info);
 }
 

--- a/ImageLounge/src/DkGui/DkViewPort.cpp
+++ b/ImageLounge/src/DkGui/DkViewPort.cpp
@@ -53,7 +53,6 @@
 #include <QInputDialog>
 #include <QMessageBox>
 #include <QDesktopWidget>
-#include <QSvgRenderer>
 #include <QMenu>
 
 #include <qmath.h>
@@ -801,7 +800,8 @@ void DkViewPort::loadSvg() {
 	if (!mLoader)
 		return;
 
-	mSvg = QSharedPointer<QSvgRenderer>(new QSvgRenderer(mLoader->filePath()));
+	mSvg = QSharedPointer<SvgRenderer>(new SvgRenderer());
+    mSvg->start_load(mLoader->filePath());
 
 	connect(mSvg.data(), SIGNAL(repaintNeeded()), this, SLOT(update()));
 
@@ -1432,7 +1432,7 @@ bool DkViewPort::unloadImage(bool fileChange) {
 	}
 
 	if (mSvg && success)
-		mSvg = QSharedPointer<QSvgRenderer>();
+		mSvg = QSharedPointer<SvgRenderer>();
 	
 	return success != 0;
 }

--- a/ImageLounge/src/DkLoader/DkBaseViewPort.cpp
+++ b/ImageLounge/src/DkLoader/DkBaseViewPort.cpp
@@ -37,7 +37,6 @@
 #include <QShortcut>
 #include <QDebug>
 #include <QTimer>
-#include <QSvgRenderer>
 #include <QMainWindow>
 
 // gestures

--- a/ImageLounge/src/DkLoader/DkBaseViewPort.h
+++ b/ImageLounge/src/DkLoader/DkBaseViewPort.h
@@ -48,7 +48,6 @@
 // Qt defines
 class QGestureEvent;
 class QShortcut;
-class QSvgRenderer;
 
 namespace nmc {
 
@@ -193,7 +192,7 @@ protected:
 
 	DkImageStorage mImgStorage;
 	QSharedPointer<QMovie> mMovie;
-	QSharedPointer<QSvgRenderer> mSvg;
+	QSharedPointer<SvgRenderer> mSvg;
 	QBrush mPattern;
 
 	QTransform mImgMatrix;

--- a/ImageLounge/src/DkLoader/DkBasicLoader.cpp
+++ b/ImageLounge/src/DkLoader/DkBasicLoader.cpp
@@ -34,6 +34,7 @@
 #include "DkTimer.h"
 #include "DkMath.h"
 #include "DkUtils.h"	// just needed for qInfo() #ifdef
+#include "DkImageStorage.h"
 
 #pragma warning(push, 0)        
 #include <QObject>
@@ -216,6 +217,11 @@ bool DkBasicLoader::loadGeneral(const QString& filePath, QSharedPointer<QByteArr
 			imgLoaded = true;
 		}
 	}
+
+    if (!imgLoaded && suf == "svg") {
+        img = SvgRenderer::render_thumb(filePath);
+        imgLoaded = !img.isNull();
+    }
 
 	// default Qt loader
 	// here we just try those formats that are officially supported

--- a/ImageLounge/src/DkLoader/DkImageStorage.h
+++ b/ImageLounge/src/DkLoader/DkImageStorage.h
@@ -33,6 +33,10 @@
 #include <QVector>
 #include <QObject>
 #include <QColor>
+#include <QSvgRenderer>
+#include <QSharedPointer>
+#include <QImageReader>
+#include <QFutureWatcher>
 
 // opencv
 #ifdef WITH_OPENCV
@@ -63,6 +67,32 @@ class QSize;
 class QColor;
 
 namespace nmc {
+
+class DllLoaderExport SvgRenderer : public QObject {
+    Q_OBJECT
+private:
+    QSharedPointer<QSvgRenderer> qsvg;
+    QString current_svg_path;
+    bool svg_is_valid;
+    bool svg_rendered;
+    QFutureWatcher<QImage> watcher;
+    QImage rasterized_svg;
+public:
+    SvgRenderer(QObject *parent=Q_NULLPTR);
+    void start_load(const QString &path);
+    void render(QPainter *painter, const QRectF &bounds);
+    QSize defaultSize() const;
+    bool isValid() const;
+    static QPixmap render_sync(const QString &, const QSize &);
+    static QImage render_thumb(QImageReader *, const QString &);
+    static QImage render_thumb(const QString &);
+signals:
+	void repaintNeeded() const;
+public slots:
+	void rendering_finished();
+    
+};
+
 
 class DkRotatingRect;
 

--- a/ImageLounge/src/DkLoader/DkThumbs.cpp
+++ b/ImageLounge/src/DkLoader/DkThumbs.cpp
@@ -184,7 +184,9 @@ QImage DkThumbNail::computeIntern(const QString& filePath, const QSharedPointer<
 		QSize initialSize = imageReader->size();
 
 		imageReader->setScaledSize(QSize(imgW, imgH));
-		thumb = imageReader->read();
+        if (imageReader->format() == "svg") {
+            thumb = SvgRenderer::render_thumb(imageReader, lFilePath);
+        } else thumb = imageReader->read();
 
 		// try to read the image
 		if (thumb.isNull()) {

--- a/ImageLounge/src/main.cpp
+++ b/ImageLounge/src/main.cpp
@@ -75,10 +75,29 @@
 void createPluginsPath();
 void computeBatch(const QString& settingsPath, const QString& logPath = QString());
 
+#ifndef Q_OS_WIN
+void silence_info_message_handler(QtMsgType type, const QMessageLogContext &context, const QString &msg)
+  {
+      QByteArray localMsg = msg.toLocal8Bit();
+      switch (type) {
+      case QtWarningMsg:
+          fprintf(stderr, "[WARN] %s (%s:%u, %s)\n", localMsg.constData(), context.file, context.line, context.function);
+          break;
+      case QtCriticalMsg:
+          fprintf(stderr, "[CRIT] %s (%s:%u, %s)\n", localMsg.constData(), context.file, context.line, context.function);
+          break;
+      case QtFatalMsg:
+          fprintf(stderr, "[FATAL] %s (%s:%u, %s)\n", localMsg.constData(), context.file, context.line, context.function);
+          abort();
+      }
+  }
+#endif
+
 #ifdef Q_OS_WIN
 int main(int argc, wchar_t *argv[]) {
 #else
 int main(int argc, char *argv[]) {
+    if (getenv("NOMACS_SILENT")) qInstallMessageHandler(silence_info_message_handler);
 #endif
 
 #ifdef READ_TUWIEN


### PR DESCRIPTION
At runtime, the presence of rsvg-convert is detected, and, if available
it is used to render SVG images. This is needed because QSvgRenderer
only supports SVG Tiny. An example of an SVG file it does
not render correctly: https://commons.wikimedia.org/wiki/File:Emoji_u1f337.svg

Note that QSvgRenderer is still used to render the application icons.

Downsides:

1) SVG rendering is slower. This is mitigated by using a disk cache to
store the rendered svg files, keyed by the file path, render size and
file mtime.

2) No support for SVG animation. This could be remedied in the future
by using another backend to render SVG. Options are librsvg and
QWebEngine.

EDIT: Also contains some commits to prevent nomacs from spamming stdout (I run nomacs from the terminal)