### PR TITLE
Include a git version tag, if built from a git repo.

### DIFF
--- a/ImageLounge/CMakeLists.txt
+++ b/ImageLounge/CMakeLists.txt
@@ -16,6 +16,7 @@ endif(COMMAND cmake_policy)
 project(nomacs)
 
 # needed for soname
+
 set(NOMACS_VERSION_MAJOR 3)
 set(NOMACS_VERSION_MINOR 7)
 set(NOMACS_VERSION_PATCH 0)
@@ -27,7 +28,20 @@ else()
 	SET(NMC_ARCHITECTURE "x86")
 endif()
 
-add_definitions(-DNOMACS_VERSION="${NOMACS_VERSION}")
+if(NOMACS_BUILD_TAG)
+    #we've been passed a version tag, use that
+    set(NOMACS_VCSVERSION "(build: ${NOMACS_BUILD_TAG})")
+    set(NOMACS_FULL_VERSION "${NOMACS_FULL_VERSION} ${NOMACS_VCSVERSION}")
+else()
+    include(cmake/GitVersionString.cmake)
+    get_git_version_string()
+    if(NOMACS_VCSVERSION)
+        #we have git, add the current description
+        set(NOMACS_FULL_VERSION "${NOMACS_FULL_VERSION} ${NOMACS_VCSVERSION}")
+    endif()
+endif()
+
+add_definitions(-DNOMACS_VERSION="${NOMACS_FULL_VERSION}")
 
 set(BINARY_NAME ${CMAKE_PROJECT_NAME})
 set(NOMACS_BUILD_DIRECTORY ${CMAKE_BINARY_DIR})
@@ -189,7 +203,7 @@ endif()
 # status
 MESSAGE(STATUS "")
 MESSAGE(STATUS "----------------------------------------------------------------------------------")
-MESSAGE(STATUS " ${PROJECT_NAME} - Image Lounge ${NOMACS_VERSION}  <http://www.nomacs.org>")
+MESSAGE(STATUS " ${PROJECT_NAME} - Image Lounge ${NOMACS_FULL_VERSION} - <http://www.nomacs.org>")
 MESSAGE(STATUS "")
 
 option(ENABLE_READ_BUILD "Build nomacs for READ" OFF)

--- a/ImageLounge/cmake/GitVersionString.cmake
+++ b/ImageLounge/cmake/GitVersionString.cmake
@@ -1,0 +1,38 @@
+# ----------------------------------------------------------------------------
+# macro get_git_version_string
+#
+# sets the variable NOMACS_VCSVERSION from git, if available.
+#
+# if no git was found NOMACS_VCSVERSION is ""
+# otherwise NOMACS_VCSVERSION is a a string "(git: 3.6.1-48-g3494189-dirty)"
+#
+# The version string components are:
+# - last 3 letter version tag, e.g. '3.6.1'
+# - number of commits since the tag, e.g. '48'
+# - a short ref of the current commit, e.g. 'g394189'
+# - a tag indicating a dirty build repo, e.g. '-dirty'
+#
+# ----------------------------------------------------------------------------
+find_package(Git)
+
+macro(get_git_version_string)
+if(GIT_FOUND)
+  execute_process(
+    COMMAND "${GIT_EXECUTABLE}" describe --tags --always --dirty --match "[0-9].[0-9].[0-9]*"
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    OUTPUT_VARIABLE NOMACS_VCSVERSION
+    RESULT_VARIABLE GIT_RESULT
+    #ERROR_QUIET
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  if(NOT GIT_RESULT EQUAL 0)
+    set(NOMACS_VCSVERSION "")
+  else()
+      set(NOMACS_VCSVERSION "(git: ${NOMACS_VCSVERSION})")
+  endif()
+elseif(NOT DEFINED NOMACS_VCSVERSION)
+  # We don't have git:
+  set(NOMACS_VCSVERSION "")
+endif()
+
+endmacro()


### PR DESCRIPTION
- makes `nomacs --version` report:

   [INFO] Hi there
   Image Lounge 3.7 (git: 3.6.1-48-g3494189-dirty)

- About dialog shows the same string.