### PR TITLE
Drag-n-Drop Improvements

### DIFF
--- a/ImageLounge/src/DkCore/DkUtils.cpp
+++ b/ImageLounge/src/DkCore/DkUtils.cpp
@@ -957,6 +957,21 @@ QString DkUtils::resolveFraction(const QString& frac) {
 	return result;
 }
 
+QList<QUrl> DkUtils::findUrlsInTextNewline(QString text){
+    QList<QUrl> urls;
+    QStringList lines = text.split(QRegExp("\n|\r\n|\r"));
+    for(QUrl maybeUrl: QUrl::fromStringList(lines)){
+        if(maybeUrl.isValid()){
+            if(maybeUrl.isRelative()){
+                maybeUrl.setScheme("file");
+            }
+            urls.append(maybeUrl);
+        }
+    }
+    return urls;
+}
+
+
 // code from: http://stackoverflow.com/questions/5625884/conversion-of-stdwstring-to-qstring-throws-linker-error
 std::wstring DkUtils::qStringToStdWString(const QString &str) {
 #ifdef _MSC_VER

--- a/ImageLounge/src/DkCore/DkUtils.cpp
+++ b/ImageLounge/src/DkCore/DkUtils.cpp
@@ -589,19 +589,22 @@ QFileInfo DkUtils::urlToLocalFile(const QUrl& url) {
  * @return bool true if the file format is supported.
  **/
 bool DkUtils::isValid(const QFileInfo& fileInfo) {
+    bool fileIsValid = false;
 
-	printf("accepting file...\n");
 
 	QFileInfo fInfo = fileInfo;
 	if (fInfo.isSymLink())
 		fInfo = fileInfo.symLinkTarget();
 
-	if (!fInfo.exists())
-		return false;
-
-	QString fileName = fInfo.fileName();
-
-	return hasValidSuffix(fileName);
+    if (!fInfo.exists()) {
+        fileIsValid = false;
+    } else{
+        QString fileName = fInfo.fileName();
+        fileIsValid = hasValidSuffix(fileName);
+    }
+    QString resultText(fileIsValid?"valid":"invalid");
+    qDebug() << QString("file %1 is %2").arg(fileInfo.filePath()).arg(resultText);
+    return fileIsValid;
 }
 
 bool DkUtils::isSavable(const QString & fileName) {

--- a/ImageLounge/src/DkCore/DkUtils.h
+++ b/ImageLounge/src/DkCore/DkUtils.h
@@ -188,6 +188,7 @@ public:
 	static QString readableByte(float bytes);
 	static QStringList filterStringList(const QString& query, const QStringList& list);
 	static bool moveToTrash(const QString& filePath);
+	static QList<QUrl> findUrlsInTextNewline(QString text);
 
 #ifdef WITH_OPENCV
 	/**

--- a/ImageLounge/src/DkGui/DkCentralWidget.cpp
+++ b/ImageLounge/src/DkGui/DkCentralWidget.cpp
@@ -1040,14 +1040,28 @@ void DkCentralWidget::loadDir(const QString& filePath) {
 
 void DkCentralWidget::loadFileToTab(const QString& filePath) {
 
-	if (mTabInfos.size() > 1 || (!mTabInfos.empty() && mTabInfos.at(0)->getMode() != DkTabInfo::tab_empty)) {
-		addTab(filePath);
-	}
-	else {
-		mTabInfos.at(0)->setFilePath(filePath);
-		updateTab(mTabInfos.at(0));
-		currentTabChanged(0);
-	}
+    if (mTabInfos.size() == 0){
+        // this is the first one: open a new tab
+        addTab(filePath);
+    }else{
+        // we already have some opened tabs.
+        int currentTabIdx = mTabbar->currentIndex();
+        int currentTabMode = mTabInfos[currentTabIdx]->getMode();
+
+        if (currentTabMode == DkTabInfo::tab_thumb_preview ||
+            currentTabMode == DkTabInfo::tab_recent_files ||
+            currentTabMode == DkTabInfo::tab_empty) {
+
+            // reuse the currently open tab.
+            mTabInfos.at(currentTabIdx)->setFilePath(filePath);
+            updateTab(mTabInfos.at(currentTabIdx));
+            currentTabChanged(currentTabIdx);
+
+        }else{
+            // no tab to reuse. open create a new tab
+            addTab(filePath);
+        }
+    }
 }
 
 void DkCentralWidget::loadDirToTab(const QString& dirPath) {

--- a/ImageLounge/src/DkGui/DkCentralWidget.cpp
+++ b/ImageLounge/src/DkGui/DkCentralWidget.cpp
@@ -992,35 +992,10 @@ void DkCentralWidget::dragEnterEvent(QDragEnterEvent *event) {
 
 	printf("[DkCentralWidget] drag enter event\n");
 
-	//if (event->source() == this)
-	//	return;
-
-	if (event->mimeData()->hasUrls()) {
-		QUrl url = event->mimeData()->urls().at(0);
-
-		QList<QUrl> urls = event->mimeData()->urls();
-
-		for (int idx = 0; idx < urls.size(); idx++)
-			qDebug() << "url: " << urls.at(idx);
-
-		url = url.toLocalFile();
-
-		// TODO: check if we accept appropriately (network drives that are not mounted)
-		QFileInfo file = QFileInfo(url.toString());
-
-		// just accept image files
-		if (DkUtils::isValid(file))
-			event->acceptProposedAction();
-		else if (file.isDir())
-			event->acceptProposedAction();
-		else if (event->mimeData()->urls().at(0).isValid() && DkUtils::hasValidSuffix(event->mimeData()->urls().at(0).toString()))
-			event->acceptProposedAction();
-
-	}
-	if (event->mimeData()->hasImage()) {
+	if (event->mimeData()->hasUrls() ||
+		event->mimeData()->hasImage()) {
 		event->acceptProposedAction();
 	}
-
 	QWidget::dragEnterEvent(event);
 }
 
@@ -1175,88 +1150,73 @@ void DkCentralWidget::dropEvent(QDropEvent *event) {
 		mViewport->getController()->setInfo(tr("Sorry, I could not drop the content."));
 }
 
+
 bool DkCentralWidget::loadFromMime(const QMimeData* mimeData) {
 
-	if (!mimeData)
-		return false;
+    if (!mimeData)
+        return false;
 
-	if ((mimeData->hasUrls() && mimeData->urls().size() > 0) || mimeData->hasText()) {
-		QUrl url = mimeData->hasText() ? QUrl::fromUserInput(mimeData->text()) : QUrl::fromUserInput(mimeData->urls().at(0).toString());
+    QStringList mimeFmts = mimeData->formats();
+    qDebug() << "loading mime data with formats: " << mimeFmts;
 
-		// try manual conversion first, this fixes the DSC#josef.jpg problems (url fragments)
-		QString fString = url.toString();
-		fString = fString.replace("file:///", "");
+    if (mimeData->hasImage()) {
+        // we got an image buffer
 
-		QFileInfo file = QFileInfo(fString);
-		if (!file.exists()) {	// try an alternative conversion
-			file = QFileInfo(url.toLocalFile());
-			fString = url.toLocalFile();
-		}
-		
-		QList<QUrl> urls = mimeData->urls();
+        QImage dropImg = qvariant_cast<QImage>(mimeData->imageData());
+        mViewport->loadImage(dropImg);
+        return true;
+    }
 
-		// merge OpenCV vec files if multiple vec files are dropped
-		if (urls.size() > 1 && file.suffix() == "vec") {
+    // parse mime data. get a non-empty list of urls. url is the first.
+    QList<QUrl> urls;
+    QUrl url;
 
-			QStringList vecFiles;
+    if(mimeData->formats().contains("text/plain")){
+        //we got text data. maybe it is a list of urls
+        urls = DkUtils::findUrlsInTextNewline(mimeData->text());
+    } else if(mimeFmts.contains("text/uri-list")) {
+        //we got a list of uris
+        //mimeData has both urls and text (empty string. at least for dolphin 16.04.3)
+        for(QUrl u: mimeData->urls()){
+            if(u.isValid())
+                urls.append(u);
+        }
+    }else {
+        //
+        qDebug() << "no handled Mime types found in drop: " << mimeData->formats();
+        return false;
+    }
 
-			for (int idx = 0; idx < urls.size(); idx++)
-				vecFiles.append(urls.at(idx).toLocalFile());
+    if(urls.size() == 0){
+        return false;
+    }
+    url = urls.at(0);
 
-			// ask user for filename
-			QString sPath(QFileDialog::getSaveFileName(this, tr("Save File"),
-				QFileInfo(vecFiles.first()).absolutePath(), "Cascade Training File (*.vec)"));
+    // At this point we have a non empty list of valid urls we can load
+    qDebug() << urls.size() << " files dropped:";
+    for(QUrl url: urls){
+        QString fname = url.toLocalFile();
+        QFileInfo file(fname);
+        qDebug() << QString("url [%1]: %2 %3")
+                        .arg(url.isLocalFile()?QString("local"):QString("remote"))
+                        .arg(url.toDisplayString())
+                        .arg(url.isLocalFile()?url.toLocalFile():QString(""));
+        Q_ASSERT(url.isValid());
+    }
 
-			DkBasicLoader loader;
-			int numFiles = loader.mergeVecFiles(vecFiles, sPath);
+    // Pass urls to the appropriate loading function
+    QFileInfo file(url.toLocalFile());
+    QString fString = file.filePath();
 
-			if (numFiles) {
-				loadFile(sPath);
-				mViewport->getController()->setInfo(tr("%1 vec files merged").arg(numFiles));
-				return true;
-			}
-
-			return false;
-		}
-		else
-			qDebug() << urls.size() << file.suffix() << " files dropped";
-
-		if (!mTabInfos.empty() && mTabInfos[mTabbar->currentIndex()]->getMode() == DkTabInfo::tab_thumb_preview) {
-			// TODO: this event won't be called if the thumbs view is visible
-
-			// >DIR: TODO [19.2.2015 markus]
-			//QDir newDir = (file.isDir()) ? QDir(file.absoluteFilePath()) : file.absolutePath();
-			//mViewport->getImageLoader()->loadDir(newDir);
-		}
-		else {
-			// just accept image files
-			if (DkUtils::isValid(file) || file.isDir())
-				loadFile(fString);
-			else if (url.isValid() && !mTabInfos.empty()) {
-				mTabInfos[mTabbar->currentIndex()]->getImageLoader()->downloadFile(url);
-			}
-			else
-				return false;
-		}
-
-		for (int idx = 1; idx < urls.size() && idx < 20; idx++) {
-
-			QFileInfo fi = DkUtils::urlToLocalFile(urls[idx]);
-
-			if (DkUtils::isValid(fi))
-				addTab(urls[idx].toLocalFile());
-		}
-
-		return true;
-	}
-	else if (mimeData->hasImage()) {
-
-		QImage dropImg = qvariant_cast<QImage>(mimeData->imageData());
-		mViewport->loadImage(dropImg);
-		return true;
-	}
-
-	return false;
+    if (urls.size() > 1 && file.suffix() == "vec") {
+        // assume multiple OpenCV vec files where dropped.
+        return loadCascadeTrainingFiles(urls);
+    }else{
+        // load urls generically
+        loadUrls(urls);
+        return true;
+    }
+    return false;
 }
 
 

--- a/ImageLounge/src/DkGui/DkCentralWidget.cpp
+++ b/ImageLounge/src/DkGui/DkCentralWidget.cpp
@@ -1069,8 +1069,9 @@ void DkCentralWidget::loadDirToTab(const QString& dirPath) {
 	if (mTabInfos.size() > 1 || (!mTabInfos.empty() && mTabInfos.at(0)->getMode() != DkTabInfo::tab_empty)) {
 		addTab();
 	}
-	
-	mTabInfos.at(mTabbar->currentIndex())->setDirPath(dirPath);
+	int currentTabIdx = mTabbar->currentIndex();
+
+	mTabInfos.at(currentTabIdx)->setDirPath(dirPath);
 	showThumbView();
 }
 

--- a/ImageLounge/src/DkGui/DkCentralWidget.cpp
+++ b/ImageLounge/src/DkGui/DkCentralWidget.cpp
@@ -1060,6 +1060,54 @@ void DkCentralWidget::loadDirToTab(const QString& dirPath) {
 	showThumbView();
 }
 
+/** loadUrl() loads a single valid url
+ *  @param loadInTab: if true, replace the currently active image, so it exists.
+ */
+void DkCentralWidget::loadUrl(const QUrl url, bool loadInTab){
+    Q_ASSERT(url.isValid());
+
+    Q_UNUSED(loadInTab);
+    Q_ASSERT(loadInTab == true);
+    // TODO decide cases where we just load over the current image
+
+    if(url.isLocalFile()){
+        QFileInfo file(url.toLocalFile());
+
+        if (DkUtils::isValid(file)){
+            // load a local file
+            loadFileToTab(url.toLocalFile());
+        }else if(file.isDir()){
+            // load a directory in thmbnail view
+            loadDirToTab(file.filePath());
+        }
+    }else{
+       //load a remote url
+        qDebug() << "unhandled remote url: " << url.toDisplayString();
+
+        //BUG: loading an url WILL replace the current tab.
+        mTabInfos[mTabbar->currentIndex()]->getImageLoader()->downloadFile(url);
+    }
+}
+
+/** loadUrls() loads a list of valid urls.
+ * @param maxUrlsToLoad determines the maximum
+ */
+void DkCentralWidget::loadUrls(const QList<QUrl> urls, int maxUrlsToLoad)
+{
+    if(urls.size() == 0)
+        return;
+
+    if(urls.size() > maxUrlsToLoad){
+        QString urlsWarning(tr("Too many urls to load. Loading only the first %1"));
+        qDebug() << urlsWarning.arg(urls.size());
+    }
+
+    for (int idx = 0; idx < urls.size() && idx < maxUrlsToLoad; idx++) {
+        QUrl url = urls[idx];
+        loadUrl(url);
+    }
+}
+
 void DkCentralWidget::openBatch(const QStringList& selectedFiles) {
 
 	// switch to tab if already opened

--- a/ImageLounge/src/DkGui/DkCentralWidget.cpp
+++ b/ImageLounge/src/DkGui/DkCentralWidget.cpp
@@ -1196,4 +1196,30 @@ bool DkCentralWidget::loadFromMime(const QMimeData* mimeData) {
 	return false;
 }
 
+
+/** load a number of Cascade Trainig files */
+bool DkCentralWidget::loadCascadeTrainingFiles(QList<QUrl> urls) {
+    QStringList vecFiles;
+
+    if (urls.size() > 1 && urls.at(0).toLocalFile().endsWith("vec")) {
+
+        for (int idx = 0; idx < urls.size(); idx++)
+            vecFiles.append(urls.at(idx).toLocalFile());
+
+        // ask user for filename
+        QString sPath(QFileDialog::getSaveFileName(this, tr("Save File"),
+            QFileInfo(vecFiles.first()).absolutePath(), "Cascade Training File (*.vec)"));
+
+        DkBasicLoader loader;
+        int numFiles = loader.mergeVecFiles(vecFiles, sPath);
+
+        if (numFiles) {
+            loadFile(sPath);
+            mViewport->getController()->setInfo(tr("%1 vec files merged").arg(numFiles));
+            return true;
+        }
+    }
+    return false;
 }
+
+} // namespace nmc

--- a/ImageLounge/src/DkGui/DkCentralWidget.h
+++ b/ImageLounge/src/DkGui/DkCentralWidget.h
@@ -169,6 +169,8 @@ public slots:
 	void loadDir(const QString& filePath);
 	void loadFileToTab(const QString& filePath);
 	void loadDirToTab(const QString& dirPath);
+	void loadUrl(const QUrl urls, bool loadInTab = true);
+	void loadUrls(const QList<QUrl> urls, const int maxUrlsToLoad = 20);
 	void openBatch(const QStringList& selectedFiles = QStringList());
 	void showBatch(bool show = true);
 	void openPreferences();

--- a/ImageLounge/src/DkGui/DkCentralWidget.h
+++ b/ImageLounge/src/DkGui/DkCentralWidget.h
@@ -193,6 +193,7 @@ protected:
 	void dropEvent(QDropEvent *event);
 	void dragEnterEvent(QDragEnterEvent *event);
 	bool loadFromMime(const QMimeData* mimeData);
+	bool loadCascadeTrainingFiles(QList<QUrl> urls);
 	void updateLoader(QSharedPointer<DkImageLoader> loader) const;
 	DkPreferenceWidget* createPreferences();
 	DkThumbScrollWidget* createThumbScrollWidget();


### PR DESCRIPTION
This PR attempts to: 
- fix Drag-n-Drop for KDEs dolphin browser (Issue  #116)
- make nomacs's drag-n-drop support more robust.
- profit from clean up

## Features
- can drop 'text/uri-list' with multiple urls (plain filename, local url starting with `file://`, and remote urls).
- can drop 'text/plain' content.
 The text plain drops are treated as newline separated list of files

## Todo

- [ ] when a remote url is dropped. it will be loaded in the current tab.
- [x] test updated code on Windows platforms.

