### PR TITLE
Compile fix

### DIFF
--- a/ImageLounge/src/DkCore/DkProcess.cpp
+++ b/ImageLounge/src/DkCore/DkProcess.cpp
@@ -41,6 +41,8 @@
 #include <QWidget>
 #pragma warning(pop)		// no warnings from includes - end
 
+#include <cassert>
+
 namespace nmc {
 
 /// <summary>


### PR DESCRIPTION
These changes ensure that the CMake build directory can be the same as the source directory, and still being able to do "git add ." without the wrong files being included.
quazip.vcxproj gets auto generated, so no need to keep it in the git repo.

My VS2015 complained that assert was not defined in DkProcess.cpp, so I added #include <cassert>