### PR TITLE
Update macOS build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,7 @@ Install [Homebrew](http://brew.sh/) for easier installation of depenedencies.
 Install required dependencies:
 
 ```
-$ brew install qt5 exiv2 homebrew/science/opencv libraw quazip
-
+$ brew install qt5 exiv2 opencv libraw quazip
 ```
 
 Go to the `nomacs` directory and run cmake to get the Makefiles

--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ Install required dependencies:
 $ brew install qt5 exiv2 opencv libraw quazip
 ```
 
+Link `qmake` binary into `/usr/local/bin`:
+
+```
+$ ln -s /usr/local/opt/qt5/bin/qmake /usr/local/bin/
+```
+
 Go to the `nomacs` directory and run cmake to get the Makefiles
 
 ```


### PR DESCRIPTION
Fixes two things I encountered while trying to build latest master on macOS 10.13.2:

1. `opencv` is now in homebrew/core, specifying `homebrew/science/opencv` path doesn't work any longer
2. The `qmake` binary is not on the `PATH` after installation, as was also mentioned in [issue 133](https://github.com/nomacs/nomacs/issues/133). Linking it into `/usr/local/bin` seems standard (rather than adding the qmake dir itself to the PATH).