### PR TITLE
Use the correct variable name

### DIFF
--- a/ImageLounge/CMakeLists.txt
+++ b/ImageLounge/CMakeLists.txt
@@ -195,7 +195,7 @@ MESSAGE(STATUS "")
 option(ENABLE_READ_BUILD "Build nomacs for READ" OFF)
 option(ENABLE_PLUGINS "Compile nomacs with plugin support" ON)
 
-IF(OPENCV_FOUND)
+IF(OpenCV_FOUND)
     MESSAGE(STATUS " nomacs will be compiled with OPENCV support .................. YES")
 ELSE()
     MESSAGE(STATUS " nomacs will be compiled with OPENCV support .................. NO")


### PR DESCRIPTION
`OpenCV_FOUND` is set in the `.cmake` files but `OPENCV_FOUND` is used in the CMakeLists.txt which means it will always say that it will not be compiled with OpenCV support because `OPENCV_FOUND` is never set.