### PR TITLE
Don't install to absolute paths

### DIFF
--- a/ImageLounge/cmake/UnixBuildTarget.cmake
+++ b/ImageLounge/cmake/UnixBuildTarget.cmake
@@ -80,7 +80,7 @@ install(FILES ${NOMACS_QM} DESTINATION share/nomacs/translations)
 #  manpage
 install(FILES Readme/nomacs.1 DESTINATION share/man/man1)
 #  appdata
-install(FILES nomacs.appdata.xml DESTINATION /usr/share/appdata/)
+install(FILES nomacs.appdata.xml DESTINATION share/appdata/)
 
 # "make dist" target
 string(TOLOWER ${PROJECT_NAME} CPACK_PACKAGE_NAME)


### PR DESCRIPTION
Static files should probably be installed relative to the installation root, rather than via absolute paths.

Ran into this while packaging `nomacs` for the `nixpkgs` repository.