### PR TITLE
HDR images support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_script:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install exiv2; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install libraw; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew tap homebrew/science; fi
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install -v opencv3 --with-contrib --without-eigen --without-opencl --without-openexr --without-python --without-numpy --without-tests; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install -v opencv3 --with-contrib --without-eigen --without-opencl --with-openexr --without-python --without-numpy --without-tests; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew ln opencv3 --force; fi
 
   # Linux dependencies

--- a/ImageLounge/cmake/Mac.cmake
+++ b/ImageLounge/cmake/Mac.cmake
@@ -40,7 +40,7 @@ if(ENABLE_OPENCV)
 	endif(PKG_CONFIG_FOUND)
 
 	if(OpenCV_LIBS STREQUAL "")
-		find_package(OpenCV 2.1.0 REQUIRED core imgproc)
+		find_package(OpenCV 2.1.0 REQUIRED core imgproc imgcodecs photo)
 	endif(OpenCV_LIBS STREQUAL "")
 
 	if(NOT OpenCV_FOUND)

--- a/ImageLounge/cmake/Unix.cmake
+++ b/ImageLounge/cmake/Unix.cmake
@@ -38,7 +38,7 @@ endif(NOT EXIV2_FOUND)
 # search for opencv
 unset(OpenCV_FOUND CACHE)
 if(ENABLE_OPENCV)
-	find_package(OpenCV REQUIRED core imgproc)
+	find_package(OpenCV REQUIRED core imgproc imgcodecs photo)
 	if (NOT OpenCV_LIBRARIES) # OpenCV_FOUND can not be used since it is set in Ubuntu 12.04 (without finding opencv)
 		# Older OpenCV versions only supplied pkg-config files
 		if(PKG_CONFIG_FOUND)

--- a/ImageLounge/cmake/Win.cmake
+++ b/ImageLounge/cmake/Win.cmake
@@ -81,7 +81,7 @@ unset(OpenCV_DIR)
 # unset(OpenCV_DIR CACHE) # maa that always set it to default!
 
 if(ENABLE_OPENCV)
-	find_package(OpenCV REQUIRED core imgproc)
+	find_package(OpenCV REQUIRED core imgproc imgcodecs photo)
 
 	SET(OpenCV_LIBRARY_DIRS ${OpenCV_LIBRARY_DIRS} ${OpenCV_LIB_DIR_DBG} ${OpenCV_LIB_DIR_OPT} ${OpenCV_DIR}/lib/${OpenCV_LIB_DIR_DBG} ${OpenCV_DIR}/lib/${OpenCV_LIB_DIR_OPT})
 	if(NOT OpenCV_FOUND)

--- a/ImageLounge/src/DkCore/DkBasicLoader.cpp
+++ b/ImageLounge/src/DkCore/DkBasicLoader.cpp
@@ -1457,7 +1457,7 @@ bool DkHDRLoader::load()
 bool DkHDRLoader::loadOCV()
 {
 	if (!mFilePath.right(4).compare(".hdr") || !mFilePath.right(4).compare(".exr"))
-		hdr = cv::imread(mFilePath.toStdString(), cv::IMREAD_UNCHANGED);
+		hdr = cv::imread(mFilePath.toLocal8Bit().constData(), cv::IMREAD_UNCHANGED); //.toLocal8Bit().constData()
 	else
 		return false;
 	if (!hdr.data)

--- a/ImageLounge/src/DkCore/DkBasicLoader.cpp
+++ b/ImageLounge/src/DkCore/DkBasicLoader.cpp
@@ -1457,7 +1457,7 @@ bool DkHDRLoader::load()
 bool DkHDRLoader::loadOCV()
 {
 	if (!mFilePath.right(4).compare(".hdr") || !mFilePath.right(4).compare(".exr"))
-		hdr = cv::imread(mFilePath.toLocal8Bit().constData(), cv::IMREAD_UNCHANGED); //.toLocal8Bit().constData()
+		hdr = cv::imread(mFilePath.toLocal8Bit().constData(), cv::IMREAD_UNCHANGED);
 	else
 		return false;
 	if (!hdr.data)

--- a/ImageLounge/src/DkCore/DkBasicLoader.h
+++ b/ImageLounge/src/DkCore/DkBasicLoader.h
@@ -49,7 +49,8 @@
 #endif
 
 #include <opencv2/imgproc/imgproc.hpp>
-#include <opencv2/imgproc/imgproc.hpp>
+#include <opencv2/highgui.hpp>
+#include <opencv2/photo.hpp>
 #endif
 
 #ifndef DllCoreExport
@@ -180,6 +181,28 @@ protected:
 
 		return static_cast<num>(vr);
 	}
+#endif
+};
+
+class DllCoreExport DkHDRLoader
+{
+public:
+	DkHDRLoader(const QString& filePath);
+
+	bool load();
+	QImage image() const
+	{
+		return mImg;
+	}
+
+protected:
+	QImage mImg;
+	const QString mFilePath;
+#ifdef WITH_OPENCV
+	cv::Mat hdr;
+
+	bool loadOCV();
+	void convertToImg();
 #endif
 };
 
@@ -359,6 +382,7 @@ public slots:
 protected:
 	bool loadRohFile(const QString& filePath, QImage& img, QSharedPointer<QByteArray> ba = QSharedPointer<QByteArray>()) const;
 	bool loadRawFile(const QString& filePath, QImage& img, QSharedPointer<QByteArray> ba = QSharedPointer<QByteArray>(), bool fast = false) const;
+	bool loadHDRFile(const QString& filePath, QImage& img) const;
 	void indexPages(const QString& filePath);
 	void convert32BitOrder(void *buffer, int width);
 

--- a/ImageLounge/src/DkCore/DkSettings.cpp
+++ b/ImageLounge/src/DkCore/DkSettings.cpp
@@ -188,6 +188,12 @@ void DkSettings::initFileFilters() {
 	app_p.openFilters += app_p.rawFilters;
 #endif
 
+#ifdef WITH_OPENCV
+	//hdr format
+	app_p.openFilters.append("High Dynamic Range (*.hdr)");
+	app_p.openFilters.append("High Dynamic Range (*.exr)");
+#endif
+
 	// stereo formats
 	app_p.openFilters.append("JPEG Stereo (*.jps)");
 	app_p.openFilters.append("PNG Stereo (*.pns)");


### PR DESCRIPTION
Allows view high dynamic range images (*.hdr, *.exr). Useful for 3ds artists. 
HDR image reads with OpenCV, than process to 8 bit image with OpenCV implementations of Reinhard`s tonemap algorithm and converts to QImage for displaying.