### PR TITLE
Show image statistics in histogram

### DIFF
--- a/ImageLounge/src/DkCore/DkSettings.cpp
+++ b/ImageLounge/src/DkCore/DkSettings.cpp
@@ -395,6 +395,7 @@ void DkSettings::load(QSettings& settings, bool defaults) {
 	//display_p.saveThumb = settings.value("saveThumb", display_p.saveThumb).toBool();
 	display_p.antiAliasing = settings.value("antiAliasing", display_p.antiAliasing).toBool();
 	display_p.showCrop = settings.value("showCrop", display_p.showCrop).toBool();
+	display_p.histogramStyle = settings.value("histogramStyle", display_p.histogramStyle).toInt();
 	display_p.tpPattern = settings.value("tpPattern", display_p.tpPattern).toBool();
 	display_p.toolbarGradient = settings.value("toolbarGradient", display_p.toolbarGradient).toBool();
 	display_p.showBorder = settings.value("showBorder", display_p.showBorder).toBool();
@@ -632,6 +633,8 @@ void DkSettings::save(QSettings& settings, bool force) {
 		settings.setValue("antiAliasing", display_p.antiAliasing);
 	if (force ||display_p.showCrop != display_d.showCrop)
 		settings.setValue("showCrop", display_p.showCrop);
+	if (force ||display_p.histogramStyle != display_d.histogramStyle)
+		settings.setValue("histogramStyle", display_p.histogramStyle);
 	if (force ||display_p.tpPattern != display_d.tpPattern)
 		settings.setValue("tpPattern", display_p.tpPattern);
 	if (force ||display_p.toolbarGradient != display_d.toolbarGradient)
@@ -828,6 +831,7 @@ void DkSettings::setToDefaultSettings() {
 	display_p.thumbPreviewSize = 64;
 	display_p.antiAliasing = true;
 	display_p.showCrop = false;
+	display_p.histogramStyle = 0; // DkHistogram::DisplayMode::histogram_mode_simple
 	display_p.tpPattern = false;
 	display_p.toolbarGradient = false;
 	display_p.showBorder = false;

--- a/ImageLounge/src/DkCore/DkSettings.h
+++ b/ImageLounge/src/DkCore/DkSettings.h
@@ -201,6 +201,8 @@ public:
 		TransitionMode transition;
 		bool alwaysAnimate;
 		float animationDuration;
+
+		int histogramStyle;
 	};
 
 	struct Global {

--- a/ImageLounge/src/DkGui/DkPreferenceWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkPreferenceWidgets.cpp
@@ -780,6 +780,18 @@ void DkDisplayPreference::createLayout() {
 	DkGroupWidget* showCropGroup = new DkGroupWidget(tr("Show Metadata Cropping"), this);
 	showCropGroup->addWidget(showCrop);
 
+	// histogram
+	QComboBox* histogramStyleCombo = new QComboBox(this);
+	histogramStyleCombo->setObjectName("histogramStyleCombo");
+	histogramStyleCombo->setToolTip(tr("Choose your preferred histogram style"));
+	histogramStyleCombo->addItem(tr("Show only the Histogram"), (int)DkHistogram::DisplayMode::histogram_mode_simple);
+	histogramStyleCombo->addItem(tr("Show Histogram and image statistics"), (int)DkHistogram::DisplayMode::histogram_mode_extended);
+	histogramStyleCombo->setCurrentIndex(DkSettingsManager::param().display().histogramStyle);
+	histogramStyleCombo->setMinimumHeight(2);
+
+	DkGroupWidget* histogramGroup = new DkGroupWidget(tr("Histogram"), this);
+	histogramGroup->addWidget(histogramStyleCombo);
+
 	// left column
 	QWidget* leftWidget = new QWidget(this);
 	QVBoxLayout* leftLayout = new QVBoxLayout(leftWidget);
@@ -794,6 +806,7 @@ void DkDisplayPreference::createLayout() {
 	QWidget* rightWidget = new QWidget(this);
 	QVBoxLayout* rightLayout = new QVBoxLayout(rightWidget);
 	rightLayout->setAlignment(Qt::AlignTop);
+	rightLayout->addWidget(histogramGroup);
 
 	QHBoxLayout* layout = new QHBoxLayout(this);
 	layout->setAlignment(Qt::AlignLeft);
@@ -870,6 +883,12 @@ void DkDisplayPreference::on_showCrop_toggled(bool checked) const {
 	if (DkSettingsManager::param().display().showCrop != checked)
 		DkSettingsManager::param().display().showCrop = checked;
 
+}
+
+void DkDisplayPreference::on_histogramStyleCombo_currentIndexChanged(int styleIdx) const
+{
+	if (DkSettingsManager::param().display().histogramStyle != styleIdx)
+		DkSettingsManager::param().display().histogramStyle = styleIdx;
 }
 
 

--- a/ImageLounge/src/DkGui/DkPreferenceWidgets.h
+++ b/ImageLounge/src/DkGui/DkPreferenceWidgets.h
@@ -191,6 +191,7 @@ public slots:
 	void on_transition_currentIndexChanged(int index) const;
 	void on_alwaysAnimate_toggled(bool checked) const;
 	void on_showCrop_toggled(bool checked) const;
+	void on_histogramStyleCombo_currentIndexChanged(int styleIdx) const;
 
 signals:
 	void infoSignal(const QString& msg) const;

--- a/ImageLounge/src/DkGui/DkWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkWidgets.cpp
@@ -2105,7 +2105,7 @@ DkHistogram::DkHistogram(QWidget *parent) : DkWidget(parent){
 	
 	setObjectName("DkHistogram");
 	setMinimumWidth(265);
-	setMinimumHeight(130);
+	setMinimumHeight(142);
 	setCursor(Qt::ArrowCursor);
 }
 
@@ -2118,13 +2118,17 @@ DkHistogram::~DkHistogram() {
 void DkHistogram::paintEvent(QPaintEvent*) {
 
 	QPainter painter(this);
-	//painter.setPen(QColor(200, 200, 200));
 	painter.fillRect(1, 1, width(), height(), mBgCol);
-	//painter.drawRect(1, 1, width(), height());
 
-	int margin = 5;
-	int binHeight = height() - margin * 2;
+	const int margin = 5;
+	const int TEXT_SIZE = 12 + 1;  //FIXME just guessed
+	const int NUM_TEXT_LINES = 2;
+	const int textHeight = NUM_TEXT_LINES * TEXT_SIZE + margin + 5;
 
+	int binHeight = height() - margin * 2 - textHeight;
+	int binBottom = height() - margin - textHeight;
+
+	//draw Histogram
 	if(mIsPainted && mMaxValue > 0){
 		
 		for(int x = 0; x < 256; x++){
@@ -2137,16 +2141,47 @@ void DkHistogram::paintEvent(QPaintEvent*) {
 
 			painter.setCompositionMode(QPainter::CompositionMode_Clear);
 			painter.setPen(Qt::black);
-			painter.drawLine(QPoint(x + margin, height() - margin), QPoint(x + margin, height()-margin - maxLineHeight));
+			painter.drawLine(QPoint(x + margin, binBottom), QPoint(x + margin, binBottom - maxLineHeight));
 
 			painter.setCompositionMode(QPainter::CompositionMode_Screen);
 			painter.setPen(Qt::red);
-			painter.drawLine(QPoint(x+margin, height()-margin), QPoint(x+margin, height()-margin-rLineHeight));
+			painter.drawLine(QPoint(x+margin, binBottom), QPoint(x+margin, binBottom - rLineHeight));
 			painter.setPen(Qt::green);
-			painter.drawLine(QPoint(x+margin, height()-margin), QPoint(x+margin, height()-margin-gLineHeight));
+			painter.drawLine(QPoint(x+margin, binBottom), QPoint(x+margin, binBottom - gLineHeight));
 			painter.setPen(Qt::blue);
-			painter.drawLine(QPoint(x+margin, height()-margin), QPoint(x+margin, height()-margin-bLineHeight));
+			painter.drawLine(QPoint(x+margin, binBottom), QPoint(x+margin, binBottom - bLineHeight));
 		}
+	}
+
+	//draw histogram text
+	double activeRatio = (double)mNumNonZeroPixels / (double)mNumPixels;
+	double megaPixels = (double)mNumPixels * 10.0e-7;
+	painter.setPen(QColor(180, 180, 180));
+
+	QString histText1("Pixels: %1 MPix: %2");
+	painter.drawText(QPoint(margin, height() - 2 * TEXT_SIZE),
+					 histText1.arg(mNumPixels, 10, 10, QChar(' '))
+							  .arg(megaPixels, 10, 'f', -1,  QChar(' '))
+							  .arg(100.0 * activeRatio, 5, 'f', 3, QChar(' ')));
+	if (mMinBinValue < 256) {
+		//gray image statistics
+		QString histText2("Min: %1 Max: %2 Value Count: %3");
+		painter.drawText(QPoint(margin, height() - 1 * TEXT_SIZE),
+						 histText2.arg(mMinBinValue, 5, 10, QChar(' '))
+								  .arg(mMaxBinValue, 5, 10, QChar(' '))
+								  .arg(mNumDistinctValues, 5, 10, QChar(' ')));
+	}else{
+		//color image statistics
+		double blackPct = 100.0 * (double)mNumZeroPixels / (double)mNumPixels;
+		double whitePct = 100.0 * (double)mNumSaturatedPixels / (double)mNumPixels;
+		double goodPct = 100.0 * (double)(mNumPixels - mNumZeroPixels - mNumSaturatedPixels) / (double)mNumPixels;
+
+		QString histText2("Black: %1 Good: %3 White: %2");
+		painter.drawText(QPoint(margin, height() - 1 * TEXT_SIZE),
+						 histText2.arg(blackPct, 5, 'f', 2, QChar(' '))
+								  .arg(whitePct, 5, 'f', 2, QChar(' '))
+								  .arg(goodPct, 5, 'f', 2, QChar(' ')));
+
 	}
 }
 
@@ -2163,17 +2198,22 @@ void DkHistogram::drawHistogram(QImage imgQt) {
 
 	DkTimer dt;
 
-#ifdef WITH_OPENCV
-	
-	int histValues[3][256];
+	//clear histogram values
+	mNumNonZeroPixels = 0;
+	mNumZeroPixels = 0;
+	mNumSaturatedPixels = 0;
+	mMaxBinValue = -1;
+	mMinBinValue = 256;
+	mMaxValue = 0;
+	mNumPixels = imgQt.width() * imgQt.height();
 
 	for (int idx = 0; idx < 256; idx++) {
-		histValues[0][idx] = 0;
-		histValues[1][idx] = 0;
-		histValues[2][idx] = 0;
+		mHist[0][idx] = 0;
+		mHist[1][idx] = 0;
+		mHist[2][idx] = 0;
 	}
-	
 
+	// count pixel- and total values, for
 	// 8 bit images
 	if (imgQt.depth() == 8) {
 
@@ -2185,9 +2225,14 @@ void DkHistogram::drawHistogram(QImage imgQt) {
 
 			for (int cIdx = 0; cIdx < imgQt.width(); cIdx++, pixel++) {
 
-				histValues[0][*pixel]++;
-				histValues[1][*pixel]++;
-				histValues[2][*pixel]++;
+				mHist[0][*pixel]++;
+				mHist[1][*pixel]++;
+				mHist[2][*pixel]++;
+
+				if (*pixel) mNumNonZeroPixels++;
+				if (*pixel == 255) mNumSaturatedPixels++;
+				if (*pixel < mMinBinValue) mMinBinValue = *pixel;
+				if (*pixel > mMaxBinValue) mMaxBinValue = *pixel;
 			}
 		}
 	}
@@ -2200,13 +2245,13 @@ void DkHistogram::drawHistogram(QImage imgQt) {
 		for (int rIdx = 0; rIdx < imgQt.height(); rIdx++) {
 
 			const unsigned char* pixel = imgQt.constScanLine(rIdx);
-
 			for (int cIdx = 0; cIdx < imgQt.width(); cIdx++) {
 
 				// If I understood the api correctly, the first bits are 0 if we have 24bpp & < 8 bits per channel
-				histValues[0][*pixel]++; pixel++;
-				histValues[1][*pixel]++; pixel++;
-				histValues[2][*pixel]++; pixel++;
+				mHist[0][*pixel]++; pixel++;
+				mHist[1][*pixel]++; pixel++;
+				mHist[2][*pixel]++; pixel++;
+
 			}
 		}
 	}
@@ -2218,36 +2263,47 @@ void DkHistogram::drawHistogram(QImage imgQt) {
 			const QRgb* pixel = (QRgb*)(imgQt.constScanLine(rIdx));
 	
 			for (int cIdx = 0; cIdx < imgQt.width(); cIdx++, pixel++) {
+				size_t pixR = static_cast<size_t>(qRed(*pixel));
+				size_t pixG = static_cast<size_t>(qGreen(*pixel));
+				size_t pixB = static_cast<size_t>(qBlue(*pixel));
 
-				histValues[0][qRed(*pixel)]++;
-				histValues[1][qGreen(*pixel)]++;
-				histValues[2][qBlue(*pixel)]++;
+				mHist[0][pixR]++;
+				mHist[1][pixG]++;
+				mHist[2][pixB]++;
+
+				if (pixR == 0 && pixG == 0 && pixB == 0) {
+					mNumZeroPixels++;
+				}
+
+				if (pixR || pixG || pixB) {
+					mNumNonZeroPixels++;
+				}
+
+				if (pixR == 255 && pixG == 255 && pixB == 255) {
+					mNumSaturatedPixels++;
+				}
 			}
 		}
 	}
 
-	int maxHistValue = 0;
+	// determine extreme values from the histogram
+	mNumDistinctValues = 0;
 
-	for (int idx = 0; idx < 256; idx++) {
-		
-		if (histValues[0][idx] > maxHistValue)
-			maxHistValue = histValues[0][idx];
-		if (histValues[1][idx] > maxHistValue)
-			maxHistValue = histValues[1][idx];
-		if (histValues[2][idx] > maxHistValue)
-			maxHistValue = histValues[2][idx];
-	}
+    for (int idx = 0; idx < 256; idx++) {
+        if (mHist[0][idx] > mMaxValue)
+            mMaxValue = mHist[0][idx];
+        if (mHist[1][idx] > mMaxValue)
+            mMaxValue = mHist[1][idx];
+        if (mHist[2][idx] > mMaxValue)
+            mMaxValue = mHist[2][idx];
 
-	setMaxHistogramValue(maxHistValue);
-	updateHistogramValues(histValues);
+        if (mHist[0][idx] || mHist[1][idx] || mHist[2][idx]){
+            mNumDistinctValues++;
+        }
+    }
+
 	setPainted(true);
-
-#else
-	setPainted(false);
-#endif
-	
 	qDebug() << "drawing the histogram took me: " << dt;
-
 	update();
 }
 

--- a/ImageLounge/src/DkGui/DkWidgets.h
+++ b/ImageLounge/src/DkGui/DkWidgets.h
@@ -665,6 +665,13 @@ class DkHistogram : public DkWidget {
 	Q_OBJECT
 	
 public:
+	enum class DisplayMode {
+		histogram_mode_simple = 0,      /// shows just the histogram
+		histogram_mode_extended = 1,    /// shows histogram and data
+		histogram_mode_end = 2,
+	};
+
+
 	DkHistogram(QWidget *parent);
 	~DkHistogram();
 	void drawHistogram(QImage img);
@@ -679,6 +686,9 @@ protected:
 	virtual void mouseReleaseEvent(QMouseEvent *event);
 	virtual void paintEvent(QPaintEvent* event);
 
+	void loadSettings();
+	void saveSettings();
+
 private:
 	int mHist[3][256];          /// 3 channels 256 bin. channels duplicated when gray
 	int mNumPixels = 0;         /// image pixel count
@@ -692,7 +702,7 @@ private:
 	int mMaxValue = 20;         /// maximum count over all bins
 	bool mIsPainted = false;
 	float mScaleFactor = 1;
-
+	DisplayMode mDisplayMode = DisplayMode::histogram_mode_simple; /// determins shown histogram type
 };
 
 class DkFileInfo {

--- a/ImageLounge/src/DkGui/DkWidgets.h
+++ b/ImageLounge/src/DkGui/DkWidgets.h
@@ -680,11 +680,19 @@ protected:
 	virtual void paintEvent(QPaintEvent* event);
 
 private:
-	int mHist[3][256];
-	int mMaxValue = 20;
+	int mHist[3][256];          /// 3 channels 256 bin. channels duplicated when gray
+	int mNumPixels = 0;         /// image pixel count
+	int mNumDistinctValues = 0; /// number of distinct values
+	int mNumZeroPixels = 0;     /// pixels with zero value
+	int mNumNonZeroPixels = 0;  /// pixels with non-zero value
+	int mNumSaturatedPixels = 0;    /// pixels saturating RGB 8bit
+	int mNumValues = 0;         /// number of distinct histogram values
+	int mMinBinValue = 256;     /// (gray-only) minimum intensity value
+	int mMaxBinValue = -1;      /// (gray-only) maximum intensity value
+	int mMaxValue = 20;         /// maximum count over all bins
 	bool mIsPainted = false;
 	float mScaleFactor = 1;
-				
+
 };
 
 class DkFileInfo {


### PR DESCRIPTION
This PR attempts to improve the nomacs image histogram by showing a number if image statistics below the actual histogram.

![histogram-ui-screener2](https://cloud.githubusercontent.com/assets/1619633/25920005/b89e83c2-35d0-11e7-8c14-417746b90311.png)
![histogram-ui-screener](https://cloud.githubusercontent.com/assets/1619633/25920006/b8a36af4-35d0-11e7-8943-32886e1e4a05.png)


The histogram shows:
 - pixel count
 - megapixel count

For RGB images show statistics useful to inpsect image over-/ under exposure:
  - black pixel percentage:
  - white pixel percentage
  - good pixel percentage, the rest.

For 8 bit gray imagas it shows values useful for inspecting 
 - minimum value
 - maximum value
 - number of distinct values

# TODOs
- [x] add menu toggle  in the 'Display' preferences section. A change is takes effect after restart.
- [ ] layout 
