### PR TITLE
More robust file loading.

### DIFF
--- a/ImageLounge/src/DkGui/DkCentralWidget.cpp
+++ b/ImageLounge/src/DkGui/DkCentralWidget.cpp
@@ -93,7 +93,13 @@ bool DkTabInfo::operator ==(const DkTabInfo& o) const {
 void DkTabInfo::loadSettings(const QSettings& settings) {
 
 	QString file = settings.value("tabFileInfo", "").toString();
-	mTabMode = settings.value("tabMode", tab_single_image).toInt();
+	int tabSetting = settings.value("tabMode", tab_single_image).toInt();
+
+	if(tabSetting < TabMode::tab_end){
+		mTabMode = static_cast<enum TabMode>(tabSetting);
+	}else{
+		mTabMode = tab_single_image;
+	}
 
 	if (QFileInfo(file).exists())
 		mImageLoader->setCurrentImage(QSharedPointer<DkImageContainerT>(new DkImageContainerT(file)));
@@ -119,10 +125,17 @@ void DkTabInfo::setFilePath(const QString& filePath) {
 	mFilePath = filePath;
 }
 
-void DkTabInfo::setDirPath(const QString& dirPath) {
-	
-	mImageLoader->loadDir(dirPath);
-	setMode(tab_thumb_preview);
+bool DkTabInfo::setDirPath(const QFileInfo& dirPath) {
+	if(!dirPath.isDir())
+		return false;
+
+	bool dirIsLoaded = mImageLoader->loadDir(dirPath.canonicalFilePath());
+	if(dirIsLoaded) {
+		setMode(tab_thumb_preview);
+		return true;
+	}
+
+	return false;
 }
 
 QString DkTabInfo::getFilePath() const {
@@ -228,14 +241,15 @@ QString DkTabInfo::getTabText() const {
 	return tabText;
 }
 
-int DkTabInfo::getMode() const {
+enum DkTabInfo::TabMode DkTabInfo::getMode() const {
 
 	return mTabMode;
 }
 
 void DkTabInfo::setMode(int mode) {
 
-	mTabMode = mode;
+	if(mode < TabMode::tab_end)
+		mTabMode = static_cast<enum TabMode>(mode);
 }
 
 // DkCenteralWidget --------------------------------------------------------------------

--- a/ImageLounge/src/DkGui/DkCentralWidget.h
+++ b/ImageLounge/src/DkGui/DkCentralWidget.h
@@ -84,7 +84,7 @@ public:
 
 	QString getFilePath() const;
 	void setFilePath(const QString& filePath);
-	void setDirPath(const QString& dirPath);
+	bool setDirPath(const QFileInfo &dirPath);
 
 	QSharedPointer<DkImageContainerT> getImage() const;
 	void setImage(QSharedPointer<DkImageContainerT> imgC);
@@ -103,13 +103,13 @@ public:
 	QIcon getIcon();
 	QString getTabText() const;
 
-	int getMode() const;
+	TabMode getMode() const;
 	void setMode(int mode);
 
 protected:
 	QSharedPointer<DkImageLoader> mImageLoader;
 	int mTabIdx = 0;
-	int mTabMode = tab_recent_files;
+	enum TabMode mTabMode = tab_recent_files;
 	QString mFilePath = "";
 };
 
@@ -168,7 +168,7 @@ public slots:
 	void loadFile(const QString& filePath);
 	void loadDir(const QString& filePath);
 	void loadFileToTab(const QString& filePath);
-	void loadDirToTab(const QString& dirPath);
+	void loadDirToTab(const QFileInfo &dirPath);
 	void loadUrl(const QUrl urls, bool loadInTab = true);
 	void loadUrls(const QList<QUrl> urls, const int maxUrlsToLoad = 20);
 	void openBatch(const QStringList& selectedFiles = QStringList());


### PR DESCRIPTION
This PR fixes issue #115 by:

- adding file content detection via MIME database in `DkUtils::isValid()` as last resort.
- notifying the user in GUI when loading of a file failed.

further
- it stops opening new Tabs, when dropping a file onto 'untabbed' nomacs.
- it partially addresses inconsistencies when dropping directories.

