### PR TITLE
Enhancements for easier handling of large number of tabbed images

### DIFF
--- a/ImageLounge/src/DkCore/DkActionManager.cpp
+++ b/ImageLounge/src/DkCore/DkActionManager.cpp
@@ -944,7 +944,7 @@ void DkActionManager::createActions(QWidget* parent) {
 	mFileActions[menu_file_open_dir]->setShortcut(QKeySequence(shortcut_open_dir));
 	mFileActions[menu_file_open_dir]->setStatusTip(QObject::tr("Open a directory and load its first image"));
 
-	mFileActions[menu_file_open_list] = new QAction(mFileIcons[icon_file_open], QObject::tr("&Open Tabs"), parent);
+	mFileActions[menu_file_open_list] = new QAction(QObject::tr("&Open Tabs"), parent);
 	mFileActions[menu_file_open_list]->setStatusTip(QObject::tr("Open a texfile containing a list of filepaths, and open tabs for them"));
 
 	mFileActions[menu_file_quick_launch] = new QAction(QObject::tr("&Quick Launch"), parent);

--- a/ImageLounge/src/DkCore/DkActionManager.cpp
+++ b/ImageLounge/src/DkCore/DkActionManager.cpp
@@ -363,6 +363,7 @@ QMenu* DkActionManager::createFileMenu(QWidget* parent /* = 0 */) {
 
 	mFileMenu->addAction(mFileActions[menu_file_open]);
 	mFileMenu->addAction(mFileActions[menu_file_open_dir]);
+	mFileMenu->addAction(mFileActions[menu_file_open_list]);
 
 	// add open with menu
 	mFileMenu->addMenu(openWithMenu());
@@ -942,6 +943,9 @@ void DkActionManager::createActions(QWidget* parent) {
 	mFileActions[menu_file_open_dir] = new QAction(mFileIcons[icon_file_dir], QObject::tr("Open &Directory"), parent);
 	mFileActions[menu_file_open_dir]->setShortcut(QKeySequence(shortcut_open_dir));
 	mFileActions[menu_file_open_dir]->setStatusTip(QObject::tr("Open a directory and load its first image"));
+
+	mFileActions[menu_file_open_list] = new QAction(mFileIcons[icon_file_open], QObject::tr("&Open Tabs"), parent);
+	mFileActions[menu_file_open_list]->setStatusTip(QObject::tr("Open a texfile containing a list of filepaths, and open tabs for them"));
 
 	mFileActions[menu_file_quick_launch] = new QAction(QObject::tr("&Quick Launch"), parent);
 	mFileActions[menu_file_quick_launch]->setShortcutContext(Qt::WidgetWithChildrenShortcut);

--- a/ImageLounge/src/DkCore/DkActionManager.cpp
+++ b/ImageLounge/src/DkCore/DkActionManager.cpp
@@ -371,6 +371,7 @@ QMenu* DkActionManager::createFileMenu(QWidget* parent /* = 0 */) {
 	mFileMenu->addSeparator();
 	mFileMenu->addAction(mFileActions[menu_file_save]);
 	mFileMenu->addAction(mFileActions[menu_file_save_as]);
+	mFileMenu->addAction(mFileActions[menu_file_save_list]);
 	mFileMenu->addAction(mFileActions[menu_file_save_web]);
 	mFileMenu->addAction(mFileActions[menu_file_rename]);
 	mFileMenu->addSeparator();
@@ -969,6 +970,9 @@ void DkActionManager::createActions(QWidget* parent) {
 	mFileActions[menu_file_save_as] = new QAction(QObject::tr("&Save As"), parent);
 	mFileActions[menu_file_save_as]->setShortcut(QKeySequence(shortcut_save_as));
 	mFileActions[menu_file_save_as]->setStatusTip(QObject::tr("Save an image as"));
+
+	mFileActions[menu_file_save_list] = new QAction(QObject::tr("&Save Tabs"), parent);
+	mFileActions[menu_file_save_list]->setStatusTip(QObject::tr("Save a newline seperated list of the filenames of the open tabs"));
 
 	mFileActions[menu_file_save_web] = new QAction(QObject::tr("&Save for Web"), parent);
 	mFileActions[menu_file_save_web]->setStatusTip(QObject::tr("Save an Image for Web Applications"));

--- a/ImageLounge/src/DkCore/DkActionManager.h
+++ b/ImageLounge/src/DkCore/DkActionManager.h
@@ -119,6 +119,7 @@ public:
 		menu_file_app_manager,
 		menu_file_save,
 		menu_file_save_as,
+		menu_file_save_list,
 		menu_file_save_web,
 		menu_file_rename,
 		menu_file_goto,

--- a/ImageLounge/src/DkCore/DkActionManager.h
+++ b/ImageLounge/src/DkCore/DkActionManager.h
@@ -115,6 +115,7 @@ public:
 	enum FileMenuActions {
 		menu_file_open,
 		menu_file_open_dir,
+		menu_file_open_list,
 		menu_file_quick_launch,
 		menu_file_app_manager,
 		menu_file_save,

--- a/ImageLounge/src/DkGui/DkCentralWidget.cpp
+++ b/ImageLounge/src/DkGui/DkCentralWidget.cpp
@@ -68,6 +68,7 @@ DkTabInfo::DkTabInfo(const QSharedPointer<DkImageContainerT> imgC, int idx, QObj
 
 	mTabMode = (!imgC) ? tab_recent_files : tab_single_image;
 	mTabIdx = idx;
+	mFilePath = getFilePath();
 }
 
 DkTabInfo::DkTabInfo(TabMode mode, int idx, QObject* parent) : QObject(parent) {
@@ -113,6 +114,8 @@ void DkTabInfo::saveSettings(QSettings& settings) const {
 void DkTabInfo::setFilePath(const QString& filePath) {
 
 	mImageLoader->setCurrentImage(QSharedPointer<DkImageContainerT>(new DkImageContainerT(filePath)));
+	setMode(tab_single_image);
+	mFilePath = filePath;
 }
 
 void DkTabInfo::setDirPath(const QString& dirPath) {
@@ -123,7 +126,7 @@ void DkTabInfo::setDirPath(const QString& dirPath) {
 
 QString DkTabInfo::getFilePath() const {
 
-	return (mImageLoader->getCurrentImage()) ? mImageLoader->getCurrentImage()->filePath() : QString();
+	return (mImageLoader->getCurrentImage()) ? mImageLoader->getCurrentImage()->filePath() : mFilePath;
 }
 
 void DkTabInfo::setTabIdx(int tabIdx) {
@@ -142,6 +145,7 @@ void DkTabInfo::setImage(QSharedPointer<DkImageContainerT> imgC) {
 	
 	if (imgC)
 		mTabMode = tab_single_image;
+	mFilePath = getFilePath();
 }
 
 QSharedPointer<DkImageLoader> DkTabInfo::getImageLoader() const {
@@ -1028,8 +1032,11 @@ void DkCentralWidget::loadFileToTab(const QString& filePath) {
 	if (mTabInfos.size() > 1 || (!mTabInfos.empty() && mTabInfos.at(0)->getMode() != DkTabInfo::tab_empty)) {
 		addTab(filePath);
 	}
-	else
-		mViewport->loadFile(filePath);
+	else {
+		mTabInfos.at(0)->setFilePath(filePath);
+		updateTab(mTabInfos.at(0));
+		currentTabChanged(0);
+	}
 }
 
 void DkCentralWidget::loadDirToTab(const QString& dirPath) {

--- a/ImageLounge/src/DkGui/DkCentralWidget.cpp
+++ b/ImageLounge/src/DkGui/DkCentralWidget.cpp
@@ -266,6 +266,8 @@ void DkCentralWidget::createLayout() {
 
 	mTabbar = new QTabBar(this);
 	mTabbar->setShape(QTabBar::RoundedNorth);
+	mTabbar->setElideMode(Qt::TextElideMode::ElideRight);
+	mTabbar->setUsesScrollButtons(true);
 	mTabbar->setTabsClosable(true);
 	mTabbar->setMovable(true);
 	mTabbar->hide();

--- a/ImageLounge/src/DkGui/DkCentralWidget.cpp
+++ b/ImageLounge/src/DkGui/DkCentralWidget.cpp
@@ -700,25 +700,25 @@ void DkCentralWidget::updateTabIdx() {
 }
 
 void DkCentralWidget::nextTab() const {
-
-	if (mTabInfos.size() < 2)
-		return;
-
 	int idx = mTabbar->currentIndex();
 	idx++;
-	idx %= mTabInfos.size();
-	mTabbar->setCurrentIndex(idx);
+	setActiveTab(idx);
 }
 
 void DkCentralWidget::previousTab() const {
+	int idx = mTabbar->currentIndex();
+	idx--;
+	setActiveTab(idx);
+}
 
+void DkCentralWidget::setActiveTab(int idx) const {
 	if (mTabInfos.size() < 2)
 		return;
 
-	int idx = mTabbar->currentIndex();
-	idx--;
 	if (idx < 0)
-		idx = mTabInfos.size()-1;
+		idx = mTabInfos.size() - 1;
+
+	idx %= mTabInfos.size();
 	mTabbar->setCurrentIndex(idx);
 }
 

--- a/ImageLounge/src/DkGui/DkCentralWidget.h
+++ b/ImageLounge/src/DkGui/DkCentralWidget.h
@@ -157,6 +157,7 @@ public slots:
 	void removeTab(int tabIdx = -1);
 	void nextTab() const;
 	void previousTab() const;
+	void setActiveTab(int idx) const;
 	void showThumbView(bool show = true);
 	void showViewPort(bool show = true);
 	void showRecentFiles(bool show = true);

--- a/ImageLounge/src/DkGui/DkCentralWidget.h
+++ b/ImageLounge/src/DkGui/DkCentralWidget.h
@@ -110,6 +110,7 @@ protected:
 	QSharedPointer<DkImageLoader> mImageLoader;
 	int mTabIdx = 0;
 	int mTabMode = tab_recent_files;
+	QString mFilePath = "";
 };
 
 class DkViewPort;

--- a/ImageLounge/src/DkGui/DkNoMacs.cpp
+++ b/ImageLounge/src/DkGui/DkNoMacs.cpp
@@ -1271,10 +1271,17 @@ void DkNoMacs::openFile() {
 	if (fileNames.isEmpty())
 		return;
 
+	int count = getTabWidget()->getTabs().count();
+	if (getTabWidget()->getTabs().at(0)->getMode() == DkTabInfo::tab_empty)
+		count = 0; 
+		
+
 	for (QString fileName : fileNames) {
 		qDebug() << "os filename: " << fileName;
 		getTabWidget()->loadFileToTab(fileName);
 	}
+
+	getTabWidget()->setActiveTab(count);
 }
 
 void DkNoMacs::saveFileList() {

--- a/ImageLounge/src/DkGui/DkNoMacs.cpp
+++ b/ImageLounge/src/DkGui/DkNoMacs.cpp
@@ -1298,6 +1298,10 @@ void DkNoMacs::openFileList() {
 	if (fileName.isEmpty())
 		return;
 
+	int count = getTabWidget()->getTabs().count();
+	if (getTabWidget()->getTabs().at(0)->getMode() == DkTabInfo::tab_empty)
+		count = 0;
+
 	QFile file(fileName);
 	if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
 		return;
@@ -1308,6 +1312,8 @@ void DkNoMacs::openFileList() {
 			getTabWidget()->loadFileToTab(line);
 		}
 	}
+
+	getTabWidget()->setActiveTab(count);
 }
 
 void DkNoMacs::saveFileList() {

--- a/ImageLounge/src/DkGui/DkNoMacs.cpp
+++ b/ImageLounge/src/DkGui/DkNoMacs.cpp
@@ -1262,15 +1262,17 @@ void DkNoMacs::openFile() {
 	openFilters.prepend(tr("All Files (*.*)"));
 
 	// load system default open dialog
-	QString fileName = QFileDialog::getOpenFileName(this, tr("Open Image"),
+	QStringList fileNames = QFileDialog::getOpenFileNames(this, tr("Open Image"),
 		getTabWidget()->getCurrentDir(), 
 		openFilters.join(";;"));
 
-	if (fileName.isEmpty())
+	if (fileNames.isEmpty())
 		return;
 
-	qDebug() << "os filename: " << fileName;
-	getTabWidget()->loadFile(fileName);
+	for (QString fileName : fileNames) {
+		qDebug() << "os filename: " << fileName;
+		getTabWidget()->loadFileToTab(fileName);
+	}
 }
 
 void DkNoMacs::openQuickLaunch() {

--- a/ImageLounge/src/DkGui/DkNoMacs.cpp
+++ b/ImageLounge/src/DkGui/DkNoMacs.cpp
@@ -374,6 +374,7 @@ void DkNoMacs::createActions() {
 	connect(am.action(DkActionManager::menu_file_open), SIGNAL(triggered()), this, SLOT(openFile()));
 	connect(am.action(DkActionManager::menu_file_open_dir), SIGNAL(triggered()), this, SLOT(openDir()));
 	connect(am.action(DkActionManager::menu_file_quick_launch), SIGNAL(triggered()), this, SLOT(openQuickLaunch()));
+	connect(am.action(DkActionManager::menu_file_open_list), SIGNAL(triggered()), this, SLOT(openFileList()));
 	connect(am.action(DkActionManager::menu_file_save_list), SIGNAL(triggered()), this, SLOT(saveFileList()));
 	connect(am.action(DkActionManager::menu_file_rename), SIGNAL(triggered()), this, SLOT(renameFile()));
 	connect(am.action(DkActionManager::menu_file_goto), SIGNAL(triggered()), this, SLOT(goTo()));
@@ -1282,6 +1283,31 @@ void DkNoMacs::openFile() {
 	}
 
 	getTabWidget()->setActiveTab(count);
+}
+
+void DkNoMacs::openFileList() {
+	QStringList openFilters = DkSettingsManager::param().app().openFilters;
+	openFilters.pop_front();
+	openFilters.prepend(tr("Text file (*.txt)"));
+
+	// load system default open dialog
+	QString fileName = QFileDialog::getOpenFileName(this, tr("Open Image"),
+		getTabWidget()->getCurrentDir(),
+		openFilters.join(";;"));
+
+	if (fileName.isEmpty())
+		return;
+
+	QFile file(fileName);
+	if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
+		return;
+
+	while (!file.atEnd()) {
+		QString line = file.readLine().simplified();
+		if (QFileInfo::exists(line)) {
+			getTabWidget()->loadFileToTab(line);
+		}
+	}
 }
 
 void DkNoMacs::saveFileList() {

--- a/ImageLounge/src/DkGui/DkNoMacs.cpp
+++ b/ImageLounge/src/DkGui/DkNoMacs.cpp
@@ -374,6 +374,7 @@ void DkNoMacs::createActions() {
 	connect(am.action(DkActionManager::menu_file_open), SIGNAL(triggered()), this, SLOT(openFile()));
 	connect(am.action(DkActionManager::menu_file_open_dir), SIGNAL(triggered()), this, SLOT(openDir()));
 	connect(am.action(DkActionManager::menu_file_quick_launch), SIGNAL(triggered()), this, SLOT(openQuickLaunch()));
+	connect(am.action(DkActionManager::menu_file_save_list), SIGNAL(triggered()), this, SLOT(saveFileList()));
 	connect(am.action(DkActionManager::menu_file_rename), SIGNAL(triggered()), this, SLOT(renameFile()));
 	connect(am.action(DkActionManager::menu_file_goto), SIGNAL(triggered()), this, SLOT(goTo()));
 	connect(am.action(DkActionManager::menu_file_print), SIGNAL(triggered()), this, SLOT(printDialog()));
@@ -449,6 +450,7 @@ void DkNoMacs::enableNoImageActions(bool enable) {
 
 	am.action(DkActionManager::menu_file_save)->setEnabled(enable);
 	am.action(DkActionManager::menu_file_save_as)->setEnabled(enable);
+	am.action(DkActionManager::menu_file_save_list)->setEnabled(enable);
 	am.action(DkActionManager::menu_file_save_web)->setEnabled(enable);
 	am.action(DkActionManager::menu_file_rename)->setEnabled(enable);
 	am.action(DkActionManager::menu_file_print)->setEnabled(enable);
@@ -1273,6 +1275,33 @@ void DkNoMacs::openFile() {
 		qDebug() << "os filename: " << fileName;
 		getTabWidget()->loadFileToTab(fileName);
 	}
+}
+
+void DkNoMacs::saveFileList() {
+
+	if (!viewport())
+		return;
+
+	QStringList saveFilters = DkSettingsManager::param().app().saveFilters;
+	saveFilters.pop_front();
+	saveFilters.prepend(tr("Text file (*.txt)"));
+
+	QString fileName = QFileDialog::getSaveFileName(this, tr("Save Tab List"),
+		getTabWidget()->getCurrentDir(),
+		saveFilters.join(";;"));
+
+	if (fileName.isEmpty())
+		return;
+
+	QFile file(fileName);
+	if (!file.open(QIODevice::ReadWrite | QIODevice::Text))
+		return;
+
+	for (auto tab : getTabWidget()->getTabs()) {
+		file.write(tab->getFilePath().toUtf8()+"\n");
+	}
+
+	file.close();
 }
 
 void DkNoMacs::openQuickLaunch() {

--- a/ImageLounge/src/DkGui/DkNoMacs.h
+++ b/ImageLounge/src/DkGui/DkNoMacs.h
@@ -167,6 +167,7 @@ public slots:
 	void openDir();
 	void openFile();
 	void openQuickLaunch();
+	void openFileList();
 	void saveFileList();
 	void renameFile();
 	void changeSorting(bool change);

--- a/ImageLounge/src/DkGui/DkNoMacs.h
+++ b/ImageLounge/src/DkGui/DkNoMacs.h
@@ -167,6 +167,7 @@ public slots:
 	void openDir();
 	void openFile();
 	void openQuickLaunch();
+	void saveFileList();
 	void renameFile();
 	void changeSorting(bool change);
 	void goTo();


### PR DESCRIPTION
My primary use case for this program involves having many images open at the same time in different tabs.
In order to make this easier I have added several options:
Open File can now open multiple images at the same time, each in their own tab. (This is optional, as selecting one file works just as before)
New menu buttons "Open Tabs" and "Save Tabs", which respectively load and save a text file containing the file paths of every open tab, one per line. This allows for easy opening of many different sequences of images, not necessarily in the same folder and/or order.
Elision of tabs: The tabs now get smaller when there are a large number of them open. When the minimum tab size has been reached, the Tabbar scrolls as before.
Fixed bug in loadFileToTab, see commit.
I added a function to switch to a tab by idx, and changed previoustab() and nexttab() to use it. This in order to add the functionality that when opening multiple tabs, after opening all of them it switches to the first one opened, as that is usually the image you want to see first.
I have made these changes in order for the program to fit my use case. I do not know if the changes I have made fit within your vision for the program. Please comment on what you would like changed for this to be accepted.