### PR TITLE
Update Bosnian, Croatian and Serbian translations

### DIFF
--- a/ImageLounge/translations/nomacs_bs.ts
+++ b/ImageLounge/translations/nomacs_bs.ts
@@ -1,5881 +1,5063 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
 <TS version="2.1" language="bs" sourcelanguage="en">
-  <context>
-    <name>DkNoMacsClass</name>
-    <message>
-      <location filename="../src/nomacs.ui" line="16"/>
-      <source>nomacs - image lounge</source>
-      <translation>nomacs - salon slika</translation>
-    </message>
-  </context>
-  <context>
+<context>
     <name>QObject</name>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="175"/>
-      <source>&amp;Photoshop</source>
-      <translation>%Photoshop</translation>
+        <source>&amp;Photoshop</source>
+        <translation>&amp;Photoshop</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="186"/>
-      <source>Pic&amp;asa</source>
-      <translation>Pic&amp;asa</translation>
+        <source>Pic&amp;asa</source>
+        <translation>Pic&amp;asa</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="197"/>
-      <source>Picasa Ph&amp;oto Viewer</source>
-      <translation>Picasa Ph&amp;oto Viewer</translation>
+        <source>Picasa Ph&amp;oto Viewer</source>
+        <translation>Picasa Ph&amp;oto Viewer</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="208"/>
-      <source>&amp;IrfanView</source>
-      <translation>&amp;IrfanView</translation>
+        <source>&amp;IrfanView</source>
+        <translation>&amp;IrfanView</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="218"/>
-      <source>&amp;Explorer</source>
-      <translation>&amp;Explorer</translation>
+        <source>&amp;Explorer</source>
+        <translation>Pregl&amp;edač</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="355"/>
-      <source>&amp;File</source>
-      <translation>&amp;Fajl</translation>
+        <source>&amp;File</source>
+        <translation>&amp;Fajl</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="396"/>
-      <source>&amp;Open With</source>
-      <translation>&amp;Otvori pomoću</translation>
+        <source>&amp;Open With</source>
+        <translation>&amp;Otvori pomoću</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="427"/>
-      <source>S&amp;ort</source>
-      <translation>S&amp;ortiraj</translation>
+        <source>S&amp;ort</source>
+        <translation>S&amp;ortiraj</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="441"/>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="650"/>
-      <source>&amp;View</source>
-      <translation>&amp;Pogled</translation>
+        <source>&amp;View</source>
+        <translation>&amp;Pregled</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="486"/>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="656"/>
-      <source>&amp;Edit</source>
-      <translation>&amp;Uredi</translation>
+        <source>&amp;Edit</source>
+        <translation>&amp;Uredi</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="527"/>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="635"/>
-      <source>&amp;Panels</source>
-      <translation>&amp;Paneli</translation>
+        <source>&amp;Panels</source>
+        <translation>&amp;Paneli</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="529"/>
-      <source>Tool&amp;bars</source>
-      <translation>&amp;Trake</translation>
+        <source>Tool&amp;bars</source>
+        <translation>&amp;Alatne trake</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="556"/>
-      <source>&amp;Tools</source>
-      <translation>&amp;Alati</translation>
+        <source>&amp;Tools</source>
+        <translation>&amp;Alati</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="2742"/>
-      <source>&amp;Synchronize</source>
-      <translation>&amp;Sinhronizuj</translation>
+        <source>&amp;Synchronize</source>
+        <translation>&amp;Sinhronizuj</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="2748"/>
-      <source>&amp;LAN Synchronize</source>
-      <translation>&amp;LAN sinhronizacija</translation>
+        <source>&amp;LAN Synchronize</source>
+        <translation>&amp;LAN sinhronizacija</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="604"/>
-      <source>&amp;?</source>
-      <translation>&amp;?</translation>
+        <source>&amp;?</source>
+        <translation>&amp;Pomoć?</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="963"/>
-      <source>&amp;Open</source>
-      <translation>&amp;Otvori</translation>
+        <source>&amp;Open</source>
+        <translation>&amp;Otvori</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="965"/>
-      <source>Open an image</source>
-      <translation>Otvori sliku</translation>
+        <source>Open an image</source>
+        <translation>Otvori sliku</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="967"/>
-      <source>Open &amp;Directory</source>
-      <translation>Otvori &amp;direktorij</translation>
+        <source>Open &amp;Directory</source>
+        <translation>Otvori &amp;direktorij</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="969"/>
-      <source>Open a directory and load its first image</source>
-      <translation>Otvori direktorij i učitaj prvu sliku</translation>
+        <source>Open a directory and load its first image</source>
+        <translation>Otvori direktorij i učitaj prvu sliku</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="971"/>
-      <source>&amp;Quick Launch</source>
-      <translation>&amp;Brzo otvori</translation>
+        <source>&amp;Quick Launch</source>
+        <translation>&amp;Brzo otvori</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="978"/>
-      <source>&amp;Manage Applications</source>
-      <translation>&amp;Upravljaj aplikacijama</translation>
+        <source>&amp;Manage Applications</source>
+        <translation>&amp;Upravljaj aplikacijama</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="979"/>
-      <source>Manage Applications which are Automatically Opened</source>
-      <translation>Upravljaj aplikacijama koje se automatski otvaraju</translation>
+        <source>Manage Applications which are Automatically Opened</source>
+        <translation>Upravljaj aplikacijama koje se automatski otvaraju</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="982"/>
-      <source>Re&amp;name</source>
-      <translation>Preime&amp;nuj</translation>
+        <source>Re&amp;name</source>
+        <translation>Preime&amp;nuj</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="985"/>
-      <source>Rename an image</source>
-      <translation>Preimenuj sliku</translation>
+        <source>Rename an image</source>
+        <translation>Preimenuj sliku</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="987"/>
-      <source>&amp;Go To</source>
-      <translation>&amp;Idi do</translation>
+        <source>&amp;Go To</source>
+        <translation>&amp;Idi на</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="989"/>
-      <source>Go To an image</source>
-      <translation>Idi do slike</translation>
+        <source>Go To an image</source>
+        <translation>Idi na sliku</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="991"/>
-      <source>&amp;Save</source>
-      <translation>&amp;Sačuvaj</translation>
+        <source>&amp;Save</source>
+        <translation>&amp;Sačuvaj</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="993"/>
-      <source>Save an image</source>
-      <translation>Snimi sliku</translation>
+        <source>Save an image</source>
+        <translation>Snimi sliku</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="995"/>
-      <source>&amp;Save As</source>
-      <translation>&amp;Snimi kao</translation>
+        <source>&amp;Save As</source>
+        <translation>&amp;Sačuvaj kao</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="997"/>
-      <source>Save an image as</source>
-      <translation>Snimi sliku kao</translation>
+        <source>Save an image as</source>
+        <translation>Sačuvaj sliku kao</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="999"/>
-      <source>&amp;Save for Web</source>
-      <translation>Sni&amp;mi za Web</translation>
+        <source>&amp;Save for Web</source>
+        <translation>Sni&amp;mi za Web</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1000"/>
-      <source>Save an Image for Web Applications</source>
-      <translation>Snimi sliku za web aplikaciju</translation>
+        <source>Save an Image for Web Applications</source>
+        <translation>Sačuvaj sliku za web aplikaciju</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1002"/>
-      <source>&amp;Print</source>
-      <translation>&amp;Štampaj</translation>
+        <source>&amp;Print</source>
+        <translation>&amp;Štampaj</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1004"/>
-      <source>Print an image</source>
-      <translation>Štampaj sliku</translation>
+        <source>Print an image</source>
+        <translation>Štampaj sliku</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1012"/>
-      <source>&amp;Reload File</source>
-      <translation>&amp;Ponovo učitaj fajl</translation>
+        <source>&amp;Reload File</source>
+        <translation>&amp;Ponovo učitaj fajl</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1015"/>
-      <source>Reload File</source>
-      <translation>Ponovo učitaj fajl</translation>
+        <source>Reload File</source>
+        <translation>Ponovo učitaj fajl</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1017"/>
-      <source>Ne&amp;xt File</source>
-      <translation>Slj&amp;edeći fajl</translation>
+        <source>Ne&amp;xt File</source>
+        <translation>Slj&amp;edeći fajl</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1020"/>
-      <source>Load next image</source>
-      <translation>Učicaj sljedeću sliku</translation>
+        <source>Load next image</source>
+        <translation>Učitaj sljedeću sliku</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1022"/>
-      <source>Pre&amp;vious File</source>
-      <translation>Pret&amp;hodni fajl</translation>
+        <source>Pre&amp;vious File</source>
+        <translation>Pret&amp;hodni fajl</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1027"/>
-      <source>Add Image Format</source>
-      <translation>Dodaj format slike</translation>
+        <source>Add Image Format</source>
+        <translation>Dodaj format slike</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1028"/>
-      <source>Add a new image format to nomacs</source>
-      <translation>Dodaj novi format slika u nomacs</translation>
+        <source>Add a new image format to nomacs</source>
+        <translation>Dodaj novi format slika u nomacs</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1030"/>
-      <source>St&amp;art New Instance</source>
-      <translation>Po&amp;čni novu instancu</translation>
+        <source>St&amp;art New Instance</source>
+        <translation>Po&amp;čni novu instancu</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1025"/>
-      <source>Load previous file</source>
-      <translation>Učitaj prethodni fajl</translation>
+        <source>Load previous file</source>
+        <translation>Učitaj prethodni fajl</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1006"/>
-      <source>&amp;Recent Files</source>
-      <translation>&amp;Nedavni fajlovi</translation>
+        <source>&amp;Recent Files</source>
+        <translation>&amp;Nedavni fajlovi</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1010"/>
-      <source>Show Recent Files</source>
-      <translation>Prikaži nedavne fajlove</translation>
+        <source>Show Recent Files</source>
+        <translation>Prikaži nedavne fajlove</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1032"/>
-      <source>Open file in new instance</source>
-      <translation>Otvori fajl u novoj instanci</translation>
+        <source>Open file in new instance</source>
+        <translation>Otvori fajl u novoj instanci</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1034"/>
-      <source>St&amp;art Private Instance</source>
-      <translation>Pokreni privatnu ins&amp;tancu</translation>
+        <source>St&amp;art Private Instance</source>
+        <translation>Pokreni privatnu ins&amp;tancu</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1036"/>
-      <source>Open private instance</source>
-      <translation>Otvori privatnu instancu</translation>
+        <source>Open private instance</source>
+        <translation>Otvori privatnu instancu</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1038"/>
-      <source>&amp;Find &amp;&amp; Filter</source>
-      <translation>&amp;Pronađi &amp;&amp; filtriraj</translation>
+        <source>&amp;Find &amp;&amp; Filter</source>
+        <translation>&amp;Pronađi &amp;&amp; filtriraj</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1040"/>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1389"/>
-      <source>Find an image</source>
-      <translation>Pronađi sliku</translation>
+        <source>Find an image</source>
+        <translation>Pronađi sliku</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1042"/>
-      <source>Scan Folder Re&amp;cursive</source>
-      <translation>Skeniraj fasciklu rekurziv&amp;no</translation>
+        <source>Scan Folder Re&amp;cursive</source>
+        <translation>Skeniraj fasciklu rekurziv&amp;no</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1043"/>
-      <source>Step through Folder and Sub Folders</source>
-      <translation>Prođi kroz fasciklu i pod fascikle</translation>
+        <source>Step through Folder and Sub Folders</source>
+        <translation>Prolistaj kroz fasciklu i pod fascikle</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1047"/>
-      <source>&amp;Exit</source>
-      <translation>&amp;Napusti</translation>
+        <source>&amp;Exit</source>
+        <translation>&amp;Napusti</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1048"/>
-      <source>Exit</source>
-      <translation>Napusti</translation>
+        <source>Exit</source>
+        <translation>Napusti</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1053"/>
-      <source>by &amp;Filename</source>
-      <translation>po &amp;imenu fajla</translation>
+        <source>by &amp;Filename</source>
+        <translation>po &amp;imenu fajla</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1055"/>
-      <source>Sort by Filename</source>
-      <translation>Sortiraj po imenu fajla</translation>
+        <source>Sort by Filename</source>
+        <translation>Sortiraj po imenu fajla</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1059"/>
-      <source>by Date &amp;Created</source>
-      <translation>po datumu &amp;kreiranja</translation>
+        <source>by Date &amp;Created</source>
+        <translation>po datumu &amp;kreiranja</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1061"/>
-      <source>Sort by Date Created</source>
-      <translation>Sortiraju po datumu kreiranja</translation>
+        <source>Sort by Date Created</source>
+        <translation>Sortiraju po datumu kreiranja</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1065"/>
-      <source>by Date Modified</source>
-      <translation>po datumu izmjene</translation>
+        <source>by Date Modified</source>
+        <translation>po datumu izmjene</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1067"/>
-      <source>Sort by Date Last Modified</source>
-      <translation>Sortiraj po datumu posljednje izmjene</translation>
+        <source>Sort by Date Last Modified</source>
+        <translation>Sortiraj po datumu posljednje izmjene</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1071"/>
-      <source>Random</source>
-      <translation>Nasumično</translation>
+        <source>Random</source>
+        <translation>Nasumično</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1073"/>
-      <source>Sort in Random Order</source>
-      <translation>Sortiraj nasumično</translation>
+        <source>Sort in Random Order</source>
+        <translation>Sortiraj nasumično</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1077"/>
-      <source>&amp;Ascending</source>
-      <translation>&amp;Uzlazno</translation>
+        <source>&amp;Ascending</source>
+        <translation>&amp;Uzlazno</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1079"/>
-      <source>Sort in Ascending Order</source>
-      <translation>Sortiraj uzlazno</translation>
+        <source>Sort in Ascending Order</source>
+        <translation>Sortiraj uzlazno</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1083"/>
-      <source>&amp;Descending</source>
-      <translation>&amp;Silazno</translation>
+        <source>&amp;Descending</source>
+        <translation>&amp;Silazno</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1085"/>
-      <source>Sort in Descending Order</source>
-      <translation>Sortiraj silazno</translation>
+        <source>Sort in Descending Order</source>
+        <translation>Sortiraj silazno</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1092"/>
-      <source>9&amp;0%1 Clockwise</source>
-      <translation>9&amp;0%1 u smjeru kazaljke na satu</translation>
+        <source>9&amp;0%1 Clockwise</source>
+        <translation>9&amp;0%1 u smjeru kazaljke na satu</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1095"/>
-      <source>rotate the image 90%1 clockwise</source>
-      <translation>rotiraj sliku 90%1 u smjeru kazaljke na satu</translation>
+        <source>rotate the image 90%1 clockwise</source>
+        <translation>rotiraj sliku 90%1 u smjeru kazaljke na satu</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1097"/>
-      <source>&amp;90%1 Counter Clockwise</source>
-      <translation>&amp;90%1 suprotno kazaljci na satu</translation>
+        <source>&amp;90%1 Counter Clockwise</source>
+        <translation>&amp;90%1 suprotno kazaljci na satu</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1100"/>
-      <source>rotate the image 90%1 counter clockwise</source>
-      <translation>rotiraj sliku 90%1 suprotno kazaljci na satu</translation>
+        <source>rotate the image 90%1 counter clockwise</source>
+        <translation>rotiraj sliku 90%1 suprotno kazaljci na satu</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1102"/>
-      <source>180%1</source>
-      <translation>180%1</translation>
+        <source>180%1</source>
+        <translation>180%1</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1103"/>
-      <source>rotate the image by 180%1</source>
-      <translation>rotiraj sliku 180%1</translation>
+        <source>rotate the image by 180%1</source>
+        <translation>rotiraj sliku 180%1</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1105"/>
-      <source>&amp;Undo</source>
-      <translation>&amp;Opozovi</translation>
+        <source>&amp;Undo</source>
+        <translation>&amp;Opozovi</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1108"/>
-      <source>Undo Last Action</source>
-      <translation>Poništi zadnju radnju</translation>
+        <source>Undo Last Action</source>
+        <translation>Poništi zadnju radnju</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1110"/>
-      <source>&amp;Redo</source>
-      <translation>&amp;Ponovi</translation>
+        <source>&amp;Redo</source>
+        <translation>&amp;Ponovi</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1113"/>
-      <source>Redo Last Action</source>
-      <translation>Ponovi zadnju radnju</translation>
+        <source>Redo Last Action</source>
+        <translation>Ponovi zadnju radnju</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1115"/>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1517"/>
-      <source>&amp;Copy</source>
-      <translation>&amp;Kopiraj</translation>
+        <source>&amp;Copy</source>
+        <translation>&amp;Kopiraj</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1118"/>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1123"/>
-      <source>copy image</source>
-      <translation>kopiraj sliku</translation>
+        <source>copy image</source>
+        <translation>kopiraj sliku</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1120"/>
-      <source>Copy &amp;Buffer</source>
-      <translation>Kopiraj &amp;pufer</translation>
+        <source>Copy &amp;Buffer</source>
+        <translation>Kopiraj &amp;pufer</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1125"/>
-      <source>Copy Co&amp;lor</source>
-      <translation>Kopiraj bo&amp;ju</translation>
+        <source>Copy Co&amp;lor</source>
+        <translation>Kopiraj bo&amp;ju</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1128"/>
-      <source>copy pixel color value as HEX</source>
-      <translation>kopiraj vrijednost boja piksela kao HEX</translation>
+        <source>copy pixel color value as HEX</source>
+        <translation>kopiraj vrijednost boja piksela kao HEX</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1133"/>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1520"/>
-      <source>&amp;Paste</source>
-      <translation>&amp;Nalijepi</translation>
+        <source>&amp;Paste</source>
+        <translation>&amp;Nalijepi</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1136"/>
-      <source>paste image</source>
-      <translation>nalijepi sliku</translation>
+        <source>paste image</source>
+        <translation>nalijepi sliku</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1138"/>
-      <source>R&amp;esize Image</source>
-      <translation>Pr&amp;omijeni veličinu slike</translation>
+        <source>R&amp;esize Image</source>
+        <translation>Pr&amp;omijeni veličinu slike</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1141"/>
-      <source>resize the current image</source>
-      <translation>promijeni veličinu trenutne slike</translation>
+        <source>resize the current image</source>
+        <translation>promijeni veličinu trenutne slike</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1143"/>
-      <source>Cr&amp;op Image</source>
-      <translation>I&amp;sjeci sliku</translation>
+        <source>Cr&amp;op Image</source>
+        <translation>I&amp;sjeci sliku</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1146"/>
-      <source>cut the current image</source>
-      <translation>isjeci trenutnu sliku</translation>
+        <source>cut the current image</source>
+        <translation>isjeci trenutnu sliku</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1150"/>
-      <source>Flip &amp;Horizontal</source>
-      <translation>Prevrni &amp;vodoravno</translation>
+        <source>Flip &amp;Horizontal</source>
+        <translation>Prevrni &amp;vodoravno</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1151"/>
-      <source>Flip Image Horizontally</source>
-      <translation>Prevrni sliku vodoravno</translation>
+        <source>Flip Image Horizontally</source>
+        <translation>Prevrni sliku vodoravno</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1153"/>
-      <source>Flip &amp;Vertical</source>
-      <translation>Prevrni &amp;uspravno</translation>
+        <source>Flip &amp;Vertical</source>
+        <translation>Prevrni &amp;uspravno</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1154"/>
-      <source>Flip Image Vertically</source>
-      <translation>Prevrni sliku uspravno</translation>
+        <source>Flip Image Vertically</source>
+        <translation>Prevrni sliku uspravno</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1156"/>
-      <source>Nor&amp;malize Image</source>
-      <translation>Norm&amp;alizuj sliku</translation>
+        <source>Nor&amp;malize Image</source>
+        <translation>Norm&amp;alizuj sliku</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1159"/>
-      <source>Normalize the Image</source>
-      <translation>Normalizira sliku</translation>
+        <source>Normalize the Image</source>
+        <translation>Normalizuj sliku</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1161"/>
-      <source>&amp;Auto Adjust</source>
-      <translation>&amp;Automatsko podešavanje</translation>
+        <source>&amp;Auto Adjust</source>
+        <translation>&amp;Automatsko podešavanje</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1164"/>
-      <source>Auto Adjust Image Contrast and Color Balance</source>
-      <translation>Automatski podešava kontrast i balans boja slike</translation>
+        <source>Auto Adjust Image Contrast and Color Balance</source>
+        <translation>Automatski podešava kontrast i balans boja slike</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1166"/>
-      <source>&amp;Invert Image</source>
-      <translation>&amp;Obrni sliku</translation>
+        <source>&amp;Invert Image</source>
+        <translation>&amp;Obrni sliku</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1167"/>
-      <source>Invert the Image</source>
-      <translation>Obrni sliku</translation>
+        <source>Invert the Image</source>
+        <translation>Obrni sliku</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1169"/>
-      <source>&amp;Convert to Grayscale</source>
-      <translation>&amp;Konvertuj u crno-bijelo</translation>
+        <source>Convert to Grayscale</source>
+        <translation>Konvertuj u crno-bijelo</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1170"/>
-      <source>Convert to Grayscale</source>
-      <translation>Konvertuje u crno-bijelo</translation>
+        <source>&amp;Delete</source>
+        <translation>&amp;Ukloni</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1172"/>
-      <source>&amp;Unsharp Mask</source>
-      <translation>&amp;Maska za izoštravanje</translation>
+        <source>delete current fileInfo</source>
+        <translation>izbriši informacije trenutnog fajla</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1173"/>
-      <source>Stretches the Local Contrast of an Image</source>
-      <translation>Isteže lokalni kontrast slike</translation>
+        <source>&amp;Wallpaper</source>
+        <translation>Po&amp;zadinska slika</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1175"/>
-      <source>&amp;Tiny Planet</source>
-      <translation>&amp;Mala planeta</translation>
+        <source>set the current image as wallpaper</source>
+        <translation>postavi trenutnu sliku kao pozadinu</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1176"/>
-      <source>Computes a tiny planet image</source>
-      <translation>Izračunava sliku u obliku male planete</translation>
+        <source>&amp;Keyboard Shortcuts</source>
+        <translation>&amp;Prečice tastature</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1178"/>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1514"/>
-      <source>&amp;Delete</source>
-      <translation>&amp;Ukloni</translation>
+        <source>lets you customize your keyboard shortcuts</source>
+        <translation>omogućava prilagođavanje prečica na tastaturi</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1181"/>
-      <source>delete current fileInfo</source>
-      <translation>izbriši informacije trenutnog fajla</translation>
+        <source>&amp;Settings</source>
+        <translation>&amp;Postavke</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1183"/>
-      <source>&amp;Wallpaper</source>
-      <translation>Po&amp;zadinska slika</translation>
+        <source>settings</source>
+        <translation>postavke</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1184"/>
-      <source>set the current image as wallpaper</source>
-      <translation>postavi trenutnu sliku kao pozadinu</translation>
+        <source>&amp;Menu</source>
+        <translation>&amp;Izbornik</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1186"/>
-      <source>&amp;Keyboard Shortcuts</source>
-      <translation>&amp;Prečice tastature</translation>
+        <source>Hides the Menu and Shows it Again on ALT</source>
+        <translation>Skriva izbornik i pokazuje ga opet na ALT</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1188"/>
-      <source>lets you customize your keyboard shortcuts</source>
-      <translation>omogućava prilagođavanje prečica na tastaturi</translation>
+        <source>Tool&amp;bar</source>
+        <translation>Alatna tra&amp;ka</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1190"/>
-      <source>&amp;Settings</source>
-      <translation>&amp;Postavke</translation>
+        <source>Show Toolbar</source>
+        <translation>Prikaži alatnu traku</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1192"/>
-      <source>settings</source>
-      <translation>postavke</translation>
+        <source>&amp;Statusbar</source>
+        <translation>&amp;Statusna traka</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1196"/>
-      <source>&amp;Menu</source>
-      <translation>&amp;Meni</translation>
+        <source>Show Statusbar</source>
+        <translation>Prikaži statusnu traku</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1197"/>
-      <source>Hides the Menu and Shows it Again on ALT</source>
-      <translation>Skriva meni i pokazuje ga opet na ALT</translation>
+        <source>&amp;Pseudocolor Function</source>
+        <translation>&amp;Pseudo-boja funkcija</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1200"/>
-      <source>Tool&amp;bar</source>
-      <translation>Alatna tra&amp;ka</translation>
+        <source>Show Pseudocolor Function</source>
+        <translation>Prikaži funkciju pseudo-boja</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1202"/>
-      <source>Show Toolbar</source>
-      <translation>Prikaži alatnu traku</translation>
+        <source>O&amp;verview</source>
+        <translation>P&amp;regled</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1205"/>
-      <source>&amp;Statusbar</source>
-      <translation>&amp;Statusna traka</translation>
+        <source>Shows the Zoom Overview</source>
+        <translation>Prikaže zumirani pregled</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1207"/>
-      <source>Show Statusbar</source>
-      <translation>Prikaži statusnu traku</translation>
+        <source>Pla&amp;yer</source>
+        <translation>Ple&amp;jer</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1210"/>
-      <source>&amp;Pseudocolor Function</source>
-      <translation>&amp;Pseudo-bojna funkcija</translation>
+        <source>Shows the Slide Show Player</source>
+        <translation>Prikazuje slajdšou plejer</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1212"/>
-      <source>Show Pseudocolor Function</source>
-      <translation>Prikaži funkciju pseudo-boja</translation>
+        <source>File &amp;Explorer</source>
+        <translation>Pregledač &amp;fajlova</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1216"/>
-      <source>O&amp;verview</source>
-      <translation>P&amp;regled</translation>
+        <source>Show File Explorer</source>
+        <translation>Prikaži pregledač fajlova</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1218"/>
-      <source>Shows the Zoom Overview</source>
-      <translation>Prikaže zumirani pregled</translation>
+        <source>Metadata &amp;Info</source>
+        <translation>Meta &amp;podaci</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1222"/>
-      <source>Pla&amp;yer</source>
-      <translation>Ple&amp;jer</translation>
+        <source>Show Metadata Info</source>
+        <translation>Prikaži meta podatke</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1224"/>
-      <source>Shows the Slide Show Player</source>
-      <translation>Prikazuje slajdšou plejer</translation>
+        <source>&amp;Thumbnails</source>
+        <translation>&amp;Sličice</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1227"/>
-      <source>File &amp;Explorer</source>
-      <translation>Pregledač &amp;fajlova</translation>
+        <source>Show Thumbnails</source>
+        <translation>Prikaži sličice</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1229"/>
-      <source>Show File Explorer</source>
-      <translation>Prikaži pregledač fajlova</translation>
+        <source>&amp;Thumbnail Preview</source>
+        <translation>&amp;Pregled sličica</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1232"/>
-      <source>Metadata &amp;Info</source>
-      <translation>Meta &amp;podaci</translation>
+        <source>Show Thumbnails Preview</source>
+        <translation>Prikaži pregled sličica</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1234"/>
-      <source>Show Metadata Info</source>
-      <translation>Prikaži meta podatke</translation>
+        <source>&amp;Folder Scrollbar</source>
+        <translation>&amp;Klizač fascikle</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1237"/>
-      <source>&amp;Thumbnails</source>
-      <translation>&amp;Sličice</translation>
+        <source>Show Folder Scrollbar</source>
+        <translation>Prikaži klizač fascikle</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1239"/>
-      <source>Show Thumbnails</source>
-      <translation>Prikaži sličice</translation>
+        <source>&amp;Metadata</source>
+        <translation>&amp;Meta podaci</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1242"/>
-      <source>&amp;Thumbnail Preview</source>
-      <translation>&amp;Pregled sličica</translation>
+        <source>Shows the Metadata Panel</source>
+        <translation>Prikaže panel sa meta podacima</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1244"/>
-      <source>Show Thumbnails Preview</source>
-      <translation>Prikaži pregled sličica</translation>
+        <source>File &amp;Info</source>
+        <translation>Informacije o &amp;fajlu</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1247"/>
-      <source>&amp;Folder Scrollbar</source>
-      <translation>&amp;Klizač fascikle</translation>
+        <source>Shows the Info Panel</source>
+        <translation>Prikaže panel sa informacijama</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1249"/>
-      <source>Show Folder Scrollbar</source>
-      <translation>Prikaži klizač fascikle</translation>
+        <source>&amp;Histogram</source>
+        <translation>&amp;Histogram</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1252"/>
-      <source>&amp;Metadata</source>
-      <translation>&amp;Meta podaci</translation>
+        <source>Shows the Histogram Panel</source>
+        <translation>Prikaže panel sa histogramom</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1254"/>
-      <source>Shows the Metadata Panel</source>
-      <translation>Prikaže panel sa meta podacima</translation>
+        <source>Image &amp;Notes</source>
+        <translation>Napomene &amp;o slici</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1257"/>
-      <source>File &amp;Info</source>
-      <translation>Informacije o &amp;fajlu</translation>
+        <source>Shows Image Notes</source>
+        <translation>Prikaže napomene o slici</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1259"/>
-      <source>Shows the Info Panel</source>
-      <translation>Prikaže panel sa informacijama</translation>
+        <source>Edit &amp;History</source>
+        <translation>Uredi &amp;historiju</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1262"/>
-      <source>&amp;Histogram</source>
-      <translation>%Histogram</translation>
+        <source>Shows the edit history</source>
+        <translation>Prikazuje historiju uređivanja</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1264"/>
-      <source>Shows the Histogram Panel</source>
-      <translation>Prikaže panel sa histogramom</translation>
+        <source>&amp;Fit Window</source>
+        <translation>&amp;Prilagodi prozor</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1267"/>
-      <source>Image &amp;Notes</source>
-      <translation>Napomene &amp;o slici</translation>
+        <source>Fit window to the image</source>
+        <translation>Prilagođava prozor slici</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1269"/>
-      <source>Shows Image Notes</source>
-      <translation>Prikaže napomene o slici</translation>
+        <source>Fu&amp;ll Screen</source>
+        <translation>&amp;Cijeli ekran</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1272"/>
-      <source>Edit &amp;History</source>
-      <translation>Uredi &amp;historiju</translation>
+        <source>Full Screen</source>
+        <translation>Cijeli ekran</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1273"/>
-      <source>Shows the edit history</source>
-      <translation>Prikazuje prošla uređivanja</translation>
+        <source>&amp;Zoom to Fit</source>
+        <translation>&amp;Zumiraj da odgovara</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1279"/>
-      <source>&amp;Fit Window</source>
-      <translation>&amp;Prilagodi prozor</translation>
+        <source>Shows the initial view (no zooming)</source>
+        <translation>Prikaže početni pogled (bez zumiranja)</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1281"/>
-      <source>Fit window to the image</source>
-      <translation>Prilagođava prozor slici</translation>
+        <source>Show &amp;100%</source>
+        <translation>Prikaži &amp;100%</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1286"/>
-      <source>Fu&amp;ll Screen</source>
-      <translation>&amp;Cijeli ekran</translation>
+        <source>Shows the image at 100%</source>
+        <translation>Prikaže sliku pri punoj veličini</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1288"/>
-      <source>Full Screen</source>
-      <translation>Cijeli ekran</translation>
+        <source>Zoom &amp;In</source>
+        <translation>Uveć&amp;aj</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1290"/>
-      <source>&amp;Zoom to Fit</source>
-      <translation>&amp;Zumiraj da odgovara</translation>
+        <source>zoom in</source>
+        <translation>uvećaj</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1292"/>
-      <source>Shows the initial view (no zooming)</source>
-      <translation>Prikaže početni pogled (bez zumiranja)</translation>
+        <source>&amp;Zoom Out</source>
+        <translation>&amp;Umanji</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1294"/>
-      <source>Show &amp;100%</source>
-      <translation>Prikaži &amp;100%</translation>
+        <source>zoom out</source>
+        <translation>umanji</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1296"/>
-      <source>Shows the image at 100%</source>
-      <translation>Prikaže sliku pri punoj veličini</translation>
+        <source>&amp;Anti Aliasing</source>
+        <translation>&amp;Omekšavanje</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1298"/>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1497"/>
-      <source>Zoom &amp;In</source>
-      <translation>Uveć&amp;aj</translation>
+        <source>if checked images are smoother</source>
+        <translation>ako je označeno, slike imaju blaže ivice</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1300"/>
-      <source>zoom in</source>
-      <translation>uvećaj</translation>
+        <source>&amp;Transparency Pattern</source>
+        <translation>Mus&amp;tra za proznirno</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1302"/>
-      <source>&amp;Zoom Out</source>
-      <translation>&amp;Umanji</translation>
+        <source>if checked, a pattern will be displayed for transparent objects</source>
+        <translation>ako je označeno, mustra će biti prikazana za providne objekte</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1304"/>
-      <source>zoom out</source>
-      <translation>umanji</translation>
+        <source>&amp;Frameless</source>
+        <translation>&amp;Bez okvira</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1306"/>
-      <source>&amp;Anti Aliasing</source>
-      <translation>&amp;Omekšavanje</translation>
+        <source>shows a frameless window</source>
+        <translation>prikazuje prozor bez okvira</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1308"/>
-      <source>if checked images are smoother</source>
-      <translation>ako je označeno, slike imaju blaže ivice</translation>
+        <source>New &amp;Tab</source>
+        <translation>Nova &amp;kartica</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1312"/>
-      <source>&amp;Transparency Pattern</source>
-      <translation>Mus&amp;tra za proznirno</translation>
+        <source>Open a new tab</source>
+        <translation>Otvori novu karticu</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1314"/>
-      <source>if checked, a pattern will be displayed for transparent objects</source>
-      <translation>ako je označeno, mustra će biti prikazana za providne objekte</translation>
+        <source>&amp;Close Tab</source>
+        <translation>&amp;Zatvori karticu</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1318"/>
-      <source>&amp;Frameless</source>
-      <translation>&amp;Bez okvira</translation>
+        <source>Close current tab</source>
+        <translation>Zatvori trenutnu karticu</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1320"/>
-      <source>shows a frameless window</source>
-      <translation>prikazuje prozor bez okvira</translation>
+        <source>&amp;Previous Tab</source>
+        <translation>&amp;Prethodna kartica</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1324"/>
-      <source>New &amp;Tab</source>
-      <translation>Nova &amp;kartica</translation>
+        <source>Switch to previous tab</source>
+        <translation>Prebaci na prethodnu karticu</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1326"/>
-      <source>Open a new tab</source>
-      <translation>Otvori novu karticu</translation>
+        <source>&amp;Next Tab</source>
+        <translation>&amp;Sljedeća kartica</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1328"/>
-      <source>&amp;Close Tab</source>
-      <translation>&amp;Zatvori karticu</translation>
+        <source>Switch to next tab</source>
+        <translation>Prebaci na sljedeću karticu</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1330"/>
-      <source>Close current tab</source>
-      <translation>Zatvori trenutnu karticu</translation>
+        <source>&amp;Change Opacity</source>
+        <translation>&amp;Izmjeni providnost</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1332"/>
-      <source>&amp;Previous Tab</source>
-      <translation>&amp;Prethodna kartica</translation>
+        <source>change the window opacity</source>
+        <translation>promijeni providnost prozora</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1334"/>
-      <source>Switch to previous tab</source>
-      <translation>Prebaci na prethodnu karticu</translation>
+        <source>Opacity &amp;Up</source>
+        <translation>Smanji &amp;providnost</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1336"/>
-      <source>&amp;Next Tab</source>
-      <translation>&amp;Sljedeća kartica</translation>
+        <source>changes the window opacity</source>
+        <translation>mijenja providnost prozora</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1338"/>
-      <source>Switch to next tab</source>
-      <translation>Prebaci na sljedeću karticu</translation>
+        <source>Opacity &amp;Down</source>
+        <translation>Uvećaj &amp;providnost</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1340"/>
-      <source>&amp;Change Opacity</source>
-      <translation>&amp;Izmjeni providnost</translation>
+        <source>To&amp;ggle Opacity</source>
+        <translation>&amp;Izmjeni providnost</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1342"/>
-      <source>change the window opacity</source>
-      <translation>promijeni providnost prozora</translation>
+        <source>toggle the window opacity</source>
+        <translation>izmjeni providnost prozora</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1344"/>
-      <source>Opacity &amp;Up</source>
-      <translation>Smanji &amp;providnost</translation>
+        <source>Lock &amp;Window</source>
+        <translation>Zaključaj &amp;prozor</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1346"/>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1350"/>
-      <source>changes the window opacity</source>
-      <translation>mijenja providnost prozora</translation>
+        <source>lock the window</source>
+        <translation>zaključaj prozor</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1348"/>
-      <source>Opacity &amp;Down</source>
-      <translation>Uvećaj &amp;providnost</translation>
+        <source>&amp;Toggle Slideshow</source>
+        <translation>&amp;Uključu slajdšou prikaz</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1352"/>
-      <source>To&amp;ggle Opacity</source>
-      <translation>&amp;Izmjeni providnost</translation>
+        <source>Start/Pause the slideshow</source>
+        <translation>Pokreni/pauziraj slajdšou</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1354"/>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1441"/>
-      <source>toggle the window opacity</source>
-      <translation>izmjeni providnost prozora</translation>
+        <source>&amp;Pause Movie</source>
+        <translation>&amp;Pauziraj video</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1356"/>
-      <source>Lock &amp;Window</source>
-      <translation>Zaključaj &amp;prozor</translation>
+        <source>pause the current movie</source>
+        <translation>pauzira trenutni video</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1358"/>
-      <source>lock the window</source>
-      <translation>zaključaj prozor</translation>
+        <source>P&amp;revious Frame</source>
+        <translation>P&amp;retnodni frejm</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1362"/>
-      <source>&amp;Toggle Slideshow</source>
-      <translation>&amp;Uključu slajdšou prikaz</translation>
+        <source>show previous frame</source>
+        <translation>prikaže prethodni frejm</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1363"/>
-      <source>Start/Pause the slideshow</source>
-      <translation>Pokreni/pauziraj slajdšou</translation>
+        <source>&amp;Next Frame</source>
+        <translation>&amp;Sljedeći frejm</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1366"/>
-      <source>&amp;Pause Movie</source>
-      <translation>&amp;Pauziraj video</translation>
+        <source>show next frame</source>
+        <translation>prikaže sljedeću slikicu</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1367"/>
-      <source>pause the current movie</source>
-      <translation>pauzira trenutni video</translation>
+        <source>Show G&amp;PS Coordinates</source>
+        <translation>Prikaži G&amp;PS koordinate</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1371"/>
-      <source>P&amp;revious Frame</source>
-      <translation>P&amp;retnodni frejm</translation>
+        <source>shows the GPS coordinates</source>
+        <translation>prikaže GPS koordinate</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1372"/>
-      <source>show previous frame</source>
-      <translation>prikaže prethodni frejm</translation>
+        <source>Compute &amp;Thumbnails</source>
+        <translation>Izračunaj &amp;sličice</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1374"/>
-      <source>&amp;Next Frame</source>
-      <translation>&amp;Sljedeći frejm</translation>
+        <source>compute all thumbnails of the current folder</source>
+        <translation>stvara sličice za sve slike u trenutnoj fascikli</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1375"/>
-      <source>show next frame</source>
-      <translation>prikaže sljedeću slikicu</translation>
+        <source>&amp;Filter</source>
+        <translation>&amp;Filter</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1377"/>
-      <source>Show G&amp;PS Coordinates</source>
-      <translation>Prikaži G&amp;PS koordinate</translation>
+        <source>Export Multipage &amp;TIFF</source>
+        <translation>Eksportuj višestrani &amp;TIFF</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1378"/>
-      <source>shows the GPS coordinates</source>
-      <translation>prikaže GPS koordinate</translation>
+        <source>Export TIFF pages to multiple tiff files</source>
+        <translation>Eksportuje TIFF stranice u više tiff fajlova</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1384"/>
-      <source>Compute &amp;Thumbnails</source>
-      <translation>Izračunaj &amp;sličice</translation>
+        <source>Extract From Archive</source>
+        <translation>Raspakuj iz arhive</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1385"/>
-      <source>compute all thumbnails of the current folder</source>
-      <translation>stvara sličice za sve slike u trenutnoj fascikli</translation>
+        <source>Extract images from an archive (%1)</source>
+        <translation>Raspakuje slike iz arhive (%1)</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1388"/>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1511"/>
-      <source>&amp;Filter</source>
-      <translation>&amp;Filter</translation>
+        <source>&amp;Mosaic Image</source>
+        <translation>&amp;Mozaik slika</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1393"/>
-      <source>Image &amp;Manipulation</source>
-      <translation>Obrada &amp;slika</translation>
+        <source>Create a Mosaic Image</source>
+        <translation>Pravi mozaik sliku</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1395"/>
-      <source>modify the current image</source>
-      <translation>izmjeni trenutnu sliku</translation>
+        <source>Batch Processing</source>
+        <translation>Grupno podešavanje</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1397"/>
-      <source>Export Multipage &amp;TIFF</source>
-      <translation>Eksportuj višestrani &amp;TIFF</translation>
+        <source>Apply actions to multiple images</source>
+        <translation>Prihvati radnje na više slika</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1398"/>
-      <source>Export TIFF pages to multiple tiff files</source>
-      <translation>Eksportuje TIFF stranice u više tiff fajlova</translation>
+        <source>&amp;About Nomacs</source>
+        <translation>&amp;O programu Nomacs</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1400"/>
-      <source>Extract From Archive</source>
-      <translation>Raspakuj iz arhive</translation>
+        <source>about</source>
+        <translation>o programu</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1401"/>
-      <source>Extract images from an archive (%1)</source>
-      <translation>Raspakuje slike iz arhive (%1)</translation>
+        <source>&amp;Documentation</source>
+        <translation>&amp;Dokumentacija</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1404"/>
-      <source>&amp;Mosaic Image</source>
-      <translation>&amp;Mozaik slika</translation>
+        <source>Online Documentation</source>
+        <translation>Internet dokumentacija</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1405"/>
-      <source>Create a Mosaic Image</source>
-      <translation>Pravi mozaik sliku</translation>
+        <source>&amp;Report a Bug</source>
+        <translation>&amp;Prijavi grešku</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1407"/>
-      <source>Batch Processing</source>
-      <translation>Grupno podešavanje</translation>
+        <source>Report a Bug</source>
+        <translation>Prijavi grešku</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1408"/>
-      <source>Apply actions to multiple images</source>
-      <translation>Prihvati radnje na više slika</translation>
+        <source>&amp;Check for Updates</source>
+        <translation>&amp;Provjeri ažuriranje</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1413"/>
-      <source>&amp;About Nomacs</source>
-      <translation>&amp;O programu Nomacs</translation>
+        <source>check for updates</source>
+        <translation>provjeri ažuriranje</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1415"/>
-      <source>about</source>
-      <translation>o programu</translation>
+        <source>&amp;Update Translation</source>
+        <translation>&amp;Ažuriraj prevod</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1417"/>
-      <source>&amp;Documentation</source>
-      <translation>&amp;Dokumentacija</translation>
+        <source>Checks for a new version of the translations of the current language</source>
+        <translation>Provjerava da li postoji nova verzija prevoda za trenutni jezik</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1418"/>
-      <source>Online Documentation</source>
-      <translation>Internet dokumentacija</translation>
+        <source>Synchronize &amp;View</source>
+        <translation>Sinhroniziraj &amp;pogled</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1420"/>
-      <source>&amp;Report a Bug</source>
-      <translation>&amp;Prijavi grešku</translation>
+        <source>synchronize the current view</source>
+        <translation>sinhronizuj trenutni pogled</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1421"/>
-      <source>Report a Bug</source>
-      <translation>Prijavi grešku</translation>
+        <source>&amp;Window Overlay</source>
+        <translation>&amp;Preklapanje prozora</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1423"/>
-      <source>&amp;Feature Request</source>
-      <translation>&amp;Zahtijevaj poboljšanja</translation>
+        <source>Arrange Instances</source>
+        <translation>Aranžiraj instance</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1424"/>
-      <source>Feature Request</source>
-      <translation>Zahtijevaj poboljšanja</translation>
+        <source>arrange connected instances</source>
+        <translation>aranžira povezane instance</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1426"/>
-      <source>&amp;Check for Updates</source>
-      <translation>&amp;Provjeri ažuriranje</translation>
+        <source>Connect &amp;All</source>
+        <translation>Poveži &amp;sve</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1427"/>
-      <source>check for updates</source>
-      <translation>provjeri ažuriranje</translation>
+        <source>connect all instances</source>
+        <translation>povezuje sve instance</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1429"/>
-      <source>&amp;Update Translation</source>
-      <translation>&amp;Ažuriraj prevod</translation>
+        <source>&amp;Sync All Actions</source>
+        <translation>&amp;Sinhronizuj sve radnje</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1430"/>
-      <source>Checks for a new version of the translations of the current language</source>
-      <translation>Provjerava da li postoji nova verzija prevoda za trenutni jezik</translation>
+        <source>Transmit All Signals Automatically.</source>
+        <translation>Šalji sve signale automatski.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1434"/>
-      <source>Synchronize &amp;View</source>
-      <translation>Sinhroniziraj &amp;pregled</translation>
+        <source>&amp;Remote Control</source>
+        <translation>&amp;Daljinski</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1436"/>
-      <source>synchronize the current view</source>
-      <translation>sinhronizuj trenutni pregled</translation>
+        <source>Automatically Receive Images From Your Remote Instance.</source>
+        <translation>Automatski primaj slike sa udaljene instance.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1439"/>
-      <source>&amp;Window Overlay</source>
-      <translation>&amp;Preklapanje prozora</translation>
+        <source>Remote &amp;Display</source>
+        <translation>Udaljeni &amp;ekran</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1444"/>
-      <source>Arrange Instances</source>
-      <translation>Aranžiraj instance</translation>
+        <source>Automatically Send Images to a Remote Instance.</source>
+        <translation>Automatski šalji slike na udaljenu instancu.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1446"/>
-      <source>arrange connected instances</source>
-      <translation>aranžira povezane instance</translation>
+        <source>Start &amp;Server</source>
+        <translation>Pokreni &amp;server</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1449"/>
-      <source>Connect &amp;All</source>
-      <translation>Poveži &amp;sve</translation>
+        <source>Send &amp;Image</source>
+        <translation>Pošalji &amp;sliku</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1452"/>
-      <source>connect all instances</source>
-      <translation>povezuje sve instance</translation>
+        <source>Sends the current image to all clients.</source>
+        <translation>Šalje trenutnu sliku svim klijentima.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1454"/>
-      <source>&amp;Sync All Actions</source>
-      <translation>&amp;Sinhronizuj sve radnje</translation>
+        <source>&amp;Plugin Manager</source>
+        <translation>Upravljač &amp;priključaka</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1455"/>
-      <source>Transmit All Signals Automatically.</source>
-      <translation>Šalji sve signale automatski.</translation>
+        <source>manage installed plugins and download new ones</source>
+        <translation>upravljaj instaliranim priključcima i preuzmi nove</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1459"/>
-      <source>&amp;Start Upnp</source>
-      <translation>&amp;Počni UPnP</translation>
+        <source>Select &amp;All</source>
+        <translation>Izaberi &amp;sve</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1460"/>
-      <source>Starts a Upnp Media Renderer.</source>
-      <translation>Startuje UPnP medija server.</translation>
+        <source>Zoom &amp;Out</source>
+        <translation>Uma&amp;nji</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1463"/>
-      <source>&amp;Remote Control</source>
-      <translation>&amp;Daljinski</translation>
+        <source>Display &amp;Squares</source>
+        <translation>Prikaz &amp;kvadrata</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1465"/>
-      <source>Automatically Receive Images From Your Remote Instance.</source>
-      <translation>Automatski primaj slike sa udaljene instance.</translation>
+        <source>Show &amp;Filename</source>
+        <translation>Prikaži &amp;ime fajla</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1468"/>
-      <source>Remote &amp;Display</source>
-      <translation>Udaljeni &amp;ekran</translation>
+        <source>&amp;Rename</source>
+        <translation>&amp;Preimenuj</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1469"/>
-      <source>Automatically Send Images to a Remote Instance.</source>
-      <translation>Automatski šalji slike na udaljenu instancu.</translation>
+        <source>&amp;Batch Process</source>
+        <translation>&amp;Grupna obrada</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1475"/>
-      <source>Start &amp;Server</source>
-      <translation>Pokreni &amp;server</translation>
+        <source>Adds selected files to batch processing.</source>
+        <translation>Dodaje izabrane fajlove za grupnu obradu.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1480"/>
-      <source>Send &amp;Image</source>
-      <translation>Pošalji &amp;sliku</translation>
+        <source>Start pong</source>
+        <translation>Pokreni pong</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1483"/>
-      <source>Sends the current image to all clients.</source>
-      <translation>Šalje trenutnu sliku svim klijentima.</translation>
+        <source>First File</source>
+        <translation>Prvi fajl</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1487"/>
-      <source>&amp;Plugin Manager</source>
-      <translation>Upravljač &amp;priključaka</translation>
+        <source>Jump to first file</source>
+        <translation>Skoči na posljedni fajl</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1488"/>
-      <source>manage installed plugins and download new ones</source>
-      <translation>upravljaj instaliranim priključcima i preuzmi nove</translation>
+        <source>Last File</source>
+        <translation>Posljedni fajl</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1493"/>
-      <source>Select &amp;All</source>
-      <translation>Izaberi &amp;sve</translation>
+        <source>Jump to the end of the current folder</source>
+        <translation>Skoči na kraj trenutne fascikle</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1500"/>
-      <source>Zoom &amp;Out</source>
-      <translation>Uma&amp;nji</translation>
+        <source>Skip Previous Images</source>
+        <translation>Preskoči prethodne slike</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1503"/>
-      <source>Display &amp;Squares</source>
-      <translation>Prikaz &amp;kvadrata</translation>
+        <source>Jumps 10 images before the current image</source>
+        <translation>Preskače 10 slika prije trenutne slike</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1507"/>
-      <source>Show &amp;Filename</source>
-      <translation>Prikaži &amp;ime fajla</translation>
+        <source>Skip Next Images</source>
+        <translation>Preskoči sljedeće slike</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1523"/>
-      <source>&amp;Rename</source>
-      <translation>&amp;Preimenuj</translation>
+        <source>Jumps 10 images after the current image</source>
+        <translation>Preskače 10 slika poslje trenutne slike</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1526"/>
-      <source>&amp;Batch Process</source>
-      <translation>&amp;Grupna obrada</translation>
+        <source>First File Sync</source>
+        <translation>Prva sinhronizacija fajla</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1527"/>
-      <source>Adds selected files to batch processing.</source>
-      <translation>Dodaje izabrane fajlove za grupnu obradu.</translation>
+        <source>Last File Sync</source>
+        <translation>Posljednja sinhronizacija fajla</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1542"/>
-      <source>Start pong</source>
-      <translation>Pokreni pong</translation>
+        <source>Skip Previous Images Sync</source>
+        <translation>Preskoči sinhronizaciju pretnodne slike</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1545"/>
-      <source>First File</source>
-      <translation>Prvi fajl</translation>
+        <source>Skip Next Images Sync</source>
+        <translation>Preskoči sinhronizaciju sljedeće slike</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1546"/>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1562"/>
-      <source>Jump to first file</source>
-      <translation>Skoči na posljedni fajl</translation>
+        <source>Delete File Silent</source>
+        <translation>Izbriši tiho fajl</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1549"/>
-      <source>Last File</source>
-      <translation>Posljedni fajl</translation>
+        <source>Deletes a file without warning</source>
+        <translation>Briše fajl bez upozorenja</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1550"/>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1566"/>
-      <source>Jump to the end of the current folder</source>
-      <translation>Skoči na kraj trenutne fascikle</translation>
+        <source>&lt;data too large to display&gt;</source>
+        <translation>&lt;podaci preveliki za prikaz&gt;</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1553"/>
-      <source>Skip Previous Images</source>
-      <translation>Preskoči prethodne slike</translation>
+        <source>Filename</source>
+        <translation>Ime fajla</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1554"/>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1570"/>
-      <source>Jumps 10 images before the current image</source>
-      <translation>Preskače 10 slika prije trenutne slike</translation>
+        <source>Path</source>
+        <translation>Putanja</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1557"/>
-      <source>Skip Next Images</source>
-      <translation>Preskoči sljedeće slike</translation>
+        <source>Target</source>
+        <translation>Meta</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1558"/>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1574"/>
-      <source>Jumps 10 images after the current image</source>
-      <translation>Preskače 10 slika poslje trenutne slike</translation>
+        <source>Size</source>
+        <translation>Veličina</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1561"/>
-      <source>First File Sync</source>
-      <translation>Sinhronizuj prvi fajl</translation>
+        <source>Date</source>
+        <translation>Datum</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1565"/>
-      <source>Last File Sync</source>
-      <translation>Sinhronizuj posljedni fajl</translation>
+        <source>Created</source>
+        <translation>Kreirano</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1569"/>
-      <source>Skip Previous Images Sync</source>
-      <translation>Preskoči sinhronizaciju pretnodne slike</translation>
+        <source>Last Modified</source>
+        <translation>Posljednja izmjena</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1573"/>
-      <source>Skip Next Images Sync</source>
-      <translation>Preskoči sinhronizaciju sljedeće slike</translation>
+        <source>Last Read</source>
+        <translation>Posljednje pregledano</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1577"/>
-      <source>Delete File Silent</source>
-      <translation>Izbriši tiho fajl</translation>
+        <source>Owner</source>
+        <translation>Vlasnik</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1578"/>
-      <source>Deletes a file without warning</source>
-      <translation>Briše fajl bez upozorenja</translation>
+        <source>OwnerID</source>
+        <translation>Vlasnički ID</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="407"/>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="888"/>
-      <source>&lt;data too large to display&gt;</source>
-      <translation>&lt;podaci preveliki za prikaz&gt;</translation>
+        <source>Group</source>
+        <translation>Grupa</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="797"/>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="522"/>
-      <source>Filename</source>
-      <translation>Ime fajla</translation>
+        <source>Permissions</source>
+        <translation>Dozvole</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="798"/>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="525"/>
-      <source>Path</source>
-      <translation>Putanja</translation>
+        <source>User</source>
+        <translation>Korisnik</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="529"/>
-      <source>Target</source>
-      <translation>Meta</translation>
+        <source>Other</source>
+        <translation>Drugo</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="799"/>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="533"/>
-      <source>Size</source>
-      <translation>Veličina</translation>
+        <source>File</source>
+        <translation>Fajl</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="537"/>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="540"/>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="543"/>
-      <source>Date</source>
-      <translation>Datum</translation>
+        <source>not defined</source>
+        <translation>nije definisano</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="537"/>
-      <source>Created</source>
-      <translation>Kreirano</translation>
+        <source>manual</source>
+        <translation>ručno</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="540"/>
-      <source>Last Modified</source>
-      <translation>Posljednja izmjena</translation>
+        <source>normal</source>
+        <translation>normalno</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="543"/>
-      <source>Last Read</source>
-      <translation>Posljednje pregledano</translation>
+        <source>aperture priority</source>
+        <translation>prioritet otvora</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="547"/>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="560"/>
-      <source>Owner</source>
-      <translation>Vlasnik</translation>
+        <source>shutter priority</source>
+        <translation>prioritet zatvarača</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="551"/>
-      <source>OwnerID</source>
-      <translation>Vlasnički ID</translation>
+        <source>program creative</source>
+        <translation>kreativni program</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="555"/>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="574"/>
-      <source>Group</source>
-      <translation>Grupa</translation>
+        <source>high-speed program</source>
+        <translation>program za visoku brzinu</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="560"/>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="567"/>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="574"/>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="581"/>
-      <source>Permissions</source>
-      <translation>Dozvole</translation>
+        <source>portrait mode</source>
+        <translation>portret</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="567"/>
-      <source>User</source>
-      <translation>Korisnik</translation>
+        <source>landscape mode</source>
+        <translation>pejzaž</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="581"/>
-      <source>Other</source>
-      <translation>Drugo</translation>
+        <source>No Flash</source>
+        <translation>Bez blica</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="591"/>
-      <source>File</source>
-      <translation>Fajl</translation>
+        <source>Fired</source>
+        <translation>Aktivirano</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1485"/>
-      <source>not defined</source>
-      <translation>nije definisano</translation>
+        <source>Fired, Return not detected</source>
+        <translation>Aktivirano, povratak nije detektovan</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1486"/>
-      <source>manual</source>
-      <translation>ručno</translation>
+        <source>Fired, Return detected</source>
+        <translation>Aktivirano, povratak detektovan</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1487"/>
-      <source>normal</source>
-      <translation>normalno</translation>
+        <source>On, Did not fire</source>
+        <translation>Uključeno, nije aktivirano</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1488"/>
-      <source>aperture priority</source>
-      <translation>prioritet otvora</translation>
+        <source>On, Fired</source>
+        <translation>Uključeno, aktivirano</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1489"/>
-      <source>shutter priority</source>
-      <translation>prioritet zatvarača</translation>
+        <source>On, Return not detected</source>
+        <translation>Uključeno, povratak nije detektovan</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1490"/>
-      <source>program creative</source>
-      <translation>kreativni program</translation>
+        <source>On, Return detected</source>
+        <translation>Uključeno, povratak detektovan</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1491"/>
-      <source>high-speed program</source>
-      <translation>program za visoku brzinu</translation>
+        <source>Off, Did not fire</source>
+        <translation>Isključeno, nije aktivirano</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1492"/>
-      <source>portrait mode</source>
-      <translation>portret</translation>
+        <source>Off, Did not fire, Return not detected</source>
+        <translation>Isključeno, nije aktivirano, povratak nije detektovan</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1493"/>
-      <source>landscape mode</source>
-      <translation>pejzaž</translation>
+        <source>Auto, Did not fire</source>
+        <translation>Automatski, nije aktivirano</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1496"/>
-      <source>No Flash</source>
-      <translation>Bez blica</translation>
+        <source>Auto, Fired</source>
+        <translation>Automatski, aktivirano</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1497"/>
-      <source>Fired</source>
-      <translation>Aktivirano</translation>
+        <source>Auto, Fired, Return not detected</source>
+        <translation>Automatski, aktivirano, povratak nije detektovan</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1498"/>
-      <source>Fired, Return not detected</source>
-      <translation>Aktivirano, povratak nije detektovan</translation>
+        <source>Auto, Fired, Return detected</source>
+        <translation>Automatski, aktivirano, povratak detektovan</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1499"/>
-      <source>Fired, Return detected</source>
-      <translation>Aktivirano, povratak detektovan</translation>
+        <source>No flash function</source>
+        <translation>Blic isključen</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1500"/>
-      <source>On, Did not fire</source>
-      <translation>Uključeno, nije aktivirano</translation>
+        <source>Off, No flash function</source>
+        <translation>Isključeno, bez blica</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1501"/>
-      <source>On, Fired</source>
-      <translation>Uključeno, aktivirano</translation>
+        <source>Fired, Red-eye reduction</source>
+        <translation>Aktivirano, redukcija crvenih očiju</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1502"/>
-      <source>On, Return not detected</source>
-      <translation>Uključeno, povratak nije detektovan</translation>
+        <source>Fired, Red-eye reduction, Return not detected</source>
+        <translation>Aktivirano, redukcija crvenih očiju, povratak nije detektovan</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1503"/>
-      <source>On, Return detected</source>
-      <translation>Uključeno, povratak detektovan</translation>
+        <source>Fired, Red-eye reduction, Return detected</source>
+        <translation>Aktivirano, redukcija crvenih očiju, povratak detektovan</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1504"/>
-      <source>Off, Did not fire</source>
-      <translation>Isključeno, nije aktivirano</translation>
+        <source>On, Red-eye reduction</source>
+        <translation>Uključeno, redukcija crvenih očiju</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1505"/>
-      <source>Off, Did not fire, Return not detected</source>
-      <translation>Isključeno, nije aktivirano, povratak nije detektovan</translation>
+        <source>On, Red-eye reduction, Return not detected</source>
+        <translation>Uključeno, redukcija crvenih očiju, povratak nije detektovan</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1506"/>
-      <source>Auto, Did not fire</source>
-      <translation>Automatski, nije aktivirano</translation>
+        <source>On, Red-eye reduction, Return detected</source>
+        <translation>Uključeno, redukcija crvenih očiju, povratak detektovan</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1507"/>
-      <source>Auto, Fired</source>
-      <translation>Automatski, aktivirano</translation>
+        <source>Off, Red-eye reduction</source>
+        <translation>Isključeno, redukcija crvenih očiju</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1508"/>
-      <source>Auto, Fired, Return not detected</source>
-      <translation>Automatski, aktivirano, povratak nije detektovan</translation>
+        <source>Auto, Did not fire, Red-eye reduction</source>
+        <translation>Automatski, nije aktivirano, redukcija crvenih očiju</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1509"/>
-      <source>Auto, Fired, Return detected</source>
-      <translation>Automatski, aktivirano, povratak detektovan</translation>
+        <source>Auto, Fired, Red-eye reduction</source>
+        <translation>Automatski, aktivirano, redukcija crvenih očiju</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1510"/>
-      <source>No flash function</source>
-      <translation>Blic isključen</translation>
+        <source>Auto, Fired, Red-eye reduction, Return not detected</source>
+        <translation>Automatski, aktivirano, redukcija crvenih očiju, povratak nije detektovan</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1511"/>
-      <source>Off, No flash function</source>
-      <translation>Isključeno, bez blica</translation>
+        <source>Auto, Fired, Red-eye reduction, Return detected</source>
+        <translation>Automatski, aktivirano, redukcija crvenih očiju, povratak detektovan</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1512"/>
-      <source>Fired, Red-eye reduction</source>
-      <translation>Aktivirano, redukcija crvenih očiju</translation>
+        <source>New Tab</source>
+        <translation>Nova kartica</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1513"/>
-      <source>Fired, Red-eye reduction, Return not detected</source>
-      <translation>Aktivirano, redukcija crvenih očiju, povratak nije detektovan</translation>
+        <source>Thumbnail Preview</source>
+        <translation>Pregled sličica</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1514"/>
-      <source>Fired, Red-eye reduction, Return detected</source>
-      <translation>Aktivirano, redukcija crvenih očiju, povratak detektovan</translation>
+        <source>Settings</source>
+        <translation>Postavke</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1515"/>
-      <source>On, Red-eye reduction</source>
-      <translation>Uključeno, redukcija crvenih očiju</translation>
+        <source>Batch</source>
+        <translation>Grupna obrada</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1516"/>
-      <source>On, Red-eye reduction, Return not detected</source>
-      <translation>Uključeno, redukcija crvenih očiju, povratak nije detektovan</translation>
+        <source>%1 image resized, scale factor: %2%</source>
+        <translation>%1 promijenjena veličina slike, faktor skaliranja: %2%</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1517"/>
-      <source>On, Red-eye reduction, Return detected</source>
-      <translation>Uključeno, redukcija crvenih očiju, povratak detektovan</translation>
+        <source>%1 image resized, new side: %2 px</source>
+        <translation>%1 promijenjena veličina slike, nova veličina %2 px</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1518"/>
-      <source>Off, Red-eye reduction</source>
-      <translation>Isključeno, redukcija crvenih očiju</translation>
+        <source>%1 I need to increase the image, but the option is set to decrease only -&gt; skipping.</source>
+        <translation>%1 Trebam povećati sliku, ali dozvoljeno je samo smanjivanje prema postavkama-&gt; preskočeno.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1519"/>
-      <source>Auto, Did not fire, Red-eye reduction</source>
-      <translation>Automatski, nije aktivirano, redukcija crvenih očiju</translation>
+        <source>%1 I need to decrease the image, but the option is set to increase only -&gt; skipping.</source>
+        <translation>%1 Trebam smanjiti sliku, ali dozvoljeno je samo uvećavanje prema postavkama -&gt; preskočeno.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1520"/>
-      <source>Auto, Fired, Red-eye reduction</source>
-      <translation>Automatski, aktivirano, redukcija crvenih očiju</translation>
+        <source>%1 image size matches scale factor -&gt; skipping.</source>
+        <translation>%1 veličina slike odgovara faktoru skaliranja -&gt; preskočeno.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1521"/>
-      <source>Auto, Fired, Red-eye reduction, Return not detected</source>
-      <translation>Automatski, aktivirano, redukcija crvenih očiju, povratak nije detektovan</translation>
+        <source>[Transform Batch]</source>
+        <translation>[Grupna transformacija]</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1522"/>
-      <source>Auto, Fired, Red-eye reduction, Return detected</source>
-      <translation>Automatski, aktivirano, redukcija crvenih očiju, povratak detektovan</translation>
+        <source>%1 inactive -&gt; skipping</source>
+        <translation>%1 neaktivan -&gt; preskočeno</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkCentralWidget.cpp" line="201"/>
-      <source>New Tab</source>
-      <translation>Nova kartica</translation>
+        <source>%1 image transformed.</source>
+        <translation>%1 slike transformisane.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkCentralWidget.cpp" line="204"/>
-      <source>Thumbnail Preview</source>
-      <translation>Pregled sličica</translation>
+        <source>%1 error, could not transform image.</source>
+        <translation>%1 greška, ne mogu transformisati sliku.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkCentralWidget.cpp" line="206"/>
-      <source>Settings</source>
-      <translation>Postavke</translation>
+        <source>%1 Cannot apply %2.</source>
+        <translation>%1 ne mogu primjeniti %2.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkCentralWidget.cpp" line="208"/>
-      <source>Batch</source>
-      <translation>Hrpa</translation>
+        <source>Batch Action</source>
+        <translation>Grupne radnje</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="90"/>
-      <source>[Resize Batch]</source>
-      <translation>[Grupna promjena veličine]</translation>
+        <source>%1 image transformed and cropped.</source>
+        <translation>%1 slika transformisana i izrezana.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="116"/>
-      <source>%1 scale factor is 1 -&gt; ignoring</source>
-      <translation>%1 faktor skaliranja je 1 -&gt; ignorisano</translation>
+        <source>%1 Cannot cast batch plugin %2.</source>
+        <translation>%1 ne mogu odraditi grupni priključak %2.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="127"/>
-      <source>%1 no need for resizing.</source>
-      <translation>%1 nema potrebe za promjenom veličine.</translation>
+        <source>%1 illegal plugin interface: %2</source>
+        <translation>%1 nedozvoljeno sučelje za priključak: %2</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="132"/>
-      <source>%1 could not resize image.</source>
-      <translation>%1 ne mogu promijeniti veličinu slike.</translation>
+        <source>%1 Cannot apply plugin because it is NULL.</source>
+        <translation>%1 ne mogu prihvatiti priključaka jer je NULL.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="137"/>
-      <source>%1 image resized, scale factor: %2%</source>
-      <translation>%1 promijenjena veličina slike, faktor skaliranja: %2%</translation>
+        <source>%1 error, could not apply plugins.</source>
+        <translation>%1 greška, ne mogu primjeniti priključke.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="139"/>
-      <source>%1 image resized, new side: %2 px</source>
-      <translation>%1 promijenjena veličina slike, nova veličina %2 px</translation>
+        <source>%1 plugins applied.</source>
+        <translation>%1 priključaka primjenjeno.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="172"/>
-      <source>%1 I need to increase the image, but the option is set to decrease only -&gt; skipping.</source>
-      <translation>%1 Trebam povećati sliku, ali dozvoljeno je samo smanjivanje prema postavkama-&gt; preskočeno.</translation>
+        <source>[Plugin Batch]</source>
+        <translation>[Grupni dodaci]</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="176"/>
-      <source>%1 I need to decrease the image, but the option is set to increase only -&gt; skipping.</source>
-      <translation>%1 Trebam smanjiti sliku, ali dozvoljeno je samo uvećavanje prema postavkama -&gt; preskočeno.</translation>
+        <source>%1 already exists -&gt; skipping (check &apos;overwrite&apos; if you want to overwrite the file)</source>
+        <translation>%1 već postoji -&gt; preskočeno (označite &apos;pisati preko&apos; ako želite da pišete preko fajla)</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="180"/>
-      <source>%1 image size matches scale factor -&gt; skipping.</source>
-      <translation>%1 veličina slike odgovara faktoru skaliranja -&gt; preskočeno.</translation>
+        <source>Error: input file does not exist</source>
+        <translation>Greška: ulazni fajl ne postoji</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="198"/>
-      <source>[Transform Batch]</source>
-      <translation>[Grupna transformacija]</translation>
+        <source>Input: %1</source>
+        <translation>Ulaz: %1</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="218"/>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="295"/>
-      <source>%1 inactive -&gt; skipping</source>
-      <translation>%1 neaktivan -&gt; preskočeno</translation>
+        <source>Skipping: nothing to do here.</source>
+        <translation>Preskočeno: bez posla ovdje.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="242"/>
-      <source>%1 image transformed.</source>
-      <translation>%1 slike transformisane.</translation>
+        <source>processing %1</source>
+        <translation>obrađujem %1</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="248"/>
-      <source>%1 error, could not transform image.</source>
-      <translation>%1 greška, ne mogu transformisati sliku.</translation>
+        <source>Error while loading...</source>
+        <translation>Greška pri učitavanju...</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="334"/>
-      <source>%1 Cannot apply %2.</source>
-      <translation>%1 ne mogu primjeniti %2.</translation>
+        <source>Error: cannot process a NULL function.</source>
+        <translation>Greška: ne mogu obraditi NULL funkciju.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="77"/>
-      <source>Batch Action</source>
-      <translation>Serijska akcija</translation>
+        <source>%1 failed</source>
+        <translation>%1 neuspijelo</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="244"/>
-      <source>%1 image transformed and cropped.</source>
-      <translation>%1 slika transformisana i izrezana.</translation>
+        <source>%1 saved...</source>
+        <translation>%1 sačuvano...</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="326"/>
-      <source>%1 Cannot cast batch plugin %2.</source>
-      <translation>%1 ne mogu odraditi serijski priključak %2.</translation>
+        <source>Could not save: %1</source>
+        <translation>Nije moguće sačuvati: %1</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="337"/>
-      <source>%1 illegal plugin interface: %2</source>
-      <translation>%1 nedozvoljeno sučelje za priključak: %2</translation>
+        <source>Error: could not rename file, the target file exists already.</source>
+        <translation>Greška: ne mogu preimenovati fajl, željeni fajl već postoji.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="340"/>
-      <source>%1 Cannot apply plugin because it is NULL.</source>
-      <translation>%1 ne mogu prihvatiti priključaka jer je NULL.</translation>
+        <source>Error: could not rename file</source>
+        <translation>Greška: ne mogu preimenovati fajl</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="344"/>
-      <source>%1 error, could not apply plugins.</source>
-      <translation>%1 greška, ne mogu primjeniti priključke.</translation>
+        <source>Renaming: %1 -&gt; %2</source>
+        <translation>Preimenovanje: %1 -&gt; %2</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="348"/>
-      <source>%1 plugins applied.</source>
-      <translation>%1 priključaka primjenjeno.</translation>
+        <source>Error: could not copy file</source>
+        <translation>Greška: ne mogu kopirati fajl</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="354"/>
-      <source>[Plugin Batch]</source>
-      <translation>[Grupni dodaci]</translation>
+        <source>Output: %1</source>
+        <translation>Izlaz: %1</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="471"/>
-      <source>%1 already exists -&gt; skipping (check 'overwrite' if you want to overwrite the file)</source>
-      <translation>%1 već postoji -&gt; preskočeno (označite 'pisati preko' ako želite da pišete preko fajla)</translation>
+        <source>Copying: %1 -&gt; %2</source>
+        <translation>Kopiram: %1 -&gt; %2</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="476"/>
-      <source>Error: input file does not exist</source>
-      <translation>Greška: ulazni fajl ne postoji</translation>
+        <source>Error: back-up (%1) file already exists</source>
+        <translation>Greška: rezervna kopija (%1)  fajla već postoji</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="477"/>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="594"/>
-      <source>Input: %1</source>
-      <translation>Ulaz: %1</translation>
+        <source>Error: could not rename existing file to %1</source>
+        <translation>Greška: ne mogu preimenovati postojeći fajl u %1</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="482"/>
-      <source>Skipping: nothing to do here.</source>
-      <translation>Preskočeno: bez posla ovdje.</translation>
+        <source>Error: could not delete existing file</source>
+        <translation>Greška: ne mogu izbrisati postojeći fajl</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="514"/>
-      <source>processing %1</source>
-      <translation>obrađujem %1</translation>
+        <source>Ui - a lot of things went wrong sorry, your original file can be found here: %1</source>
+        <translation>Uj - izvinjavamo se za više grešaka koje su se dogodile, vaš originalni fajl možete naći ovdje: %1</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="519"/>
-      <source>Error while loading...</source>
-      <translation>Greška pri učitavanju...</translation>
+        <source>I could not save to %1 so I restored the original file.</source>
+        <translation>Nije moguće sačuvati na %1 pa je originalni fajl vraćen.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="527"/>
-      <source>Error: cannot process a NULL function.</source>
-      <translation>Greška: ne mogu obraditi NULL funkciju.</translation>
+        <source>%1 deleted.</source>
+        <translation>%1 izbrisan.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="533"/>
-      <source>%1 failed</source>
-      <translation>%1 neuspijelo</translation>
+        <source>I could not delete %1</source>
+        <translation>Nije moguće izbrisati %1</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="547"/>
-      <source>%1 saved...</source>
-      <translation>%1 sačuvano...</translation>
+        <source>I did not delete the original because I detected %1 failure(s).</source>
+        <translation>Nije izbrisan origininal jer je otkrivena %1 greška(e).</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="550"/>
-      <source>Could not save: %1</source>
-      <translation>Nije moguće sačuvati: %1</translation>
+        <source>nomacs - Image Lounge is a lightweight image viewer.</source>
+        <translation>nomacs - Salon slika je lagani pregledač slika.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="565"/>
-      <source>Error: could not rename file, the target file exists already.</source>
-      <translation>Greška: ne mogu preimenovati fajl, željeni fajl već postoji.</translation>
+        <source>Player 1</source>
+        <translation>Igrač 1</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="573"/>
-      <source>Error: could not rename file</source>
-      <translation>Greška: ne mogu preimenovati fajl</translation>
+        <source>Player 2</source>
+        <translation>Igrač 2</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="578"/>
-      <source>Renaming: %1 -&gt; %2</source>
-      <translation>Preimenovanje: %1 -&gt; %2</translation>
+        <source>Anonymous</source>
+        <translation>Anonimno</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="593"/>
-      <source>Error: could not copy file</source>
-      <translation>Greška: ne mogu kopirati fajl</translation>
+        <source>An input image.</source>
+        <translation>Ulazna slika.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="595"/>
-      <source>Output: %1</source>
-      <translation>Izlaz: %1</translation>
+        <source>Start in fullscreen.</source>
+        <translation>Pokreni preko cijelog ekrana.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="600"/>
-      <source>Copying: %1 -&gt; %2</source>
-      <translation>Kopiram: %1 -&gt; %2</translation>
+        <source>Start Pong.</source>
+        <translation>Pokreni Pong.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="615"/>
-      <source>Error: back-up (%1) file already exists</source>
-      <translation>Greška: rezervna kopija (%1)  fajla već postoji</translation>
+        <source>Start in private mode.</source>
+        <translation>Pokreni u privatnom načinu rada.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="622"/>
-      <source>Error: could not rename existing file to %1</source>
-      <translation>Greška: ne mogu preimenovati postojeći fajl u %1</translation>
+        <source>Set the viewing mode &lt;mode&gt;.</source>
+        <translation>Postavlja način prikaza &lt;mode&gt;.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="640"/>
-      <source>Error: could not delete existing file</source>
-      <translation>Greška: ne mogu izbrisati postojeći fajl</translation>
+        <source>default | frameless | pseudocolor</source>
+        <translation>zadani | bez okvira | pseudo boja</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="651"/>
-      <source>Ui - a lot of things went wrong sorry, your original file can be found here: %1</source>
-      <translation>Uj - izvinjavamo se za više grešaka koje su se dogodile, vaš originalni fajl možete naći ovdje: %1</translation>
+        <source>Load all files of a &lt;directory&gt;.</source>
+        <translation>Učitaj sve fajlove iz &lt;directory&gt;.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="656"/>
-      <source>I could not save to %1 so I restored the original file.</source>
-      <translation>Nije moguće sačuvati na %1 pa je originalni fajl vraćen.</translation>
+        <source>directory</source>
+        <translation>direktorij</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="672"/>
-      <source>%1 deleted.</source>
-      <translation>%1 izbrisan.</translation>
+        <source>Load &lt;images&gt; to tabs.</source>
+        <translation>Učitaj &lt;images&gt; u kartice.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="675"/>
-      <source>I could not delete %1</source>
-      <translation>Nije moguće izbrisati %1</translation>
+        <source>images</source>
+        <translation>slike</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="680"/>
-      <source>I did not delete the original because I detected %1 failure(s).</source>
-      <translation>Nije izbrisan origininal jer je otkrivena %1 greška(e).</translation>
+        <source>Binary</source>
+        <translation>Binarni</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="932"/>
-      <source>nomacs - Image Lounge is a lightweight image viewer.</source>
-      <translation>nomacs - Salon slika je lagani pregledač slika.</translation>
+        <source>Indexed 8-bit</source>
+        <translation>Indeksirani 8-bit</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPong.h" line="88"/>
-      <source>Player 1</source>
-      <translation>Igrač 1</translation>
+        <source>RGB 32-bit</source>
+        <translation>RGB 32-bita</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPong.h" line="89"/>
-      <source>Player 2</source>
-      <translation>Igrač 2</translation>
+        <source>ARGB 32-bit</source>
+        <translation>ARGB 32-bita</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPong.h" line="99"/>
-      <source>Anonymous</source>
-      <translation>Anonimac</translation>
+        <source>RGB 16-bit</source>
+        <translation>RGB 16-bita</translation>
     </message>
     <message>
-      <location filename="../src/main.cpp" line="121"/>
-      <source>An input image.</source>
-      <translation>Ulazna slika.</translation>
+        <source>ARGB 24-bit</source>
+        <translation>ARGB 24-bita</translation>
     </message>
     <message>
-      <location filename="../src/main.cpp" line="124"/>
-      <source>Start in fullscreen.</source>
-      <translation>Pokreni preko cijelog ekrana.</translation>
+        <source>RGB 24-bit</source>
+        <translation>RGB 24-bita</translation>
     </message>
     <message>
-      <location filename="../src/main.cpp" line="127"/>
-      <source>Start Pong.</source>
-      <translation>Pokreni Pong.</translation>
+        <source>ARGB 16-bit</source>
+        <translation>ARGB 16-bita</translation>
     </message>
     <message>
-      <location filename="../src/main.cpp" line="130"/>
-      <source>Start in private mode.</source>
-      <translation>Pokreni u privatnom načinu rada.</translation>
+        <source>BGR 32-bit</source>
+        <translation>BGR 32-bita</translation>
     </message>
     <message>
-      <location filename="../src/main.cpp" line="134"/>
-      <source>Set the viewing mode &lt;mode&gt;.</source>
-      <translation>Postavlja način prikaza &lt;mode&gt;.</translation>
+        <source>ABGR 32-bit</source>
+        <translation>ABGR 32-bita</translation>
     </message>
     <message>
-      <location filename="../src/main.cpp" line="135"/>
-      <source>default | frameless | pseudocolor</source>
-      <translation>zadani | bez okvira | pseudoboja</translation>
+        <source>Grayscale 8-bit</source>
+        <translation>Crno-bijelo 8-bita</translation>
     </message>
     <message>
-      <location filename="../src/main.cpp" line="139"/>
-      <source>Load all files of a &lt;directory&gt;.</source>
-      <translation>Učitava sve fajlova u &lt;directory&gt;.</translation>
+        <source>Alpha 8-bit</source>
+        <translation>Alfa 8-bita</translation>
     </message>
     <message>
-      <location filename="../src/main.cpp" line="140"/>
-      <source>directory</source>
-      <translation>direktorij</translation>
+        <source>Cropped</source>
+        <translation>Izrezano</translation>
     </message>
     <message>
-      <location filename="../src/main.cpp" line="144"/>
-      <source>Load &lt;images&gt; to tabs.</source>
-      <translation>Učitava &lt;images&gt; u kartice.</translation>
+        <source>Plugin Manager</source>
+        <translation>Upravljač priključaka</translation>
     </message>
     <message>
-      <location filename="../src/main.cpp" line="145"/>
-      <source>images</source>
-      <translation>slike</translation>
-    </message>
-    <message>
-      <location filename="../src/DkCore/DkUtils.cpp" line="636"/>
-      <source>Binary</source>
-      <translation>Binarno</translation>
-    </message>
-    <message>
-      <location filename="../src/DkCore/DkUtils.cpp" line="637"/>
-      <source>Indexed 8-bit</source>
-      <translation>Indeksirani 8-bit</translation>
-    </message>
-    <message>
-      <location filename="../src/DkCore/DkUtils.cpp" line="643"/>
-      <source>RGB 32-bit</source>
-      <translation>RGB 32-bita</translation>
-    </message>
-    <message>
-      <location filename="../src/DkCore/DkUtils.cpp" line="649"/>
-      <source>ARGB 32-bit</source>
-      <translation>ARGB 32-bita</translation>
-    </message>
-    <message>
-      <location filename="../src/DkCore/DkUtils.cpp" line="652"/>
-      <source>RGB 16-bit</source>
-      <translation>RGB 16-bita</translation>
-    </message>
-    <message>
-      <location filename="../src/DkCore/DkUtils.cpp" line="655"/>
-      <source>ARGB 24-bit</source>
-      <translation>ARGB 24-bita</translation>
-    </message>
-    <message>
-      <location filename="../src/DkCore/DkUtils.cpp" line="657"/>
-      <source>RGB 24-bit</source>
-      <translation>RGB 24-bita</translation>
-    </message>
-    <message>
-      <location filename="../src/DkCore/DkUtils.cpp" line="658"/>
-      <source>ARGB 16-bit</source>
-      <translation>ARGB 16-bita</translation>
-    </message>
-    <message>
-      <location filename="../src/DkCore/DkUtils.cpp" line="661"/>
-      <source>BGR 32-bit</source>
-      <translation>BGR 32-bita</translation>
-    </message>
-    <message>
-      <location filename="../src/DkCore/DkUtils.cpp" line="662"/>
-      <source>ABGR 32-bit</source>
-      <translation>ABGR 32-bita</translation>
-    </message>
-    <message>
-      <location filename="../src/DkCore/DkUtils.cpp" line="663"/>
-      <source>Grayscale 8-bit</source>
-      <translation>Crno-bijelo 8-bita</translation>
-    </message>
-    <message>
-      <location filename="../src/DkCore/DkUtils.cpp" line="664"/>
-      <source>Alpha 8-bit</source>
-      <translation>Alfa 8-bita</translation>
-    </message>
-    <message>
-      <location filename="../src/DkLoader/DkImageContainer.cpp" line="142"/>
-      <source>Cropped</source>
-      <translation>Izrezano</translation>
-    </message>
-    <message>
-      <location filename="../src/DkLoader/DkPluginManager.cpp" line="1094"/>
-      <source>Plugin Manager</source>
-      <translation>Upravljač priključaka</translation>
-    </message>
-    <message>
-      <location filename="../src/DkLoader/DkPluginManager.cpp" line="1094"/>
-      <source>The dll could not be deleted!
+        <source>The dll could not be deleted!
 Please restart nomacs and try again.</source>
-      <translation>Ne mogu izbrisati dll!
+        <translation>Ne mogu izbrisati dll!
 Molim restartujte nomacs i pokušajte ponovo.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkPluginManager.cpp" line="1241"/>
-      <source>Close plugin</source>
-      <translation>Ugasi priključak</translation>
+        <source>Close plugin</source>
+        <translation>Ugasi priključak</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkPluginManager.cpp" line="1243"/>
-      <source>Please close the currently opened plugin.</source>
-      <translation>Molim zatvorite trenutno otvoreni priključak.</translation>
+        <source>Please close the currently opened plugin.</source>
+        <translation>Molim zatvorite trenutno otvoreni priključak.</translation>
     </message>
-  </context>
-  <context>
+    <message>
+        <source>&amp;Adjustments</source>
+        <translation>&amp;Podešavanja</translation>
+    </message>
+    <message>
+        <source>&amp;Close All Tabs</source>
+        <translation>&amp;Zatvori sve kartice</translation>
+    </message>
+    <message>
+        <source>Close all open tabs</source>
+        <translation>Zatvori sve otvorene kartice</translation>
+    </message>
+    <message>
+        <source>&amp;Open Tabs</source>
+        <translation>&amp;Otvori kartice</translation>
+    </message>
+    <message>
+        <source>Open a texfile containing a list of filepaths, and open tabs for them</source>
+        <translation>Otvori tekstualni fajl koji sadrži listu putanja i otvori kartice za njiih</translation>
+    </message>
+    <message>
+        <source>&amp;Save Tabs</source>
+        <translation>&amp;Sačuvaj kartice</translation>
+    </message>
+    <message>
+        <source>Save a newline separated list of the filenames of the open tabs</source>
+        <translation>Sačuvaj listu imena fajlova otvorenih kartica</translation>
+    </message>
+    <message>
+        <source>Image &amp;Adjustments</source>
+        <translation>Podeš&amp;avanja slike</translation>
+    </message>
+    <message>
+        <source>open image manipulation toolbox</source>
+        <translation>otvori alatke za manipulaciju slikom</translation>
+    </message>
+    <message>
+        <source>&amp;Hide All Panels</source>
+        <translation>&amp;Sakrij sve panele</translation>
+    </message>
+    <message>
+        <source>Hide all panels</source>
+        <translation>Sakrij sve panele</translation>
+    </message>
+    <message>
+        <source>F&amp;irst Tab</source>
+        <translation>Prva kart&amp;ica</translation>
+    </message>
+    <message>
+        <source>Switch to first tab</source>
+        <translation>Prebaci na prvu karticu</translation>
+    </message>
+    <message>
+        <source>&amp;Go to Tab</source>
+        <translation>&amp;Idi na karticu</translation>
+    </message>
+    <message>
+        <source>Go to tab by index</source>
+        <translation>Idi na karticu po broju</translation>
+    </message>
+    <message>
+        <source>La&amp;st Tab</source>
+        <translation>Po&amp;sljednja kartica</translation>
+    </message>
+    <message>
+        <source>Switch to last tab</source>
+        <translation>Prebaci na posljednju karticu</translation>
+    </message>
+    <message>
+        <source>&amp;Grayscale</source>
+        <translation>&amp;Crno-bijelo</translation>
+    </message>
+    <message>
+        <source>&amp;Tiny Planet...</source>
+        <translation>Mala plane&amp;ta...</translation>
+    </message>
+    <message>
+        <source>Create a Tiny Planet</source>
+        <translation>Napravi malu planetu</translation>
+    </message>
+    <message>
+        <source>&amp;Sharpen...</source>
+        <translation>Izo&amp;štri...</translation>
+    </message>
+    <message>
+        <source>Sharpens the image by applying an unsharp mask</source>
+        <translation>Izoštrava sliku metodom neoštre maske</translation>
+    </message>
+    <message>
+        <source>&amp;Rotate...</source>
+        <translation>&amp;Rotiraj...</translation>
+    </message>
+    <message>
+        <source>Rotate the image</source>
+        <translation>Rotira sliku</translation>
+    </message>
+    <message>
+        <source>&amp;Threshold...</source>
+        <translation>&amp;Prag...</translation>
+    </message>
+    <message>
+        <source>Threshold the image</source>
+        <translation>Primjenjuje prag na sliku</translation>
+    </message>
+    <message>
+        <source>&amp;Hue/Saturation...</source>
+        <translation>&amp;Nijansa/Zasićenje...</translation>
+    </message>
+    <message>
+        <source>Change Hue and Saturation</source>
+        <translation>Izmjeni nijansu i zasićenje</translation>
+    </message>
+    <message>
+        <source>&amp;Exposure...</source>
+        <translation>&amp;Eksponiranje...</translation>
+    </message>
+    <message>
+        <source>Change the Exposure and Gamma</source>
+        <translation>Izmjeni eksponiranje i gamu</translation>
+    </message>
+    <message>
+        <source>Could not convert to grayscale</source>
+        <translation>Neuspijelo konvertovanje u crno-bijelo</translation>
+    </message>
+    <message>
+        <source>Cannot auto adjust</source>
+        <translation>Nemoguće automatsko prilagođavanje</translation>
+    </message>
+    <message>
+        <source>The Image is Already Normalized...</source>
+        <translation>Slika je već normalizovana...</translation>
+    </message>
+    <message>
+        <source>Cannot invert image</source>
+        <translation>Nemoguće obrnuti sliku</translation>
+    </message>
+    <message>
+        <source>Cannot flip image</source>
+        <translation>Nemoguće prevrnuti sliku</translation>
+    </message>
+    <message>
+        <source>Sorry, I could not create a tiny planet</source>
+        <translation>Žao nam je, ne može se napraviti mala planeta</translation>
+    </message>
+    <message>
+        <source>Cannot sharpen image</source>
+        <translation>Nemoguće izoštriti sliku</translation>
+    </message>
+    <message>
+        <source>Cannot rotate image</source>
+        <translation>Nemoguće rotirati sliku</translation>
+    </message>
+    <message>
+        <source>Cannot threshold image</source>
+        <translation>Nemoguće primjeniti prag na sliku</translation>
+    </message>
+    <message>
+        <source>Cannot change Hue/Saturation</source>
+        <translation>Nemoguće promjeniti nijansu/zasićenje</translation>
+    </message>
+    <message>
+        <source>Cannot apply exposure</source>
+        <translation>Nemoguće primjeniti ekspoziciju</translation>
+    </message>
+    <message>
+        <source>transformed</source>
+        <translation>transformisano</translation>
+    </message>
+    <message>
+        <source>%1 %2 applied.</source>
+        <translation>%1 %2 primijenjeno.</translation>
+    </message>
+    <message>
+        <source>%1 error, could not apply image adjustments.</source>
+        <translation>%1 greška, nemoguće primijeniti podešavanja slike.</translation>
+    </message>
+    <message>
+        <source>[Adjustment Batch]</source>
+        <translation>[Grupna podešavanja]</translation>
+    </message>
+    <message>
+        <source>%1 not saved - option &apos;Do not Save&apos; is checked...</source>
+        <translation>%1 nije sačuvan - opcija &apos;Nemoj sačuvati&apos; je uključena...</translation>
+    </message>
+    <message>
+        <source>I should copy the file, but &apos;Do not Save&apos; is checked - so I will do nothing...</source>
+        <translation>Zahtijevano kopiranje, ali &apos;Nemoj sačuvati&apos; je uključeno - ignorišem...</translation>
+    </message>
+    <message>
+        <source>Batch processing of &lt;batch-settings.pnm&gt;.</source>
+        <translation>Grupno procesovanje &lt;batch-settings.pnm&gt;.</translation>
+    </message>
+    <message>
+        <source>batch-settings-path</source>
+        <translation>putanja grupnog podešavanja</translation>
+    </message>
+    <message>
+        <source>Saves batch log to &lt;log-path.txt&gt;.</source>
+        <translation>Sačuva zapis grupnog podešavanja u &lt;log-path.txt&gt;.</translation>
+    </message>
+    <message>
+        <source>log-path.txt</source>
+        <translation>putanja-zapisa.txt</translation>
+    </message>
+    <message>
+        <source>Imports the settings from &lt;settings-path.nfo&gt; and saves them.</source>
+        <translation>Unosi postavke iz &lt;settings-path.nfo&gt; i sačuva ih.</translation>
+    </message>
+    <message>
+        <source>settings-path.nfo</source>
+        <translation>postavke-putanja.nfo</translation>
+    </message>
+    <message>
+        <source>Critical Error</source>
+        <translation>Kritična greška</translation>
+    </message>
+    <message>
+        <source>Sorry, nomacs ran out of memory...</source>
+        <translation>Žao nam je, nomacs je ostao bez memorije...</translation>
+    </message>
+</context>
+<context>
     <name>QObject::QObject</name>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1533"/>
-      <source>Lena</source>
-      <translation>Lena</translation>
+        <source>Lena</source>
+        <translation>Lena</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1534"/>
-      <source>Show test image</source>
-      <translation>Prikazuje test sliku</translation>
+        <source>Show test image</source>
+        <translation>Prikazuje test sliku</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1537"/>
-      <source>All Images</source>
-      <translation>Sve slike</translation>
+        <source>All Images</source>
+        <translation>Sve slike</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1538"/>
-      <source>Generates all images in the world</source>
-      <translation>Generiše sve slike na svijetu</translation>
+        <source>Generates all images in the world</source>
+        <translation>Generiše sve slike na svijetu</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1541"/>
-      <source>Pong</source>
-      <translation>Ping</translation>
+        <source>Pong</source>
+        <translation>Pong</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkAdvancedPreference</name>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1138"/>
-      <source>Always Load JPG if Embedded</source>
-      <translation>Uvijek učitaj JPG ako je ugrađen</translation>
+        <source>Always Load JPG if Embedded</source>
+        <translation>Uvijek učitaj JPG ako je umetnut</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1139"/>
-      <source>Load JPG if it Fits the Screen Resolution</source>
-      <translation>Učitaj JPG ako odgovara rezoluciji ekrana</translation>
+        <source>Load JPG if it Fits the Screen Resolution</source>
+        <translation>Učitaj JPG ako odgovara rezoluciji ekrana</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1140"/>
-      <source>Always Load RAW Data</source>
-      <translation>Uvijek učitaj RAW podatke</translation>
+        <source>Always Load RAW Data</source>
+        <translation>Uvijek učitaj RAW podatke</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1151"/>
-      <source>Apply Noise Filtering to RAW Images</source>
-      <translation>Prihvati filtriranje šuma na RAW slikama</translation>
+        <source>Apply Noise Filtering to RAW Images</source>
+        <translation>Prihvati filtriranje šuma na RAW slikama</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1153"/>
-      <source>If checked, a noise filter is applied which reduced color noise</source>
-      <translation>Ako je čekirano, filter šuma smanjuje šum boja</translation>
+        <source>If checked, a noise filter is applied which reduced color noise</source>
+        <translation>Ako je čekirano, filter šuma smanjuje šum boja</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1156"/>
-      <source>RAW Loader Settings</source>
-      <translation>Postavke RAW čitača</translation>
+        <source>RAW Loader Settings</source>
+        <translation>Postavke RAW čitača</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1164"/>
-      <source>Ask to Save Deleted Files</source>
-      <translation>Pitaj da spasi obrisane fajlove</translation>
+        <source>Ask to Save Deleted Files</source>
+        <translation>Pitaj da spasi obrisane fajlove</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1166"/>
-      <source>If checked, nomacs asked to save files which were deleted by other applications</source>
-      <translation>Ako je označeno, nomacs pita da spasi fajlove koji su izbrisani od strane drugih aplikacija</translation>
+        <source>If checked, nomacs asked to save files which were deleted by other applications</source>
+        <translation>Ako je označeno, nomacs pita da spasi fajlove koji su izbrisani od strane drugih aplikacija</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1169"/>
-      <source>Ignore Exif Orientation when Loading</source>
-      <translation>Ignoriši EXIF orijentaciju priliko učitavanja</translation>
+        <source>Ignore Exif Orientation when Loading</source>
+        <translation>Ignoriši Exif orijentaciju prilikom učitavanja</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1171"/>
-      <source>If checked, images are NOT rotated with respect to their Exif orientation</source>
-      <translation>Ako je označeno, slike NEĆE biti rotirane prema EXIF orijentaciji</translation>
+        <source>If checked, images are NOT rotated with respect to their Exif orientation</source>
+        <translation>Ako je označeno, slike NEĆE biti rotirane prema Exif orijentaciji</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1174"/>
-      <source>Save Exif Orientation</source>
-      <translation>Snimi EXIF orijentaciju</translation>
+        <source>Save Exif Orientation</source>
+        <translation>Snimi Exif orijentaciju</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1176"/>
-      <source>If checked, orientation is written to the Exif rather than rotating the image Matrix
+        <source>If checked, orientation is written to the Exif rather than rotating the image Matrix
 </source>
-      <translation>Ako je označeno, orijentacija se snima u EXIF umjesto da se obrće slika
+        <translation>Ako je označeno, orijentacija se snima u Exif umjesto da se obrće slika
 </translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1177"/>
-      <source>NOTE: this allows for rotating JPGs without losing information.</source>
-      <translation>NAPOMENA: ovo dozvoljava rotaciju JPG slika bez gubitka podataka.</translation>
+        <source>NOTE: this allows for rotating JPGs without losing information.</source>
+        <translation>NAPOMENA: ovo omogućava rotaciju JPG slika bez gubitka podataka.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1180"/>
-      <source>File Loading/Saving</source>
-      <translation>Učitavanje/snimanje fajla</translation>
+        <source>File Loading/Saving</source>
+        <translation>Učitavanje/sačuvanje fajla</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1188"/>
-      <source>Choose the number of Threads in the thread pool</source>
-      <translation>Izaberi broj dretvi u bazenu dretvi</translation>
+        <source>Choose the number of Threads in the thread pool</source>
+        <translation>Izaberi broj dretvi u ukupnom fondu</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1193"/>
-      <source>Number of Threads</source>
-      <translation>Broj dretvi</translation>
+        <source>Number of Threads</source>
+        <translation>Broj dretvi</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1197"/>
-      <source>Use Log File</source>
-      <translation>Koristi log fajl</translation>
+        <source>Use Log File</source>
+        <translation>Koristi fajl zapisa</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1199"/>
-      <source>If checked, a log file will be created.</source>
-      <translation>Ako je označeno, log fajl će biti kreiran.</translation>
+        <source>If checked, a log file will be created.</source>
+        <translation>Ako je označeno, fajl sa zapisom će biti kreiran.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1202"/>
-      <source>Open Log</source>
-      <translation>Otvori log</translation>
+        <source>Open Log</source>
+        <translation>Otvori zapis</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1210"/>
-      <source>Logging</source>
-      <translation>Logiranje</translation>
+        <source>Logging</source>
+        <translation>Vođenje zapisa</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1256"/>
-      <source>Please Restart nomacs to apply changes</source>
-      <translation>Molimo restartujte nomacs da bi prihvatili promjene</translation>
+        <source>Please Restart nomacs to apply changes</source>
+        <translation>Molimo restartujte nomacs da bi prihvatili promjene</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkAppManagerDialog</name>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="434"/>
-      <source>Manage Applications</source>
-      <translation>Upravljanje aplikacijama</translation>
+        <source>Manage Applications</source>
+        <translation>Upravljanje aplikacijama</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="457"/>
-      <source>&amp;Run</source>
-      <translation>&amp;Pokreni</translation>
+        <source>&amp;Run</source>
+        <translation>&amp;Pokreni</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="460"/>
-      <source>&amp;Add</source>
-      <translation>&amp;Dodaj</translation>
+        <source>&amp;Add</source>
+        <translation>&amp;Dodaj</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="463"/>
-      <source>&amp;Delete</source>
-      <translation>&amp;Ukloni</translation>
+        <source>&amp;Delete</source>
+        <translation>&amp;Ukloni</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="469"/>
-      <source>&amp;OK</source>
-      <translation>&amp;U redu</translation>
+        <source>&amp;OK</source>
+        <translation>&amp;U redu</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="470"/>
-      <source>&amp;Cancel</source>
-      <translation>&amp;Otkaži</translation>
+        <source>&amp;Cancel</source>
+        <translation>&amp;Otkaži</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="502"/>
-      <source>Executable Files (*.exe);;</source>
-      <translation>Izvršni fajlovi (*.exe);;</translation>
+        <source>Executable Files (*.exe);;</source>
+        <translation>Izvršni fajlovi (*.exe);;</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="510"/>
-      <source>Open Application</source>
-      <translation>Otvori aplikaciju</translation>
+        <source>Open Application</source>
+        <translation>Otvori aplikaciju</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkArchiveExtractionDialog</name>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4275"/>
-      <source>Extract images from an archive</source>
-      <translation>Raspakuj slike iz arhive</translation>
+        <source>Extract images from an archive</source>
+        <translation>Raspakuj slike iz arhive</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4284"/>
-      <source>Archive (%1)</source>
-      <translation>Arhiva (%1)</translation>
+        <source>Archive (%1)</source>
+        <translation>Arhiva (%1)</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4291"/>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4300"/>
-      <source>&amp;Browse</source>
-      <translation>&amp;Pregledaj</translation>
+        <source>&amp;Browse</source>
+        <translation>&amp;Pregledaj</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4295"/>
-      <source>Extract to</source>
-      <translation>Raspakuj u</translation>
+        <source>Extract to</source>
+        <translation>Raspakuj u</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4308"/>
-      <source>Remove Subfolders</source>
-      <translation>Ukloni podfascikle</translation>
+        <source>Remove Subfolders</source>
+        <translation>Ukloni podfascikle</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4314"/>
-      <source>&amp;Extract</source>
-      <translation>&amp;Raspakuj</translation>
+        <source>&amp;Extract</source>
+        <translation>&amp;Raspakuj</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4316"/>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4537"/>
-      <source>&amp;Cancel</source>
-      <translation>&amp;Otkaži</translation>
+        <source>&amp;Cancel</source>
+        <translation>&amp;Otkaži</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4395"/>
-      <source>Open Archive</source>
-      <translation>Otvori arhivu</translation>
+        <source>Open Archive</source>
+        <translation>Otvori arhivu</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4396"/>
-      <source>Archives (%1)</source>
-      <translation>Arhive (%1)</translation>
+        <source>Archives (%1)</source>
+        <translation>Arhive (%1)</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4407"/>
-      <source>Open Directory</source>
-      <translation>Otvori fasciklu</translation>
+        <source>Open Directory</source>
+        <translation>Otvori fasciklu</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4441"/>
-      <source>Not a valid archive.</source>
-      <translation>Neispravna arhiva.</translation>
+        <source>Not a valid archive.</source>
+        <translation>Neispravna arhiva.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4470"/>
-      <source>Number of images: </source>
-      <translation>Broj slika:</translation>
+        <source>Number of images: </source>
+        <translation>Broj slika: </translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4472"/>
-      <source>The archive does not contain any images.</source>
-      <translation>Arhiva ne sadrži nijednu sliku.</translation>
+        <source>The archive does not contain any images.</source>
+        <translation>Arhiva ne sadrži nijednu sliku.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4497"/>
-      <source>The images could not be extracted!</source>
-      <translation>Slike nije moguće raspakovati!</translation>
+        <source>The images could not be extracted!</source>
+        <translation>Slike nije moguće raspakovati!</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4539"/>
-      <source>Extracting files...</source>
-      <translation>Raspakivam fajlove...</translation>
+        <source>Extracting files...</source>
+        <translation>Raspakivam fajlove...</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4548"/>
-      <source>Extracting file %1 of %2</source>
-      <translation>Raspakivam fajl %1 od %2</translation>
+        <source>Extracting file %1 of %2</source>
+        <translation>Raspakivam fajl %1 od %2</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkBasicLoader</name>
     <message>
-      <location filename="../src/DkLoader/DkBasicLoader.cpp" line="312"/>
-      <location filename="../src/DkLoader/DkBasicLoader.cpp" line="1044"/>
-      <source>Original Image</source>
-      <translation>Originalna slika</translation>
+        <source>Original Image</source>
+        <translation>Originalna slika</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkBasicLoader.cpp" line="1176"/>
-      <source>Sorry, I could not save: %1</source>
-      <translation>Izvini, nije moguće sačuvati: %1</translation>
+        <source>Sorry, I could not save: %1</source>
+        <translation>Izvini, nije moguće sačuvati: %1</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
+    <name>nmc::DkBatchButtonsWidget</name>
+    <message>
+        <source>Start/Cancel Batch Processing (%1)</source>
+        <translation>Počni/otkaži grupnu obradu (%1)</translation>
+    </message>
+</context>
+<context>
+    <name>nmc::DkBatchInput</name>
+    <message>
+        <source>File Explorer</source>
+        <translation>Pregledač fajlova</translation>
+    </message>
+    <message>
+        <source>Thumbnails</source>
+        <translation>Sličice</translation>
+    </message>
+    <message>
+        <source>File List</source>
+        <translation>Fajl lista</translation>
+    </message>
+    <message>
+        <source>Open an Image Directory</source>
+        <translation>Otvori fasciklu sa slikama</translation>
+    </message>
+    <message>
+        <source>No Files Selected</source>
+        <translation>Bez odabranih fajlova</translation>
+    </message>
+    <message>
+        <source>%1 File Selected</source>
+        <translation>%1 fajl odabran</translation>
+    </message>
+    <message>
+        <source>%1 Files Selected</source>
+        <translation>%1 fajlova odabrano</translation>
+    </message>
+    <message>
+        <source>Results</source>
+        <translation>Rezultati</translation>
+    </message>
+</context>
+<context>
+    <name>nmc::DkBatchManipulatorWidget</name>
+    <message>
+        <source>Select Image Adjustments</source>
+        <translation>Izaberi podešavanja slike</translation>
+    </message>
+    <message>
+        <source>inactive</source>
+        <translation>neaktivno</translation>
+    </message>
+    <message>
+        <source>%1 manipulators selected</source>
+        <translation>%1 manipulator odabran</translation>
+    </message>
+</context>
+<context>
     <name>nmc::DkBatchOutput</name>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="685"/>
-      <source>Output Directory</source>
-      <translation>Izlazna fascikla</translation>
+        <source>Output Directory</source>
+        <translation>Izlazna fascikla</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="687"/>
-      <source>Browse</source>
-      <translation>Pregledaj</translation>
+        <source>Browse</source>
+        <translation>Pregledaj</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="689"/>
-      <source>Select a Directory</source>
-      <translation>Izaberi fasciklu</translation>
+        <source>Select a Directory</source>
+        <translation>Izaberi fasciklu</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="694"/>
-      <source>Overwrite Existing Files</source>
-      <translation>Piši preko postojećih fajlova</translation>
+        <source>Overwrite Existing Files</source>
+        <translation>Piši preko postojećih fajlova</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="695"/>
-      <source>If checked, existing files are overwritten.
+        <source>If checked, existing files are overwritten.
 This option might destroy your images - so be careful!</source>
-      <translation>Ako je označeno, piše preko postojećih fajlova.
+        <translation>Ako je označeno, piše preko postojećih fajlova.
 Ova postavka može uništiti vaše slike - budite pažljivi!</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="699"/>
-      <source>Use Input Folder</source>
-      <translation>Koristi ulaznu fasciklu</translation>
+        <source>Use Input Folder</source>
+        <translation>Koristi ulaznu fasciklu</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="700"/>
-      <source>If checked, the batch is applied to the input folder - so be careful!</source>
-      <translation>Ako je označeno, izmjene se pišu u ulaznu fasciklu - budite oprezni!</translation>
+        <source>If checked, the batch is applied to the input folder - so be careful!</source>
+        <translation>Ako je označeno, izmjene se pišu u ulaznu fasciklu - budite oprezni!</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="704"/>
-      <source>Delete Input Files</source>
-      <translation>Izbriši ulazne fajlove</translation>
+        <source>Delete Input Files</source>
+        <translation>Izbriši ulazne fajlove</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="705"/>
-      <source>If checked, the original file will be deleted if the conversion was successful.
+        <source>If checked, the original file will be deleted if the conversion was successful.
  So be careful!</source>
-      <translation>Ako je označeno, originalni fajl će biti izbrisan ako je koonverzija uspešna.
+        <translation>Ako je označeno, originalni fajl će biti izbrisan ako je koonverzija uspešna.
 Budite oprezni!</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="723"/>
-      <source>Filename</source>
-      <translation>Ime fajla</translation>
+        <source>Filename</source>
+        <translation>Ime fajla</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="740"/>
-      <source>Keep Extension</source>
-      <translation>Zadrži ekstenziju</translation>
+        <source>Keep Extension</source>
+        <translation>Zadrži ekstenziju</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="741"/>
-      <source>Convert To</source>
-      <translation>Konvertuj u</translation>
+        <source>Convert To</source>
+        <translation>Konvertuj u</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="749"/>
-      <source>Compression</source>
-      <translation>Kompresija</translation>
+        <source>Open an Image Directory</source>
+        <translation>Otvori fasciklu sa slikama</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="764"/>
-      <source>Old: </source>
-      <translation>Staro: </translation>
+        <source>Do not Save Output Images</source>
+        <translation>Nemoj sačuvati izlazne slike</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="767"/>
-      <source>New: </source>
-      <translation>Novo: </translation>
+        <source>If checked, output images are not saved at all.
+This option is only useful if plugins save sidecar files - so be careful!</source>
+        <translation>Ako je uključeno, izlazne slike neće biti nikako sačuvane.
+Ova opcija je jedino korisna ako dodaci sačuvaju sporedne fajlove - budite oprezni!</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="772"/>
-      <source>Filename Preview</source>
-      <translation>Pregled imena fajla</translation>
+        <source>Quality</source>
+        <translation>Kvalitet</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="796"/>
-      <source>Open an Image Directory</source>
-      <translation>Otvori fasciklu sa slikama</translation>
+        <source>Preview</source>
+        <translation>Pregled</translation>
     </message>
-  </context>
-  <context>
+    <message>
+        <source>Old Filename: </source>
+        <translation>Staro ime fajla: </translation>
+    </message>
+    <message>
+        <source>New Filename: </source>
+        <translation>Novo ime fajla: </translation>
+    </message>
+</context>
+<context>
     <name>nmc::DkBatchPluginWidget</name>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1081"/>
-      <source>Sorry, no Plugins found.</source>
-      <translation>Извини, прикључци нису пронађени.</translation>
+        <source>inactive</source>
+        <translation>neaktivno</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1085"/>
-      <source>Drag Plugin Actions here.</source>
-      <translation>Prenesi akcije priključka ovdje.</translation>
+        <source>%1 plugins selected</source>
+        <translation>%1 priključaka izabrano</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1118"/>
-      <source>inactive</source>
-      <translation>neaktivno</translation>
+        <source>Select Plugins</source>
+        <translation>Izaberi priključke</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1120"/>
-      <source>%1 plugins selected</source>
-      <translation>%1 priključaka izabrano</translation>
+        <source> Settings</source>
+        <translation> Postavke</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkBatchProcessing</name>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="863"/>
-      <source>[OK]</source>
-      <translation>[U REDU]</translation>
+        <source>[OK]</source>
+        <translation>[U REDU]</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="865"/>
-      <source>[FAIL]</source>
-      <translation>[GREŠKA]</translation>
+        <source>[FAIL]</source>
+        <translation>[GREŠKA]</translation>
     </message>
-  </context>
-  <context>
-    <name>nmc::DkBatchResizeWidget</name>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="969"/>
-      <source>Percent</source>
-      <translation>Postotak</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="969"/>
-      <source>Long Side</source>
-      <translation>Duga strana</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="969"/>
-      <source>Short Side</source>
-      <translation>Kratka strana</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="969"/>
-      <source>Width</source>
-      <translation>Širina</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="969"/>
-      <source>Height</source>
-      <translation>Visina</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="974"/>
-      <source>Transform All</source>
-      <translation>Transformiši sve</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="974"/>
-      <source>Shrink Only</source>
-      <translation>Samo umanji</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="974"/>
-      <source>Enlarge Only</source>
-      <translation>Samo povećaj</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="978"/>
-      <source>%</source>
-      <translation>%</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="984"/>
-      <source> px</source>
-      <translation> px</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1022"/>
-      <source>inactive</source>
-      <translation>neaktivno</translation>
-    </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkBatchTransformWidget</name>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1134"/>
-      <source>Do &amp;Not Rotate</source>
-      <translation>Ne &amp;rotiraj</translation>
+        <source>Do &amp;Not Rotate</source>
+        <translation>Ne &amp;rotiraj</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1136"/>
-      <source>90%1 Counter Clockwise</source>
-      <translation>90%1 suprotno kazaljci na satu</translation>
+        <source>90%1 Counter Clockwise</source>
+        <translation>90%1 suprotno kazaljci na satu</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1137"/>
-      <source>90%1 Clockwise</source>
-      <translation>90%1 u smjeru kazaljke na satu</translation>
+        <source>90%1 Clockwise</source>
+        <translation>90%1 u smjeru kazaljke na satu</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1138"/>
-      <source>180%1</source>
-      <translation>180%1</translation>
+        <source>180%1</source>
+        <translation>180%1</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1147"/>
-      <source>Flip &amp;Horizontal</source>
-      <translation>Prevrni &amp;vodoravno</translation>
+        <source>&amp;Crop from Metadata</source>
+        <translation>&amp;Izreži sa meta podataka</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1148"/>
-      <source>Flip &amp;Vertical</source>
-      <translation>Prevrni &amp;uspravno</translation>
+        <source>inactive</source>
+        <translation>neaktivno</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1149"/>
-      <source>&amp;Crop from Metadata</source>
-      <translation>&amp;Izreži sa metapodataka</translation>
+        <source>Rotating by: %1</source>
+        <translation>Rotiraj: %1</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1193"/>
-      <source>inactive</source>
-      <translation>neaktivno</translation>
+        <source>Crop</source>
+        <translation>Izreži</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1198"/>
-      <source>Rotating by: %1</source>
-      <translation>Rotiraj: %1</translation>
+        <source>Resize</source>
+        <translation>Promijeni veličinu</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1202"/>
-      <source>Flipping</source>
-      <translation>Prevrtanje</translation>
+        <source>Percent</source>
+        <translation>Postotak</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1207"/>
-      <source>Crop</source>
-      <translation>Izreži</translation>
+        <source>Long Side</source>
+        <translation>Duga strana</translation>
     </message>
-  </context>
-  <context>
+    <message>
+        <source>Short Side</source>
+        <translation>Kratka strana</translation>
+    </message>
+    <message>
+        <source>Width</source>
+        <translation>Širina</translation>
+    </message>
+    <message>
+        <source>Height</source>
+        <translation>Visina</translation>
+    </message>
+    <message>
+        <source>%</source>
+        <translation>%</translation>
+    </message>
+    <message>
+        <source> px</source>
+        <translation> px</translation>
+    </message>
+    <message>
+        <source>Transform All</source>
+        <translation>Transformiši sve</translation>
+    </message>
+    <message>
+        <source>Shrink Only</source>
+        <translation>Samo umanji</translation>
+    </message>
+    <message>
+        <source>Enlarge Only</source>
+        <translation>Samo povećaj</translation>
+    </message>
+    <message>
+        <source>Orientation</source>
+        <translation>Orijentacija</translation>
+    </message>
+    <message>
+        <source>Transformations</source>
+        <translation>Transformacije</translation>
+    </message>
+    <message>
+        <source>Resize by: %1%</source>
+        <translation>Promjeni veličinu za: %1%</translation>
+    </message>
+    <message>
+        <source>Resize %1 to: %2 px</source>
+        <translation>Promjeni veličinu %1 u %2 px</translation>
+    </message>
+</context>
+<context>
     <name>nmc::DkBatchWidget</name>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1241"/>
-      <source>Batch Conversion</source>
-      <translation>Grupna konverzija</translation>
+        <source>next</source>
+        <translation>sljedeće</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1250"/>
-      <source>next</source>
-      <translation>sljedeće</translation>
+        <source>previous</source>
+        <translation>prethodno</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1255"/>
-      <source>previous</source>
-      <translation>prethodno</translation>
+        <source>no files selected</source>
+        <translation>nijedan fajl odabran</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1277"/>
-      <source>Input Directory</source>
-      <translation>Ulazna fascikla</translation>
+        <source>inactive</source>
+        <translation>neaktivno</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1277"/>
-      <source>no files selected</source>
-      <translation>nijedan fajl odabran</translation>
+        <source>Transform</source>
+        <translation>Transformisati</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1283"/>
-      <source>Resize</source>
-      <translation>Promijeni veličinu</translation>
+        <source>Plugins</source>
+        <translation>Priključci</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1283"/>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1287"/>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1292"/>
-      <source>inactive</source>
-      <translation>neaktivno</translation>
+        <source>Output</source>
+        <translation>Izlaz</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1287"/>
-      <source>Transform</source>
-      <translation>Transformisati</translation>
+        <source>not set</source>
+        <translation>nije postavljeno</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1292"/>
-      <source>Plugins</source>
-      <translation>Priključci</translation>
+        <source>Please select files for processing.</source>
+        <translation>Molimo izaberite fajlove za obradu.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1297"/>
-      <source>Output</source>
-      <translation>Izlaz</translation>
+        <source>I am missing a widget.</source>
+        <translation>Nedostaje vidžet.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1297"/>
-      <source>not set</source>
-      <translation>nije postavljeno</translation>
+        <source>Please check &apos;Overwrite Existing Files&apos; or choose a different output directory.</source>
+        <translation>Molimo označite &apos;pisati preko postojećih fajlova&apos; ili izaberite drugu izlaznu fasciklu.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1310"/>
-      <source>Show &amp;Log</source>
-      <translation>Prikaži &amp;logove</translation>
+        <source>Create Output Directory</source>
+        <translation>Kreiraj izlaznu fasciklu</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1311"/>
-      <source>Shows detailed status messages.</source>
-      <translation>Prikaži detaljne statusne poruke.</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1317"/>
-      <source>&amp;OK</source>
-      <translation>&amp;U redu</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1383"/>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1401"/>
-      <source>Wrong Configuration</source>
-      <translation>Pogrešna konfiguracija</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1383"/>
-      <source>Please select files for processing.</source>
-      <translation>Molimo izaberite fajlove za obradu.</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1391"/>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1452"/>
-      <source>Fatal Error</source>
-      <translation>Fatalna greška</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1391"/>
-      <source>I am missing a widget.</source>
-      <translation>Nedostaje vidžet.</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1401"/>
-      <source>Please check 'Overwrite Existing Files' or choose a different output directory.</source>
-      <translation>Molimo označite 'pisati preko postojećih fajlova' ili izaberite drugu izlaznu fasciklu.</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1414"/>
-      <source>Create Output Directory</source>
-      <translation>Kreiraj izlaznu fasciklu</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1415"/>
-      <source>Should I create:
+        <source>Should I create:
 %1</source>
-      <translation>Da li da kreiram:
+        <translation>Da li da kreiram:
 %1</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1431"/>
-      <source>Info</source>
-      <translation>Informacije</translation>
+        <source>Please select an output directory.</source>
+        <translation>Molimo izaberite izlaznu fasciklu.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1431"/>
-      <source>Please select an output directory.</source>
-      <translation>Molimo izaberite izlaznu fasciklu.</translation>
+        <source>Error</source>
+        <translation>Greška</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1435"/>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1439"/>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1443"/>
-      <source>Error</source>
-      <translation>Greška</translation>
+        <source>Sorry, I cannot create %1.</source>
+        <translation>Žao nam je, ne mogu kreirati %1.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1435"/>
-      <source>Sorry, I cannot create %1.</source>
-      <translation>Izvini, ne mogu kreirati %1.</translation>
+        <source>Sorry, I cannot find files to process.</source>
+        <translation>Žao nam je, ne mogu pronaći fajlove za obradu.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1439"/>
-      <source>Sorry, I cannot find files to process.</source>
-      <translation>Izvini, ne mogu pronaći fajlove za obradu.</translation>
+        <source>Sorry, the file pattern is empty.</source>
+        <translation>Žao nam je, mustra za fajlove je prazna.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1443"/>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1452"/>
-      <source>Sorry, the file pattern is empty.</source>
-      <translation>Izvini, mustra za fajlove je prazna.</translation>
+        <source>%1/%2 files processed... %3 failed.</source>
+        <translation>%1/%2 fajlova obrađeno... %3 nije uspijelo.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1559"/>
-      <source>%1/%2 files processed... %3 failed.</source>
-      <translation>%1/%2 fajlova obrađeno... %3 nije uspijelo.</translation>
+        <source>Input</source>
+        <translation>Ulaz</translation>
     </message>
-  </context>
-  <context>
-    <name>nmc::DkBrightness</name>
     <message>
-      <location filename="../src/DkGui/DkManipulationWidgets.cpp" line="875"/>
-      <source>Brightness</source>
-      <translation>Svjetlina</translation>
+        <source>Adjustments</source>
+        <translation>Podešavanja</translation>
     </message>
-  </context>
-  <context>
+    <message>
+        <source>Profiles</source>
+        <translation>Profili</translation>
+    </message>
+    <message>
+        <source>Sorry, I cannot start processing - please check the configuration.</source>
+        <translation>Žao nam je, nemoguće početi procesiranje - molimo provjerite konfiguraciju.</translation>
+    </message>
+    <message>
+        <source>Canceling...</source>
+        <translation>Otkazujem...</translation>
+    </message>
+    <message>
+        <source>Batch Log</source>
+        <translation>Zapis grupnog podešavanja</translation>
+    </message>
+    <message>
+        <source>Save Profile</source>
+        <translation>Sačuvaj profil</translation>
+    </message>
+    <message>
+        <source>Cannot save empty profile.</source>
+        <translation>Nemoguće sačuvati prazan profil.</translation>
+    </message>
+    <message>
+        <source>Sorry, I cannot save the settings...</source>
+        <translation>Žao nam je, nemoguće sačuvati ove postavke...</translation>
+    </message>
+    <message>
+        <source>Error Loading Profile</source>
+        <translation>Greška pri učitavanju profila</translation>
+    </message>
+    <message>
+        <source>Sorry, I cannot load batch settings from: 
+%1</source>
+        <translation>Žao nam je, nemoguće učitati grupne postavke iz:
+%1</translation>
+    </message>
+</context>
+<context>
     <name>nmc::DkCentralWidget</name>
     <message>
-      <location filename="../src/DkGui/DkCentralWidget.cpp" line="485"/>
-      <source>General</source>
-      <translation>Opšte</translation>
+        <source>General</source>
+        <translation>Opšte</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkCentralWidget.cpp" line="491"/>
-      <source>Display</source>
-      <translation>Ekran</translation>
+        <source>Display</source>
+        <translation>Ekran</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkCentralWidget.cpp" line="497"/>
-      <source>File</source>
-      <translation>Fajl</translation>
+        <source>File</source>
+        <translation>Fajl</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkCentralWidget.cpp" line="503"/>
-      <source>File Associations</source>
-      <translation>Fajl asocijacije</translation>
+        <source>File Associations</source>
+        <translation>Fajl asocijacije</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkCentralWidget.cpp" line="510"/>
-      <source>Advanced</source>
-      <translation>Napredno</translation>
+        <source>Advanced</source>
+        <translation>Napredno</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkCentralWidget.cpp" line="1083"/>
-      <source>Sorry, I could not drop the content.</source>
-      <translation>Izvini, ne mogu odbaciti sadržaj.</translation>
+        <source>Sorry, I could not drop the content.</source>
+        <translation>Izvini, ne mogu odbaciti sadržaj.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkCentralWidget.cpp" line="1115"/>
-      <source>Save File</source>
-      <translation>Sačuvaj fajl</translation>
+        <source>Save File</source>
+        <translation>Sačuvaj fajl</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkCentralWidget.cpp" line="1123"/>
-      <source>%1 vec files merged</source>
-      <translation>%1 fajlova je spojeno</translation>
+        <source>%1 vec files merged</source>
+        <translation>%1 fajlova je spojeno</translation>
     </message>
-  </context>
-  <context>
+    <message>
+        <source>Go to Tab</source>
+        <translation>Idi na karticu</translation>
+    </message>
+    <message>
+        <source>Go to tab number: </source>
+        <translation>Idi na kraticu broj: </translation>
+    </message>
+    <message>
+        <source>Editor</source>
+        <translation>Uređivač</translation>
+    </message>
+    <message>
+        <source>I could not load &quot;%1&quot;</source>
+        <translation>Nemoguće učitati &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <source>Unable to load file &quot;%1&quot;</source>
+        <translation>Nemoguće učitati fajl &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <source>&quot;%1&quot; cannot be loaded</source>
+        <translation>&quot;%1&quot; nemoguće učitati</translation>
+    </message>
+    <message>
+        <source>downloading &quot;%1&quot;</source>
+        <translation>preuzimam &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <source>Too many urls to load. Loading only the first %1</source>
+        <translation>Previše URLova za učitati. Učitavam samo prvih %1</translation>
+    </message>
+</context>
+<context>
     <name>nmc::DkColorChooser</name>
     <message>
-      <location filename="../src/DkLoader/DkBasicWidgets.cpp" line="167"/>
-      <source>Reset</source>
-      <translation>Resetuj</translation>
+        <source>Reset</source>
+        <translation>Resetuj</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkColorSlider</name>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="114"/>
-      <source>Drag the slider downwards for elimination</source>
-      <translation>Povuci klizač nadole za eliminaciju</translation>
+        <source>Drag the slider downwards for elimination</source>
+        <translation>Povuci klizač nadole za eliminaciju</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkCommentTextEdit</name>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="1143"/>
-      <source>Click here to add notes</source>
-      <translation>Klikni ovdje za dodavanje napomena</translation>
+        <source>Click here to add notes</source>
+        <translation>Klikni ovdje za dodavanje napomena</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkCommentWidget</name>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="1162"/>
-      <source>NOTES</source>
-      <translation>NAPOMENE</translation>
+        <source>NOTES</source>
+        <translation>NAPOMENE</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="1176"/>
-      <source>Enter your notes here. They will be saved to the image metadata.</source>
-      <translation>Unesi napomene ovdje. Biti će snimljene među podatke slike.</translation>
+        <source>Enter your notes here. They will be saved to the image metadata.</source>
+        <translation>Unesi napomene ovdje. Biti će snimljene među podatke slike.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="1182"/>
-      <source>Save Note (CTRL + ENTER)</source>
-      <translation>Sačuvaj napomenu (CTRL + ENTER)</translation>
+        <source>Save Note (CTRL + ENTER)</source>
+        <translation>Sačuvaj napomenu (CTRL + ENTER)</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="1189"/>
-      <source>Discard Changes (ESC)</source>
-      <translation>Odbaci promjene (ESC)</translation>
+        <source>Discard Changes (ESC)</source>
+        <translation>Odbaci promjene (ESC)</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="1230"/>
-      <source>Sorry, I cannot save comments for this image format.</source>
-      <translation>Izvini, ne mogu sačuvati komentare za ovaj format slike.</translation>
+        <source>Sorry, I cannot save comments for this image format.</source>
+        <translation>Izvini, ne mogu sačuvati komentare za ovaj format slike.</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkCompressDialog</name>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="178"/>
-      <source>Original</source>
-      <translation>Originalna</translation>
+        <source>Original</source>
+        <translation>Originalna</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="180"/>
-      <source>New</source>
-      <translation>Nova</translation>
+        <source>New</source>
+        <translation>Nova</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="206"/>
-      <source>Medium (1024 x 786)</source>
-      <translation>Srednja (1024 × 768)</translation>
+        <source>Medium (1024 x 786)</source>
+        <translation>Srednja (1024 × 768)</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="212"/>
-      <source>Image Quality</source>
-      <translation>Kvalitet slike</translation>
+        <source>Image Quality</source>
+        <translation>Kvalitet slike</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="218"/>
-      <source>Lossless Compression</source>
-      <translation>Kompresija bez gubitka</translation>
+        <source>Lossless Compression</source>
+        <translation>Kompresija bez gubitka</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="225"/>
-      <source>Background Color</source>
-      <translation>Boja pozadine</translation>
+        <source>Background Color</source>
+        <translation>Boja pozadine</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="257"/>
-      <source>&amp;OK</source>
-      <translation>&amp;U redu</translation>
+        <source>&amp;OK</source>
+        <translation>&amp;U redu</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="254"/>
-      <source>&amp;Cancel</source>
-      <translation>&amp;Otkaži</translation>
+        <source>&amp;Cancel</source>
+        <translation>&amp;Otkaži</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="140"/>
-      <source>JPG Settings</source>
-      <translation>JPG postavke</translation>
+        <source>JPG Settings</source>
+        <translation>JPG postavke</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="142"/>
-      <source>J2K Settings</source>
-      <translation>J2k postavke</translation>
+        <source>J2K Settings</source>
+        <translation>J2k postavke</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="151"/>
-      <source>WebP Settings</source>
-      <translation>WebP postavke</translation>
+        <source>WebP Settings</source>
+        <translation>WebP postavke</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="164"/>
-      <source>Save for Web</source>
-      <translation>Snimi za web</translation>
+        <source>Save for Web</source>
+        <translation>Snimi za web</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="205"/>
-      <source>Small  (800 x 600)</source>
-      <translation>Mala  (800 × 600)</translation>
+        <source>Small  (800 x 600)</source>
+        <translation>Mala  (800 × 600)</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="207"/>
-      <source>Large  (1920 x 1080)</source>
-      <translation>Velika  (1920 × 1080)</translation>
+        <source>Large  (1920 x 1080)</source>
+        <translation>Velika  (1920 × 1080)</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="208"/>
-      <source>Original Size</source>
-      <translation>Originalna veličina</translation>
+        <source>Original Size</source>
+        <translation>Originalna veličina</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="375"/>
-      <source>File Size: --</source>
-      <translation>Veličina fajla: --</translation>
+        <source>File Size: --</source>
+        <translation>Veličina fajla: --</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="392"/>
-      <source>File Size: ~%1</source>
-      <translation>Veličina fajla: ~%1</translation>
+        <source>File Size: ~%1</source>
+        <translation>Veličina fajla: ~%1</translation>
     </message>
-  </context>
-  <context>
-    <name>nmc::DkContrast</name>
-    <message>
-      <location filename="../src/DkGui/DkManipulationWidgets.cpp" line="969"/>
-      <source>Contrast</source>
-      <translation>Kontrast</translation>
-    </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkControlWidget</name>
     <message>
-      <location filename="../src/DkGui/DkControlWidget.cpp" line="579"/>
-      <source>Closing Plugin</source>
-      <translation>Zatvaram priključak</translation>
+        <source>Closing Plugin</source>
+        <translation>Zatvaram priključak</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkControlWidget.cpp" line="580"/>
-      <source>Apply plugin changes?</source>
-      <translation>Prihvati promjena priključka?</translation>
+        <source>Apply plugin changes?</source>
+        <translation>Prihvati promjena priključka?</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkCropToolBar</name>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="959"/>
-      <source>Crop (ENTER)</source>
-      <translation>Isjeci (ENTER)</translation>
+        <source>Crop (ENTER)</source>
+        <translation>Isjeci (ENTER)</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="963"/>
-      <source>Cancel (ESC)</source>
-      <translation>Otkaži (ESC)</translation>
+        <source>Cancel (ESC)</source>
+        <translation>Otkaži (ESC)</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="967"/>
-      <source>Pan</source>
-      <translation>Švenk</translation>
+        <source>Pan</source>
+        <translation>Švenk</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="975"/>
-      <source>User Defined</source>
-      <translation>Korisnički definisano</translation>
+        <source>User Defined</source>
+        <translation>Korisnički definisano</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="976"/>
-      <source>No Aspect Ratio</source>
-      <translation>Bez razmjera</translation>
+        <source>No Aspect Ratio</source>
+        <translation>Bez razmjera</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="984"/>
-      <source>Horizontal Constraint</source>
-      <translation>Horizontalno ograničenje</translation>
+        <source>Horizontal Constraint</source>
+        <translation>Horizontalno ograničenje</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="987"/>
-      <source>Swap</source>
-      <translation>Razmjena</translation>
+        <source>Swap</source>
+        <translation>Razmjena</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="989"/>
-      <source>Swap Dimensions</source>
-      <translation>Dimenzije razmjene</translation>
+        <source>Swap Dimensions</source>
+        <translation>Dimenzije razmjene</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="995"/>
-      <source>Vertical Constraint</source>
-      <translation>Vertikalno ograničenje</translation>
+        <source>Vertical Constraint</source>
+        <translation>Vertikalno ograničenje</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="1009"/>
-      <source>Background Color</source>
-      <translation>Boja pozadine</translation>
+        <source>Background Color</source>
+        <translation>Boja pozadine</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="1018"/>
-      <source>Guides</source>
-      <translation>Vodiči</translation>
+        <source>Guides</source>
+        <translation>Vodiči</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="1018"/>
-      <source>Rule of Thirds</source>
-      <translation>Pravilo trećine</translation>
+        <source>Rule of Thirds</source>
+        <translation>Pravilo trećine</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="1018"/>
-      <source>Grid</source>
-      <translation>Mreža</translation>
+        <source>Grid</source>
+        <translation>Mreža</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="1022"/>
-      <source>Show Guides in the Preview</source>
-      <translation>Prikaži vodiče u pregledu</translation>
+        <source>Show Guides in the Preview</source>
+        <translation>Prikaži vodiče u pregledu</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="1026"/>
-      <source>Invert Crop Tool Color</source>
-      <translation>Obrni boju alata za isjecanje</translation>
+        <source>Invert Crop Tool Color</source>
+        <translation>Obrni boju alata za isjecanje</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="1031"/>
-      <source>Show Info</source>
-      <translation>Prikaži informacije</translation>
+        <source>Show Info</source>
+        <translation>Prikaži informacije</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="1036"/>
-      <source>Crop to Metadata</source>
-      <translation>Izreži do metapodataka</translation>
+        <source>Crop to Metadata</source>
+        <translation>Izreži do metapodataka</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkCropWidget</name>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="2003"/>
-      <source>Crop Toolbar</source>
-      <translation>Alatna traka za isjecanje</translation>
+        <source>Crop Toolbar</source>
+        <translation>Alatna traka za isjecanje</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkDescriptionEdit</name>
     <message>
-      <location filename="../src/DkLoader/DkPluginManager.cpp" line="956"/>
-      <source>No metadata available!</source>
-      <translation>Metapodaci nedostupni!</translation>
+        <source>No metadata available!</source>
+        <translation>Metapodaci nedostupni!</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkDialogManager</name>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4597"/>
-      <source>Preview</source>
-      <translation>Pred-pregled</translation>
+        <source>Preview</source>
+        <translation>Pregled</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4612"/>
-      <source>Shortcuts</source>
-      <translation>Prečice</translation>
+        <source>Shortcuts</source>
+        <translation>Prečice</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkDirectoryChooser</name>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="2733"/>
-      <source>...</source>
-      <translation>...</translation>
+        <source>...</source>
+        <translation>...</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="2747"/>
-      <source>Open an Image Directory</source>
-      <translation>Otvori fasciklu sa slikama</translation>
+        <source>Open an Image Directory</source>
+        <translation>Otvori fasciklu sa slikama</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkDisplayPreference</name>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="597"/>
-      <source>Invert mouse wheel behaviour for zooming</source>
-      <translation>Obrni ponašanje kolutića miša kod zumiranja</translation>
+        <source>Invert mouse wheel behaviour for zooming</source>
+        <translation>Obrni ponašanje kolutića miša kod zumiranja</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="599"/>
-      <source>If checked, the mouse wheel behaviour is inverted while zooming.</source>
-      <translation>Ako je označeno, kolutić miša se ponaša obrnuto tokom zumiranja.</translation>
+        <source>If checked, the mouse wheel behaviour is inverted while zooming.</source>
+        <translation>Ako je označeno, kolutić miša se ponaša obrnuto tokom zumiranja.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="602"/>
-      <source>Show pixels if zoom level is above</source>
-      <translation>Prikaži piksele ako je nivo zuma iznad</translation>
+        <source>Show pixels if zoom level is above</source>
+        <translation>Prikaži piksele ako je nivo zuma iznad</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="606"/>
-      <source>nomacs will not interpolate images if the zoom level is larger.</source>
-      <translation>nomacs neće interpolirati slike ako je nivo zuma veći.</translation>
+        <source>nomacs will not interpolate images if the zoom level is larger.</source>
+        <translation>nomacs neće interpolirati slike ako je nivo zuma veći.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="612"/>
-      <source>Zoom</source>
-      <translation>Zum</translation>
+        <source>Zoom</source>
+        <translation>Zum</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="620"/>
-      <source>Always keep zoom</source>
-      <translation>Uvijek zadrži zum</translation>
+        <source>Always keep zoom</source>
+        <translation>Uvijek zadrži zum</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="621"/>
-      <source>Keep zoom if the size is the same</source>
-      <translation>Zadrži zum ako je veličina ista</translation>
+        <source>Keep zoom if the size is the same</source>
+        <translation>Zadrži zum ako je veličina ista</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="622"/>
-      <source>If checked, the zoom level is only kept, if the image loaded has the same level as the previous.</source>
-      <translation>Ako je označeno, nivo zuma se jedino zadrži ako učitana slika ima istu veličinu kao i prethodna.</translation>
+        <source>If checked, the zoom level is only kept, if the image loaded has the same level as the previous.</source>
+        <translation>Ako je označeno, nivo zuma se jedino zadrži ako učitana slika ima istu veličinu kao i prethodna.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="623"/>
-      <source>Never keep zoom</source>
-      <translation>Nikada ne zadržavaj zum</translation>
+        <source>Never keep zoom</source>
+        <translation>Nikada ne zadržavaj zum</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="625"/>
-      <source>Always zoom to fit</source>
-      <translation>Uvijek zumiraj da slika stane</translation>
+        <source>Always zoom to fit</source>
+        <translation>Uvijek zumiraj da slika stane</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="638"/>
-      <source>When Displaying New Images</source>
-      <translation>Prilikom prikazivanja nove slike</translation>
+        <source>When Displaying New Images</source>
+        <translation>Prilikom prikazivanja nove slike</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="647"/>
-      <source>Define the icon size in pixel.</source>
-      <translation>Definiši veličinu ikona u pikselima.</translation>
+        <source>Define the icon size in pixel.</source>
+        <translation>Definiši veličinu ikona u pikselima.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="653"/>
-      <source>Icon Size</source>
-      <translation>Veličina ikona</translation>
+        <source>Icon Size</source>
+        <translation>Veličina ikona</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="657"/>
-      <source>Image Transition</source>
-      <translation>Prelaz između slika</translation>
+        <source>Image Transition</source>
+        <translation>Prelaz između slika</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="661"/>
-      <source>Choose a transition when loading a new image</source>
-      <translation>Izaberi prelaz pri učitavanju slika</translation>
+        <source>Choose a transition when loading a new image</source>
+        <translation>Izaberi prelaz pri učitavanju slika</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="665"/>
-      <source>Unknown Transition</source>
-      <translation>Nepoznat prelaz</translation>
+        <source>Unknown Transition</source>
+        <translation>Nepoznat prelaz</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="668"/>
-      <source>Appear</source>
-      <translation>Pojavljivanje</translation>
+        <source>Appear</source>
+        <translation>Izgled</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="669"/>
-      <source>Swipe</source>
-      <translation>Potegnuti</translation>
+        <source>Swipe</source>
+        <translation>Potegnuti</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="670"/>
-      <source>Fade</source>
-      <translation>Uvenuti</translation>
+        <source>Fade</source>
+        <translation>Isčezni</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="679"/>
-      <source>Define the image transition speed.</source>
-      <translation>Definiši brzinu prelaza slika.</translation>
+        <source>Define the image transition speed.</source>
+        <translation>Definiši brzinu prelaza slika.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="686"/>
-      <source>Always Animate Image Loading</source>
-      <translation>Uvijek animiraj učitavanje slika</translation>
+        <source>Always Animate Image Loading</source>
+        <translation>Uvijek animiraj učitavanje slika</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="688"/>
-      <source>If unchecked, loading is only animated if nomacs is fullscreen</source>
-      <translation>Ako nije označeno, učitavanje je jedino animirano ako je nomacs preko cijelog ekrana</translation>
+        <source>If unchecked, loading is only animated if nomacs is fullscreen</source>
+        <translation>Ako nije označeno, učitavanje je jedino animirano ako je nomacs preko cijelog ekrana</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="691"/>
-      <source>Display Time</source>
-      <translation>Vrijeme prikaza</translation>
+        <source>Display Time</source>
+        <translation>Vrijeme prikaza</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="695"/>
-      <source>Define the time an image is displayed.</source>
-      <translation>Definiše vrijeme koliko se slika prikazuje.</translation>
+        <source>Define the time an image is displayed.</source>
+        <translation>Definiše vrijeme koliko se slika prikazuje.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="702"/>
-      <source>Slideshow</source>
-      <translation>Slajdšou</translation>
+        <source>Slideshow</source>
+        <translation>Slajdšou</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="711"/>
-      <source>Show crop rectangle</source>
-      <translation>Prikaži kvadrat za rezanje</translation>
+        <source>Show crop rectangle</source>
+        <translation>Prikaži kvadrat za rezanje</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="715"/>
-      <source>Show Metadata Cropping</source>
-      <translation>Prikaži rezanje metapodataka</translation>
+        <source>Show Metadata Cropping</source>
+        <translation>Prikaži rezanje metapodataka</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="765"/>
-      <source>Please Restart nomacs to apply changes</source>
-      <translation>Molimo restartujte nomacs da bi prihvatili promjene</translation>
+        <source>Please Restart nomacs to apply changes</source>
+        <translation>Molimo restartujte nomacs da bi prihvatili promjene</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkExplorer</name>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="479"/>
-      <source>Editable</source>
-      <translation>Moguće izmjeniti</translation>
+        <source>Editable</source>
+        <translation>Moguće izmjeniti</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="485"/>
-      <source>Open Selected Image</source>
-      <translation>Otvori odabranu sliku</translation>
+        <source>Open Selected Image</source>
+        <translation>Otvori odabranu sliku</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="495"/>
-      <source>Adjust Columns</source>
-      <translation>Namjesti kolumne</translation>
+        <source>Adjust Columns</source>
+        <translation>Namjesti kolumne</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkExportTiffDialog</name>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2523"/>
-      <source>Export Multi-Page TIFF</source>
-      <translation>Eksportuj višestrani TIFF</translation>
+        <source>Export Multi-Page TIFF</source>
+        <translation>Eksportuj višestrani TIFF</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2569"/>
-      <source>Multi-Page TIFF:</source>
-      <translation>Višestrani TIFF:</translation>
+        <source>Multi-Page TIFF:</source>
+        <translation>Višestrani TIFF:</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2572"/>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2581"/>
-      <source>&amp;Browse</source>
-      <translation>&amp;Pregledaj</translation>
+        <source>&amp;Browse</source>
+        <translation>&amp;Pregledaj</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2575"/>
-      <source>No Multi-Page TIFF loaded</source>
-      <translation>Bez učitanog višestranog TIFF</translation>
+        <source>No Multi-Page TIFF loaded</source>
+        <translation>Bez učitanog višestranog TIFF</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2578"/>
-      <source>Save Folder:</source>
-      <translation>Sačuvaj u fasciklu:</translation>
+        <source>Save Folder:</source>
+        <translation>Sačuvaj u fasciklu:</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2584"/>
-      <source>Specify a Save Folder</source>
-      <translation>Odredi fasciklu za sačuvanje</translation>
+        <source>Specify a Save Folder</source>
+        <translation>Odredi fasciklu za sačuvanje</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2587"/>
-      <source>Filename:</source>
-      <translation>Ime fajla:</translation>
+        <source>Filename:</source>
+        <translation>Ime fajla:</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2598"/>
-      <source>Export Pages</source>
-      <translation>Eksportuj stranice</translation>
+        <source>Export Pages</source>
+        <translation>Eksportuj stranice</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2605"/>
-      <source>Overwrite</source>
-      <translation>Piši preko</translation>
+        <source>Overwrite</source>
+        <translation>Piši preko</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2637"/>
-      <source>&amp;Export</source>
-      <translation>&amp;Eksportuj</translation>
+        <source>&amp;Export</source>
+        <translation>&amp;Eksportuj</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2638"/>
-      <source>&amp;Cancel</source>
-      <translation>&amp;Otkaži</translation>
+        <source>&amp;Cancel</source>
+        <translation>&amp;Otkaži</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2655"/>
-      <source>Open TIFF</source>
-      <translation>Otvori TIFF</translation>
+        <source>Open TIFF</source>
+        <translation>Otvori TIFF</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2666"/>
-      <source>Open an Image Directory</source>
-      <translation>Otvori fasciklu sa slikama</translation>
+        <source>Open an Image Directory</source>
+        <translation>Otvori fasciklu sa slikama</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2753"/>
-      <source>%1 exists, skipping...</source>
-      <translation>%1 postoji, preskočeno...</translation>
+        <source>%1 exists, skipping...</source>
+        <translation>%1 postoji, preskočeno...</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2766"/>
-      <source>Sorry, I could not save: %1</source>
-      <translation>Izvini, nije moguće sačuvati: %1</translation>
+        <source>Sorry, I could not save: %1</source>
+        <translation>Izvini, nije moguće sačuvati: %1</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2758"/>
-      <source>Sorry, I could not load page: %1</source>
-      <translation>Izvini, ne mogu učitati stranicu: %1</translation>
+        <source>Sorry, I could not load page: %1</source>
+        <translation>Izvini, ne mogu učitati stranicu: %1</translation>
     </message>
-  </context>
-  <context>
-    <name>nmc::DkExposure</name>
+</context>
+<context>
+    <name>nmc::DkExposureWidget</name>
     <message>
-      <location filename="../src/DkGui/DkManipulationWidgets.cpp" line="1368"/>
-      <source>Exposure</source>
-      <translation>Ekspozicija</translation>
+        <source>Exposure</source>
+        <translation>Ekspozicija</translation>
     </message>
-  </context>
-  <context>
+    <message>
+        <source>Offset</source>
+        <translation>Istup</translation>
+    </message>
+    <message>
+        <source>Gamma</source>
+        <translation>Gama</translation>
+    </message>
+</context>
+<context>
     <name>nmc::DkFileAssociationsPreference</name>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="997"/>
-      <source>Filter</source>
-      <translation>Filter</translation>
+        <source>Filter</source>
+        <translation>Filter</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="998"/>
-      <source>Browse</source>
-      <translation>Pregledaj</translation>
+        <source>Browse</source>
+        <translation>Pregledaj</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="999"/>
-      <source>Register</source>
-      <translation>Registruj</translation>
+        <source>Register</source>
+        <translation>Registruj</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1011"/>
-      <source>Set as Default Viewer</source>
-      <translation>Postavi kao po&amp;drazumijevani pregledač slika</translation>
+        <source>Set as Default Viewer</source>
+        <translation>Postavi kao podrazumijevani pregledač slika</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1029"/>
-      <source>Please Restart nomacs to apply changes</source>
-      <translation>Molimo restartujte nomacs da bi prihvatili promjene</translation>
+        <source>Please Restart nomacs to apply changes</source>
+        <translation>Molimo restartujte nomacs da bi prihvatili promjene</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1102"/>
-      <source>Image</source>
-      <translation>Slika</translation>
+        <source>Image</source>
+        <translation>Slika</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkFileInfoLabel</name>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="1147"/>
-      <source>Info Box</source>
-      <translation>Info kutija</translation>
+        <source>Info Box</source>
+        <translation>Info kutija</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="1148"/>
-      <source>All information fields are currently hidden.
+        <source>All information fields are currently hidden.
 Do you want to show them again?</source>
-      <translation>Sva polja su trenutno skrivena.
+        <translation>Sva polja su trenutno skrivena.
 Da li ih želite povratiti?</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkFilePreference</name>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="835"/>
-      <source>Screenshots are automatically saved to this folder</source>
-      <translation>Snimke ekrana se automatski snimaju u ovaj direktorij</translation>
+        <source>Screenshots are automatically saved to this folder</source>
+        <translation>Snimke ekrana se automatski snimaju u ovaj direktorij</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="837"/>
-      <source>Use Temporary Folder</source>
-      <translation>Koristi privremeni direktorij</translation>
+        <source>Use Temporary Folder</source>
+        <translation>Koristi privremeni direktorij</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="852"/>
-      <source>We recommend to set a moderate cache value around 100 MB</source>
-      <translation>Preporučujemo stavljanje umjerene veličine keša oko 100MB</translation>
+        <source>Maximal Cache Size</source>
+        <translation>Maksimalna veličina keša</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="854"/>
-      <source>Maximal Cache Size</source>
-      <translation>Maksimalna veličina keša</translation>
+        <source>History Size</source>
+        <translation>Veličina historije</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="868"/>
-      <source>We recommend to set a moderate edit history value around 100 MB</source>
-      <translation>Preporučujemo stavljanje umjerene veličine historije oko 100MB</translation>
+        <source>Skip Images</source>
+        <translation>Preskoči slike</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="870"/>
-      <source>History Size</source>
-      <translation>Veličina historije</translation>
+        <source>Images are skipped until the Next key is released</source>
+        <translation>Slike su preskočene dok se ne pusti Next dugme</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="877"/>
-      <source>Skip Images</source>
-      <translation>Preskoči slike</translation>
+        <source>Wait for Images to be Loaded</source>
+        <translation>Sačekaj da slike budu učitane</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="878"/>
-      <source>Images are skipped until the Next key is released</source>
-      <translation>Slike su preskočene dok se ne pusti Next dugme</translation>
+        <source>The next image is loaded after the current image is shown.</source>
+        <translation>Sljedeća slika se učita nakon što se prikaže trenutna.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="879"/>
-      <source>Wait for Images to be Loaded</source>
-      <translation>Sačekaj da slike budu učitane</translation>
+        <source>Image Loading Policy</source>
+        <translation>Postavke učitavanja slika</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="880"/>
-      <source>The next image is loaded after the current image is shown.</source>
-      <translation>Sljedeća slika se učita nakon što se prikaže trenutna.</translation>
+        <source>Number of Skipped Images on PgUp/PgDown</source>
+        <translation>Broj preskočenih slika na PgUp/PgDown</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="891"/>
-      <source>Image Loading Policy</source>
-      <translation>Postavke učitavanja slika</translation>
+        <source>We recommend to set a moderate cache value around 100 MB. [%1-%2 MB]</source>
+        <translation>Predlažemo da se postavi umjerena vrijednost keša oko 100MB. [%1-%2 MB]</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="903"/>
-      <source>Number of Skipped Images on PgUp/PgDown</source>
-      <translation>Broj preskočenih slika na PgUp/PgDown</translation>
+        <source>We recommend to set a moderate edit history value around 100 MB. [%1-%2 MB]</source>
+        <translation>Predlažemo da se postavi umjerena vrijednost historije uređivanja oko 100MB. [%1-%2 MB]</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkFilePreview</name>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="191"/>
-      <source>Show Left</source>
-      <translation>Prikaži lijevo</translation>
+        <source>Show Left</source>
+        <translation>Prikaži lijevo</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="192"/>
-      <source>Shows the Thumbnail Bar on the Left</source>
-      <translation>Prikazuje traku sličica lijevo</translation>
+        <source>Shows the Thumbnail Bar on the Left</source>
+        <translation>Prikazuje traku sličica lijevo</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="195"/>
-      <source>Show Top</source>
-      <translation>Prikaži gore</translation>
+        <source>Show Top</source>
+        <translation>Prikaži gore</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="196"/>
-      <source>Shows the Thumbnail Bar at the Top</source>
-      <translation>Prikazuje traku sličica na vrhu</translation>
+        <source>Shows the Thumbnail Bar at the Top</source>
+        <translation>Prikazuje traku sličica na vrhu</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="199"/>
-      <source>Show Right</source>
-      <translation>Prikaži desno</translation>
+        <source>Show Right</source>
+        <translation>Prikaži desno</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="200"/>
-      <source>Shows the Thumbnail Bar on the Right</source>
-      <translation>Prikazuje traku sličica desno</translation>
+        <source>Shows the Thumbnail Bar on the Right</source>
+        <translation>Prikazuje traku sličica desno</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="203"/>
-      <source>Show Bottom</source>
-      <translation>Prikaži dole</translation>
+        <source>Show Bottom</source>
+        <translation>Prikaži dole</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="204"/>
-      <source>Shows the Thumbnail Bar at the Bottom</source>
-      <translation>Prikazuje traku sličica na dnu</translation>
+        <source>Shows the Thumbnail Bar at the Bottom</source>
+        <translation>Prikazuje traku sličica na dnu</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="207"/>
-      <source>Undock</source>
-      <translation>Odvoji</translation>
+        <source>Undock</source>
+        <translation>Odvoji</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="208"/>
-      <source>Undock the thumbnails</source>
-      <translation>Odvoji sličice</translation>
+        <source>Undock the thumbnails</source>
+        <translation>Odvoji sličice</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="211"/>
-      <source>File Preview Menu</source>
-      <translation>Meni pregleda fajla</translation>
+        <source>File Preview Menu</source>
+        <translation>Meni pregleda fajla</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="578"/>
-      <source>Name: </source>
-      <translation>Ime: </translation>
+        <source>Name: </source>
+        <translation>Ime: </translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="579"/>
-      <source>Size: </source>
-      <translation>Veličina: </translation>
+        <source>Size: </source>
+        <translation>Veličina: </translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="580"/>
-      <source>Created: </source>
-      <translation>Kreirano:</translation>
+        <source>Created: </source>
+        <translation>Kreirano: </translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="597"/>
-      <source>CTRL+Zoom resizes the thumbnails</source>
-      <translation>CTRL + zum mijenja veličinu sličica</translation>
+        <source>CTRL+Zoom resizes the thumbnails</source>
+        <translation>CTRL + zum mijenja veličinu sličica</translation>
     </message>
-  </context>
-  <context>
-    <name>nmc::DkFileSelection</name>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="446"/>
-      <source>No Files Selected</source>
-      <translation>Bez odabranih fajlova</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="325"/>
-      <source>File Explorer</source>
-      <translation>Pregledač fajlova</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="337"/>
-      <source>Thumbnails</source>
-      <translation>Sličice</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="338"/>
-      <source>File List</source>
-      <translation>Fajl lista</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="382"/>
-      <source>Open an Image Directory</source>
-      <translation>Otvori fasciklu sa slikama</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="448"/>
-      <source>%1 File Selected</source>
-      <translation>%1 fajl odabran</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="450"/>
-      <source>%1 Files Selected</source>
-      <translation>%1 fajlova odabrano</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="471"/>
-      <location filename="../src/DkGui/DkBatch.cpp" line="485"/>
-      <source>Results</source>
-      <translation>Rezultati</translation>
-    </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkFilenameWidget</name>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="514"/>
-      <source>Current Filename</source>
-      <translation>Trenutno ime fajla</translation>
+        <source>Current Filename</source>
+        <translation>Trenutno ime fajla</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="515"/>
-      <source>Text</source>
-      <translation>Tekst</translation>
+        <source>Text</source>
+        <translation>Tekst</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="516"/>
-      <source>Number</source>
-      <translation>Broj</translation>
+        <source>Number</source>
+        <translation>Broj</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="522"/>
-      <source>Keep Case</source>
-      <translation>Zadrži velika i mala slova</translation>
+        <source>Keep Case</source>
+        <translation>Zadrži velika i mala slova</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="523"/>
-      <source>To lowercase</source>
-      <translation>U mala slova</translation>
+        <source>To lowercase</source>
+        <translation>U mala slova</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="524"/>
-      <source>To UPPERCASE</source>
-      <translation>U VELIKA SLOVA</translation>
+        <source>To UPPERCASE</source>
+        <translation>U VELIKA SLOVA</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="535"/>
-      <source>1 digit</source>
-      <translation>1 cifra</translation>
+        <source>1 digit</source>
+        <translation>1 cifra</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="536"/>
-      <source>2 digits</source>
-      <translation>2 cifre</translation>
+        <source>2 digits</source>
+        <translation>2 cifre</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="537"/>
-      <source>3 digits</source>
-      <translation>3 cifre</translation>
+        <source>3 digits</source>
+        <translation>3 cifre</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="538"/>
-      <source>4 digits</source>
-      <translation>4 cifre</translation>
+        <source>4 digits</source>
+        <translation>4 cifre</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="539"/>
-      <source>5 digits</source>
-      <translation>5 cifara</translation>
+        <source>5 digits</source>
+        <translation>5 cifara</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkForceThumbDialog</name>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4159"/>
-      <source>Overwrite Existing Thumbnails</source>
-      <translation>Piši preko postojećih sličica</translation>
+        <source>Overwrite Existing Thumbnails</source>
+        <translation>Piši preko postojećih sličica</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4164"/>
-      <source>&amp;OK</source>
-      <translation>&amp;U redu</translation>
+        <source>&amp;OK</source>
+        <translation>&amp;U redu</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4165"/>
-      <source>&amp;Cancel</source>
-      <translation>&amp;Otkaži</translation>
+        <source>&amp;Cancel</source>
+        <translation>&amp;Otkaži</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4182"/>
-      <source>Compute thumbnails for all images in:
+        <source>Compute thumbnails for all images in:
  %1
 </source>
-      <translation>Izračunaj sličice za sve slike u:
- %1</translation>
+        <translation>Izračunaj sličice za sve slike u:
+ %1
+</translation>
     </message>
-  </context>
-  <context>
-    <name>nmc::DkGamma</name>
-    <message>
-      <location filename="../src/DkGui/DkManipulationWidgets.cpp" line="1270"/>
-      <source>Gamma</source>
-      <translation>Gama</translation>
-    </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkGeneralPreference</name>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="306"/>
-      <source>Highlight Color</source>
-      <translation>Boja za istaknivanje</translation>
+        <source>Highlight Color</source>
+        <translation>Istaknuta boja</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="311"/>
-      <source>Icon Color</source>
-      <translation>Boja ikona</translation>
+        <source>Icon Color</source>
+        <translation>Boja ikona</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="316"/>
-      <source>Background Color</source>
-      <translation>Boja pozadine</translation>
+        <source>Background Color</source>
+        <translation>Boja pozadine</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="321"/>
-      <source>Fullscreen Color</source>
-      <translation>Boja celog ekrana</translation>
+        <source>Fullscreen Color</source>
+        <translation>Boja celog ekrana</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="326"/>
-      <source>HUD Foreground Color</source>
-      <translation>Prednja boja HUD-a</translation>
+        <source>HUD Foreground Color</source>
+        <translation>Prednja boja HUD-a</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="331"/>
-      <source>HUD Background Color</source>
-      <translation>Pozadinska boja HUD-a</translation>
+        <source>HUD Background Color</source>
+        <translation>Pozadinska boja HUD-a</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="337"/>
-      <source>Color Settings</source>
-      <translation>Postavke boja</translation>
+        <source>Color Settings</source>
+        <translation>Postavke boja</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="346"/>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="554"/>
-      <source>Reset All Settings</source>
-      <translation>Povrati sve postavke</translation>
+        <source>Reset All Settings</source>
+        <translation>Povrati sve postavke</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="350"/>
-      <source>Default Settings</source>
-      <translation>Podrazumijevane postavke</translation>
+        <source>Default Settings</source>
+        <translation>Podrazumijevane postavke</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="363"/>
-      <source>Show Recent Files on Start-Up</source>
-      <translation>Prikaži nedavne fajlove pri pokretanju</translation>
+        <source>Show Recent Files on Start-Up</source>
+        <translation>Prikaži nedavne fajlove pri pokretanju</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="365"/>
-      <source>Show the History Panel on Start-Up</source>
-      <translation>Prikaži panel za povijest pri pokretanju</translation>
+        <source>Show the History Panel on Start-Up</source>
+        <translation>Prikaži panel za povijest pri pokretanju</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="368"/>
-      <source>Log Recent Files</source>
-      <translation>Bilježi nedavne slike</translation>
+        <source>Log Recent Files</source>
+        <translation>Bilježi nedavne slike</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="370"/>
-      <source>If checked, recent files will be saved.</source>
-      <translation>Ako je označeno, nedavni fajlovi će biti snimljeni.</translation>
+        <source>If checked, recent files will be saved.</source>
+        <translation>Ako je označeno, nedavni fajlovi će biti snimljeni.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="373"/>
-      <source>Loop Images</source>
-      <translation>Prikazuj u petlji</translation>
+        <source>Loop Images</source>
+        <translation>Prikazuj u petlji</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="375"/>
-      <source>Start with the first image in a folder after showing the last.</source>
-      <translation>Prikaži prvu sliku u direktoriju nakon prikaza posljednje.</translation>
+        <source>Start with the first image in a folder after showing the last.</source>
+        <translation>Prikaži prvu sliku u direktoriju nakon prikaza posljednje.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="378"/>
-      <source>Mouse Wheel Zooms</source>
-      <translation>Zumiraj točkićem miša</translation>
+        <source>Mouse Wheel Zooms</source>
+        <translation>Zumiraj točkićem miša</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="380"/>
-      <source>If checked, the mouse wheel zooms - otherwise it is used to switch between images.</source>
-      <translation>Ako je označeno, točkić na mišu zumira. Inače se koristi za promjenu slika.</translation>
+        <source>If checked, the mouse wheel zooms - otherwise it is used to switch between images.</source>
+        <translation>Ako je označeno, točkić na mišu zumira. Inače se koristi za promjenu slika.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="383"/>
-      <source>Double Click Opens Fullscreen</source>
-      <translation>Dupli klik otvora preko cijelog ekrana</translation>
+        <source>Double Click Opens Fullscreen</source>
+        <translation>Dupli klik otvora preko cijelog ekrana</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="385"/>
-      <source>If checked, a double click on the canvas opens the fullscreen mode.</source>
-      <translation>Ako je označeno, dupli klik na sliku otvara prikaz preko cijelog ekrana.</translation>
+        <source>If checked, a double click on the canvas opens the fullscreen mode.</source>
+        <translation>Ako je označeno, dupli klik na sliku otvara prikaz preko cijelog ekrana.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="388"/>
-      <source>Show Background Image</source>
-      <translation>Prikaži pozadinsku sliku</translation>
+        <source>Show Background Image</source>
+        <translation>Prikaži pozadinsku sliku</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="390"/>
-      <source>If checked, the nomacs logo is shown in the bottom right corner.</source>
-      <translation>Ako je označeno, nomacs logo će biti prikazan u donjem desnom uglu.</translation>
+        <source>If checked, the nomacs logo is shown in the bottom right corner.</source>
+        <translation>Ako je označeno, nomacs logo će biti prikazan u donjem desnom uglu.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="393"/>
-      <source>Switch CTRL with ALT</source>
-      <translation>Zamjeni CTRL i ALT</translation>
+        <source>Switch CTRL with ALT</source>
+        <translation>Zamjeni CTRL i ALT</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="395"/>
-      <source>If checked, CTRL + Mouse is switched with ALT + Mouse.</source>
-      <translation>Ako je označeno, CTRL + miš je zamijenjeno sa ALT + miš.</translation>
+        <source>If checked, CTRL + Mouse is switched with ALT + Mouse.</source>
+        <translation>Ako je označeno, CTRL + miš je zamijenjeno sa ALT + miš.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="398"/>
-      <source>Enable LAN Sync</source>
-      <translation>Omogući LAN sinhronizaciju</translation>
+        <source>Enable LAN Sync</source>
+        <translation>Omogući LAN sinhronizaciju</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="400"/>
-      <source>If checked, syncing in your LAN is enabled.</source>
-      <translation>Ako je označeno, LAN sinhronizacija je omogućena.</translation>
+        <source>If checked, syncing in your LAN is enabled.</source>
+        <translation>Ako je označeno, LAN sinhronizacija je omogućena.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="403"/>
-      <source>Close on ESC</source>
-      <translation>Zatvori na ESC</translation>
+        <source>Close on ESC</source>
+        <translation>Zatvori na ESC</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="405"/>
-      <source>Close nomacs if ESC is pressed.</source>
-      <translation>Zatvori nomacs pri pritisku ESC dugmeta.</translation>
+        <source>Close nomacs if ESC is pressed.</source>
+        <translation>Zatvori nomacs pri pritisku ESC dugmeta.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="408"/>
-      <source>Check For Updates</source>
-      <translation>Provjeri ažuriranja</translation>
+        <source>Check For Updates</source>
+        <translation>Provjeri ažuriranja</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="410"/>
-      <source>Check for updates on start-up.</source>
-      <translation>Provjerava da li postoje ažuriranja pri pokretanju.</translation>
+        <source>Check for updates on start-up.</source>
+        <translation>Provjerava da li postoje ažuriranja pri pokretanju.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="413"/>
-      <source>General</source>
-      <translation>Opšte</translation>
+        <source>General</source>
+        <translation>Opšte</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="428"/>
-      <source>Choose your preferred language.</source>
-      <translation>Izaberi jezik.</translation>
+        <source>Choose your preferred language.</source>
+        <translation>Izaberi jezik.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="433"/>
-      <source>Info on how to translate nomacs.</source>
-      <translation>Informacije za prevod nomacsa.</translation>
+        <source>Info on how to translate nomacs.</source>
+        <translation>Informacije za prevod nomacsa.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="436"/>
-      <source>Language</source>
-      <translation>Jezik</translation>
+        <source>Language</source>
+        <translation>Jezik</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="457"/>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="558"/>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="571"/>
-      <source>Please Restart nomacs to apply changes</source>
-      <translation>Molimo restartujte nomacs da bi prihvatili promjene</translation>
+        <source>Please Restart nomacs to apply changes</source>
+        <translation>Molimo restartujte nomacs da bi prihvatili promjene</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="554"/>
-      <source>This will reset all personal settings!</source>
-      <translation>Ovo će izbrisati sve lične postavke!</translation>
+        <source>This will reset all personal settings!</source>
+        <translation>Ovo će izbrisati sve lične postavke!</translation>
     </message>
-  </context>
-  <context>
+    <message>
+        <source>&amp;Import Settings</source>
+        <translation>&amp;Importuj postavke</translation>
+    </message>
+    <message>
+        <source>&amp;Export Settings</source>
+        <translation>&amp;Eksportuj postavke</translation>
+    </message>
+    <message>
+        <source>Check for Duplicates on Open</source>
+        <translation>Provjeri da ovjerene duplikate</translation>
+    </message>
+    <message>
+        <source>If any files are opened which are already open in a tab, don&apos;t open them again.</source>
+        <translation>Ne otvaraj ponovo fajlove koji su već otvoreni u nekoj kartici.</translation>
+    </message>
+    <message>
+        <source>Show extra options related to tabs</source>
+        <translation>Prikaži dodatne postavke u povezanim karticama</translation>
+    </message>
+    <message>
+        <source>Enables the &quot;Go to Tab&quot;, &quot;First Tab&quot;, and &quot;Last Tab&quot; options in the View menu, and the &quot;Open Tabs&quot; and &quot;Save Tabs&quot; options in the File menu.</source>
+        <translation>Prikazuje &quot;Idi na karticu&quot;, &quot;Prva kartica&quot; i &quot;Zadnja kartica&quot; mogućnost u izborniku pogleda, i &quot;Otvori kartice&quot; i &quot;Sačuvaj kartice&quot; mogućnost u izborniku fajlova.</translation>
+    </message>
+    <message>
+        <source>Next Image on Horizontal Zoom</source>
+        <translation>Sljedeća slika pri horizontalnom zumiranju</translation>
+    </message>
+    <message>
+        <source>If checked, horizontal wheel events load the next/previous images.</source>
+        <translation>Ako je uključeno, horizontalno kretanje točkića učitava sljedeću/prethodnu sliku.</translation>
+    </message>
+    <message>
+        <source>Import Settings</source>
+        <translation>Unesi postavke</translation>
+    </message>
+    <message>
+        <source>Export Settings</source>
+        <translation>Izvezi postavke</translation>
+    </message>
+    <message>
+        <source>Settings exported</source>
+        <translation>Postavke izvedene</translation>
+    </message>
+</context>
+<context>
+    <name>nmc::DkGenericProfileWidget</name>
+    <message>
+        <source>Set As Default</source>
+        <translation>Postavi kao zadano</translation>
+    </message>
+    <message>
+        <source>Profile Name</source>
+        <translation>Ime profila</translation>
+    </message>
+    <message>
+        <source>Profile Name:</source>
+        <translation>Ime profila:</translation>
+    </message>
+    <message>
+        <source>Profile Already Exists</source>
+        <translation>Profil već postoji</translation>
+    </message>
+    <message>
+        <source>Do you want to overwrite %1?</source>
+        <translation>Da li želite snimi preko %1?</translation>
+    </message>
+    <message>
+        <source>No Profiles</source>
+        <translation>Nema profila</translation>
+    </message>
+</context>
+<context>
     <name>nmc::DkGlobalSettingsWidget</name>
     <message>
-      <location filename="../src/DkCore/DkUtils.cpp" line="344"/>
-      <source>English</source>
-      <extracomment>this should be the name of the language in which nomacs is translated to</extracomment>
-      <translation>bosanski</translation>
+        <source>English</source>
+        <extracomment>this should be the name of the language in which nomacs is translated to</extracomment>
+        <translation>bosanski</translation>
     </message>
-  </context>
-  <context>
-    <name>nmc::DkHue</name>
+</context>
+<context>
+    <name>nmc::DkHistogram</name>
     <message>
-      <location filename="../src/DkGui/DkManipulationWidgets.cpp" line="1166"/>
-      <source>Hue</source>
-      <translation>Nijansa</translation>
+        <source>Show Statistics</source>
+        <translation>Prikaži statistiku</translation>
     </message>
-  </context>
-  <context>
+    <message>
+        <source>Histogram Settings</source>
+        <translation>Histogram postavke</translation>
+    </message>
+</context>
+<context>
+    <name>nmc::DkHueWidget</name>
+    <message>
+        <source>Hue</source>
+        <translation>Nijansa</translation>
+    </message>
+    <message>
+        <source>Saturation</source>
+        <translation>Zasićenje</translation>
+    </message>
+    <message>
+        <source>Brightness</source>
+        <translation>Svjetlina</translation>
+    </message>
+</context>
+<context>
     <name>nmc::DkImageContainerT</name>
     <message>
-      <location filename="../src/DkLoader/DkImageContainer.cpp" line="666"/>
-      <source>Sorry, the file: %1 does not exist... </source>
-      <translation>Izvini, fajl: %1 ne postoji... </translation>
+        <source>Sorry, the file: %1 does not exist... </source>
+        <translation>Izvini, fajl: %1 ne postoji... </translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageContainer.cpp" line="673"/>
-      <source>Sorry, you are not allowed to read: %1</source>
-      <translation>Izvini, nije vam dozvoljeno da čitanje: %1</translation>
+        <source>Sorry, you are not allowed to read: %1</source>
+        <translation>Izvini, nije vam dozvoljeno da čitanje: %1</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageContainer.cpp" line="784"/>
-      <source>Sorry, I could not load: %1</source>
-      <translation>Izvini, nije moguće učitati: %1</translation>
+        <source>Sorry, I could not load: %1</source>
+        <translation>Izvini, nije moguće učitati: %1</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageContainer.cpp" line="827"/>
-      <source>Sorry, I could not download:
+        <source>Sorry, I could not download:
 %1</source>
-      <translation>Izvini, nije moguće preuzeti:
+        <translation>Izvini, nije moguće preuzeti:
 %1</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageContainer.cpp" line="893"/>
-      <source>I can't save an empty file, sorry...
+        <source>I can&apos;t save an empty file, sorry...
 </source>
-      <translation>Ne mogu sačuvati prazan fajl, izvini...</translation>
+        <translation>Ne mogu sačuvati prazan fajl, izvini...
+</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageContainer.cpp" line="898"/>
-      <source>Sorry, the directory: %1  does not exist
+        <source>Sorry, the directory: %1  does not exist
 </source>
-      <translation>Izvini, fascikla: %1  ne postoji</translation>
+        <translation>Izvini, fascikla: %1  ne postoji
+</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageContainer.cpp" line="903"/>
-      <source>Sorry, I can't write to the file: %1</source>
-      <translation>Izvini, ne mogu pisati u fajl: %1</translation>
+        <source>Sorry, I can&apos;t write to the file: %1</source>
+        <translation>Izvini, ne mogu pisati u fajl: %1</translation>
     </message>
-  </context>
-  <context>
+    <message>
+        <source>updated...</source>
+        <translation>ažurirano...</translation>
+    </message>
+</context>
+<context>
     <name>nmc::DkImageLoader</name>
     <message>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="852"/>
-      <source>sorry, %1 does not exist anymore...</source>
-      <translation>izvini, %1 ne postoji više...</translation>
+        <source>sorry, %1 does not exist anymore...</source>
+        <translation>izvini, %1 ne postoji više...</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="561"/>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="623"/>
-      <source>You have reached the beginning</source>
-      <translation>Stigli ste na početak</translation>
+        <source>You have reached the beginning</source>
+        <translation>Stigli ste na početak</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="567"/>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="628"/>
-      <source>You have reached the end</source>
-      <translation>Stigli ste na kraj</translation>
+        <source>You have reached the end</source>
+        <translation>Stigli ste na kraj</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="736"/>
-      <source>Save Image</source>
-      <translation>Sačuvaj sliku</translation>
+        <source>Save Image</source>
+        <translation>Sačuvaj sliku</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="736"/>
-      <source>Do you want to save changes to:
+        <source>Do you want to save changes to:
 %1</source>
-      <translation>Da li želite da sačuvate promjene u:
+        <translation>Da li želite da sačuvate promjene u:
 %1</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="948"/>
-      <source>%1 of %2</source>
-      <translation>%1 od %2</translation>
+        <source>%1 of %2</source>
+        <translation>%1 od %2</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="1043"/>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="1121"/>
-      <source>Save File %1</source>
-      <translation>Snimi fajl %1</translation>
+        <source>Save File %1</source>
+        <translation>Snimi fajl %1</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="1108"/>
-      <source>Overwrite File</source>
-      <translation>Piši preko fajla</translation>
+        <source>Overwrite File</source>
+        <translation>Piši preko fajla</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="1109"/>
-      <source>Do you want to overwrite:
+        <source>Do you want to overwrite:
 %1?</source>
-      <translation>Da li želite pisati preko:
+        <translation>Da li želite pisati preko:
 %1?</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="1237"/>
-      <source>Sorry, I cannot save an empty image...</source>
-      <translation>Izvini, ne mogu snimiti praznu sliku...</translation>
+        <source>Sorry, I cannot save an empty image...</source>
+        <translation>Izvini, ne mogu snimiti praznu sliku...</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="1420"/>
-      <source>Rotated</source>
-      <translation>Rotirano</translation>
+        <source>Rotated</source>
+        <translation>Rotirano</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="1684"/>
-      <source>Error</source>
-      <translation>Greška</translation>
+        <source>Error</source>
+        <translation>Greška</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="993"/>
-      <source>Save Directory</source>
-      <translation>Sačuvaj fasciklu</translation>
+        <source>Save Directory</source>
+        <translation>Sačuvaj fasciklu</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="1366"/>
-      <source>%1 deleted...</source>
-      <translation>%1 izbrisano...</translation>
+        <source>%1 deleted...</source>
+        <translation>%1 izbrisano...</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="1370"/>
-      <source>Sorry, I could not delete: %1</source>
-      <translation>Izvini, ne mogu izbrisati: %1</translation>
+        <source>Sorry, I could not delete: %1</source>
+        <translation>Izvini, ne mogu izbrisati: %1</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="196"/>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="232"/>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="268"/>
-      <source>%1 
+        <source>%1 
  does not contain any image</source>
-      <translation>%1 
+        <translation>%1 
  ne sadrži nijednu sliku</translation>
     </message>
-  </context>
-  <context>
-    <name>nmc::DkImageManipulationDialog</name>
-    <message>
-      <location filename="../src/DkGui/DkManipulationWidgets.cpp" line="94"/>
-      <source>Image Manipulation Tools</source>
-      <translation>Alati za manipulaciju slika</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkManipulationWidgets.cpp" line="170"/>
-      <source>&amp;OK</source>
-      <translation>&amp;U redu</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkManipulationWidgets.cpp" line="171"/>
-      <source>&amp;Cancel</source>
-      <translation>&amp;Otkaži</translation>
-    </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkImageStorage</name>
     <message>
-      <location filename="../src/DkLoader/DkImageStorage.cpp" line="1245"/>
-      <source>Anti Aliasing Enabled</source>
-      <translation>Uključen anti-alias</translation>
+        <source>Anti Aliasing Enabled</source>
+        <translation>Uključen anti-alias</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageStorage.cpp" line="1245"/>
-      <source>Anti Aliasing Disabled</source>
-      <translation>Isključen anti-alias</translation>
+        <source>Anti Aliasing Disabled</source>
+        <translation>Isključen anti-alias</translation>
     </message>
-  </context>
-  <context>
-    <name>nmc::DkInstallUpdater</name>
-    <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="228"/>
-      <source>There are new packages available: </source>
-      <translation>Dostupna nova ažuriranja: </translation>
-    </message>
-    <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="235"/>
-      <source>Updates Available</source>
-      <translation>Dostupna ažuriranja</translation>
-    </message>
-    <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="240"/>
-      <source>&amp;Upgrade</source>
-      <translation>&amp;Nadogradi</translation>
-    </message>
-    <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="241"/>
-      <source>Remind Me &amp;Later</source>
-      <translation>Napomeni me &amp;kasnije</translation>
-    </message>
-    <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="242"/>
-      <source>&amp;Skip this Version</source>
-      <translation>%Preskoči ovu verziju</translation>
-    </message>
-    <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="258"/>
-      <source>nomacs Updates</source>
-      <translation>nomacs ažuriranja</translation>
-    </message>
-    <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="258"/>
-      <source>nomacs is up-to-date</source>
-      <translation>nomacs je ažuran</translation>
-    </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkInstalledPluginsModel</name>
     <message>
-      <location filename="../src/DkLoader/DkPluginManager.cpp" line="745"/>
-      <source>Uninstall</source>
-      <translation>Deinstaliraj</translation>
+        <source>Uninstall</source>
+        <translation>Deinstaliraj</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkPluginManager.cpp" line="758"/>
-      <source>Name</source>
-      <translation>Ime</translation>
+        <source>Name</source>
+        <translation>Ime</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkPluginManager.cpp" line="760"/>
-      <source>Version</source>
-      <translation>Verzija</translation>
+        <source>Version</source>
+        <translation>Verzija</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkPluginManager.cpp" line="762"/>
-      <source>Uninstall plugin</source>
-      <translation>Deinstaliraj priključak</translation>
+        <source>Uninstall plugin</source>
+        <translation>Deinstaliraj priključak</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkListWidget</name>
     <message>
-      <location filename="../src/DkGui/DkWidgets.h" line="945"/>
-      <source>Drag Items Here</source>
-      <translation>Prenesi stvari ovdje</translation>
+        <source>Drag Items Here</source>
+        <translation>Prenesi stvari ovdje</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
+    <name>nmc::DkManipulatorWidget</name>
+    <message>
+        <source>Undo</source>
+        <translation>Opozovi</translation>
+    </message>
+    <message>
+        <source>Redo</source>
+        <translation>Ponovi</translation>
+    </message>
+</context>
+<context>
     <name>nmc::DkMessageBox</name>
     <message>
-      <location filename="../src/DkLoader/DkMessageBox.cpp" line="66"/>
-      <source>Error</source>
-      <translation>Greška</translation>
+        <source>Error</source>
+        <translation>Greška</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMessageBox.cpp" line="99"/>
-      <source>Remember my choice</source>
-      <translation>Zapamti moj izbor</translation>
+        <source>Remember my choice</source>
+        <translation>Zapamti moj izbor</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkMetaData</name>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="60"/>
-      <source>Image Size</source>
-      <translation>Veličina slike</translation>
+        <source>Image Size</source>
+        <translation>Veličina slike</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="61"/>
-      <source>Orientation</source>
-      <translation>Orijentacija</translation>
+        <source>Orientation</source>
+        <translation>Orijentacija</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="62"/>
-      <source>Make</source>
-      <translation>Marka</translation>
+        <source>Make</source>
+        <translation>Marka</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="63"/>
-      <source>Model</source>
-      <translation>Model</translation>
+        <source>Model</source>
+        <translation>Model</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="64"/>
-      <source>Aperture Value</source>
-      <translation>Otvor blende</translation>
+        <source>Aperture Value</source>
+        <translation>Otvor blende</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="65"/>
-      <source>ISO</source>
-      <translation>ISO</translation>
+        <source>ISO</source>
+        <translation>ISO</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="66"/>
-      <source>Flash</source>
-      <translation>Blic</translation>
+        <source>Flash</source>
+        <translation>Blic</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="67"/>
-      <source>Focal Length</source>
-      <translation>Fokusna dužina</translation>
+        <source>Focal Length</source>
+        <translation>Fokusna dužina</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="68"/>
-      <source>Exposure Mode</source>
-      <translation>Režim ekspozicije</translation>
+        <source>Exposure Mode</source>
+        <translation>Režim ekspozicije</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="69"/>
-      <source>Exposure Time</source>
-      <translation>Vrijeme ekspozicije</translation>
+        <source>Exposure Time</source>
+        <translation>Vrijeme ekspozicije</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="72"/>
-      <source>Rating</source>
-      <translation>Ocjena</translation>
+        <source>Rating</source>
+        <translation>Ocjena</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="73"/>
-      <source>User Comment</source>
-      <translation>Korisnički komentar</translation>
+        <source>User Comment</source>
+        <translation>Korisnički komentar</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="74"/>
-      <source>Date Time</source>
-      <translation>Datum i vrijeme</translation>
+        <source>Date Time</source>
+        <translation>Datum i vrijeme</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="75"/>
-      <source>Date Time Original</source>
-      <translation>Datum i vrijeme originala</translation>
+        <source>Date Time Original</source>
+        <translation>Datum i vrijeme originala</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="76"/>
-      <source>Image Description</source>
-      <translation>Opis slike</translation>
+        <source>Image Description</source>
+        <translation>Opis slike</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="77"/>
-      <source>Creator</source>
-      <translation>Kreator</translation>
+        <source>Creator</source>
+        <translation>Kreator</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="78"/>
-      <source>Creator Title</source>
-      <translation>Naslov kreatora</translation>
+        <source>Creator Title</source>
+        <translation>Naslov kreatora</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="79"/>
-      <source>City</source>
-      <translation>Grad</translation>
+        <source>City</source>
+        <translation>Grad</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="80"/>
-      <source>Country</source>
-      <translation>Država</translation>
+        <source>Country</source>
+        <translation>Država</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="81"/>
-      <source>Headline</source>
-      <translation>Naslov</translation>
+        <source>Headline</source>
+        <translation>Naslov</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="82"/>
-      <source>Caption</source>
-      <translation>Natpis</translation>
+        <source>Caption</source>
+        <translation>Natpis</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="83"/>
-      <source>Copyright</source>
-      <translation>Autorska prava</translation>
+        <source>Copyright</source>
+        <translation>Autorska prava</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="84"/>
-      <source>Keywords</source>
-      <translation>Ključne rječi</translation>
+        <source>Keywords</source>
+        <translation>Ključne rječi</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="85"/>
-      <source>Path</source>
-      <translation>Putanja</translation>
+        <source>Path</source>
+        <translation>Putanja</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="86"/>
-      <source>File Size</source>
-      <translation>Veličina fajla</translation>
+        <source>File Size</source>
+        <translation>Veličina fajla</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkMetaDataDock</name>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="389"/>
-      <source>Thumbnail</source>
-      <translation>Sličica</translation>
+        <source>Thumbnail</source>
+        <translation>Sličica</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkMetaDataHUD</name>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="682"/>
-      <source>Image Information</source>
-      <translation>Informacije o slici</translation>
+        <source>Image Information</source>
+        <translation>Informacije o slici</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="729"/>
-      <source>Change Entries</source>
-      <translation>Izmjeni upise</translation>
+        <source>Change Entries</source>
+        <translation>Izmjeni upise</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="730"/>
-      <source>You can customize the entries displayed here.</source>
-      <translation>Ovdje možete prilagoditi prikazane upise.</translation>
+        <source>You can customize the entries displayed here.</source>
+        <translation>Ovdje možete prilagoditi prikazane upise.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="733"/>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="1113"/>
-      <source>Number of Columns</source>
-      <translation>Broj kolona</translation>
+        <source>Number of Columns</source>
+        <translation>Broj kolona</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="734"/>
-      <source>Select the desired number of columns.</source>
-      <translation>Izaberite željeni broj kolona.</translation>
+        <source>Select the desired number of columns.</source>
+        <translation>Izaberite željeni broj kolona.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="737"/>
-      <source>Set to Default</source>
-      <translation>Vrati na standardne postavke</translation>
+        <source>Set to Default</source>
+        <translation>Vrati na standardne postavke</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="738"/>
-      <source>Reset the metadata panel.</source>
-      <translation>Resetuj panel o informacijama.</translation>
+        <source>Reset the metadata panel.</source>
+        <translation>Resetuj panel o informacijama.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="742"/>
-      <source>Show Left</source>
-      <translation>Prikaži lijevo</translation>
+        <source>Show Left</source>
+        <translation>Prikaži lijevo</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="743"/>
-      <source>Shows the Metadata on the Left</source>
-      <translation>Prikazuje informacije lijevo</translation>
+        <source>Shows the Metadata on the Left</source>
+        <translation>Prikazuje informacije lijevo</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="746"/>
-      <source>Show Top</source>
-      <translation>Prikaži gore</translation>
+        <source>Show Top</source>
+        <translation>Prikaži gore</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="747"/>
-      <source>Shows the Metadata at the Top</source>
-      <translation>Prikazuje informacije na vrhu</translation>
+        <source>Shows the Metadata at the Top</source>
+        <translation>Prikazuje informacije na vrhu</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="750"/>
-      <source>Show Right</source>
-      <translation>Prikaži desno</translation>
+        <source>Show Right</source>
+        <translation>Prikaži desno</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="751"/>
-      <source>Shows the Metadata on the Right</source>
-      <translation>Prikazuje informacije desno</translation>
+        <source>Shows the Metadata on the Right</source>
+        <translation>Prikazuje informacije desno</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="754"/>
-      <source>Show Bottom</source>
-      <translation>Prikaži dole</translation>
+        <source>Show Bottom</source>
+        <translation>Prikaži dole</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="755"/>
-      <source>Shows the Metadata at the Bottom</source>
-      <translation>Prikazuje informacije na dnu</translation>
+        <source>Shows the Metadata at the Bottom</source>
+        <translation>Prikazuje informacije na dnu</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="1030"/>
-      <source>Metadata Menu</source>
-      <translation>Meni sa informacijama</translation>
+        <source>Metadata Menu</source>
+        <translation>Meni sa informacijama</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="1092"/>
-      <source>&amp;OK</source>
-      <translation>&amp;U redu</translation>
+        <source>&amp;OK</source>
+        <translation>&amp;U redu</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="1093"/>
-      <source>&amp;Cancel</source>
-      <translation>&amp;Otkaži</translation>
+        <source>&amp;Cancel</source>
+        <translation>&amp;Otkaži</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="1113"/>
-      <source>Number of columns (-1 is default)</source>
-      <translation>Broj kolona (obično -1)</translation>
+        <source>Number of columns (-1 is default)</source>
+        <translation>Broj kolona (obično -1)</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkMetaDataModel</name>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="64"/>
-      <source>Key</source>
-      <translation>Ključ</translation>
+        <source>Key</source>
+        <translation>Ključ</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="64"/>
-      <source>Value</source>
-      <translation>Vrijednost</translation>
+        <source>Value</source>
+        <translation>Vrijednost</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="146"/>
-      <source>Data.</source>
-      <translation>Podaci.</translation>
+        <source>Data.</source>
+        <translation>Podaci.</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkMetaDataSelection</name>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="550"/>
-      <source>Check All</source>
-      <translation>Provjeri sve</translation>
+        <source>Check All</source>
+        <translation>Provjeri sve</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkMosaicDialog</name>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3207"/>
-      <source>Create Mosaic Image</source>
-      <translation>Kreiraj mozaik</translation>
+        <source>Create Mosaic Image</source>
+        <translation>Kreiraj mozaik</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3270"/>
-      <source>Darken</source>
-      <translation>Tamnije</translation>
+        <source>Darken</source>
+        <translation>Tamnije</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3271"/>
-      <source>Lighten</source>
-      <translation>Svijetlije</translation>
+        <source>Lighten</source>
+        <translation>Svijetlije</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3272"/>
-      <source>Saturation</source>
-      <translation>Zasićenje</translation>
+        <source>Saturation</source>
+        <translation>Zasićenje</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3280"/>
-      <source>Mosaic Image:</source>
-      <translation>Mozaik:</translation>
+        <source>Mosaic Image:</source>
+        <translation>Mozaik:</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3283"/>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3293"/>
-      <source>&amp;Browse</source>
-      <translation>&amp;Pregledaj</translation>
+        <source>&amp;Browse</source>
+        <translation>&amp;Pregledaj</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3285"/>
-      <source>Choose which image to mosaic.</source>
-      <translation>Izaberi sliku za stvaranja mozaika.</translation>
+        <source>Choose which image to mosaic.</source>
+        <translation>Izaberi sliku za stvaranja mozaika.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3287"/>
-      <source>No Image loaded</source>
-      <translation>Slike nisu učitane</translation>
+        <source>No Image loaded</source>
+        <translation>Slike nisu učitane</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3290"/>
-      <source>Image Database:</source>
-      <translation>Baza sa slikama:</translation>
+        <source>Image Database:</source>
+        <translation>Baza sa slikama:</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3295"/>
-      <source>Specify the root folder of the image database.</source>
-      <translation>Izaberi izvorni direktorij za bazu slika.</translation>
+        <source>Specify the root folder of the image database.</source>
+        <translation>Izaberi izvorni direktorij za bazu slika.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3297"/>
-      <source>Specify an Image Database</source>
-      <translation>Izaberite bazu podataka sa slikama</translation>
+        <source>Specify an Image Database</source>
+        <translation>Izaberite bazu podataka sa slikama</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3300"/>
-      <source>Resolution:</source>
-      <translation>Rezolucija:</translation>
+        <source>Resolution:</source>
+        <translation>Rezolucija:</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3304"/>
-      <source>Pixel Width</source>
-      <translation>Širina piksela</translation>
+        <source>Pixel Width</source>
+        <translation>Širina piksela</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3309"/>
-      <source>Pixel Height</source>
-      <translation>Visina piksela</translation>
+        <source>Pixel Height</source>
+        <translation>Visina piksela</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3316"/>
-      <source>Patches:</source>
-      <translation>Zakrpe:</translation>
+        <source>Patches:</source>
+        <translation>Zakrpe:</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3320"/>
-      <source>Number of Horizontal Patches</source>
-      <translation>Broj horizontalnih zakrpa</translation>
+        <source>Number of Horizontal Patches</source>
+        <translation>Broj horizontalnih zakrpa</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3325"/>
-      <source>Number of Vertical Patches</source>
-      <translation>Broj vertikalnih zakrpa</translation>
+        <source>Number of Vertical Patches</source>
+        <translation>Broj vertikalnih zakrpa</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3330"/>
-      <source>If this label turns red, the computation might be slower.</source>
-      <translation>Ako pocrveni, proračun može biti sporiji.</translation>
+        <source>If this label turns red, the computation might be slower.</source>
+        <translation>Ako pocrveni, proračun može biti sporiji.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3333"/>
-      <source>Filters:</source>
-      <translation>Filteri:</translation>
+        <source>Filters:</source>
+        <translation>Filteri:</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3338"/>
-      <source>You can split multiple ignore words with ;</source>
-      <translation>Možete izabrati više rječi za zanemarivanje pomoću ;</translation>
+        <source>You can split multiple ignore words with ;</source>
+        <translation>Možete izabrati više rječi za zanemarivanje pomoću ;</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3342"/>
-      <source>All Images</source>
-      <translation>Sve slike</translation>
+        <source>All Images</source>
+        <translation>Sve slike</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3391"/>
-      <source>&amp;Save</source>
-      <translation>&amp;Sačuvaj</translation>
+        <source>&amp;Save</source>
+        <translation>&amp;Sačuvaj</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3392"/>
-      <source>&amp;Generate</source>
-      <translation>&amp;Generiši</translation>
+        <source>&amp;Generate</source>
+        <translation>&amp;Generiši</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3393"/>
-      <source>&amp;Cancel</source>
-      <translation>&amp;Otkaži</translation>
+        <source>&amp;Cancel</source>
+        <translation>&amp;Otkaži</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3413"/>
-      <source>Open TIFF</source>
-      <translation>Otvori TIFF</translation>
+        <source>Open TIFF</source>
+        <translation>Otvori TIFF</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3423"/>
-      <source>Open an Image Directory</source>
-      <translation>Otvori fasciklu sa slikama</translation>
+        <source>Open an Image Directory</source>
+        <translation>Otvori fasciklu sa slikama</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3444"/>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3456"/>
-      <source>%1 x %2 cm @150 dpi</source>
-      <translation>%1 × %2 cm @150-dpi</translation>
+        <source>%1 x %2 cm @150 dpi</source>
+        <translation>%1 × %2 cm @150-dpi</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3501"/>
-      <source>Patch Resolution: %1 px</source>
-      <translation>Zakrpi rezoluciju: %1 px</translation>
+        <source>Patch Resolution: %1 px</source>
+        <translation>Zakrpi rezoluciju: %1 px</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3699"/>
-      <source>Filling empty areas...</source>
-      <translation>Popunjava prazna područja...</translation>
+        <source>Filling empty areas...</source>
+        <translation>Popunjava prazna područja...</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3703"/>
-      <source>I need to use some images twice - maybe the database is too small?</source>
-      <translation>Potrebno koristiti neke slike dva puta - da li je baza slika premala?</translation>
+        <source>I need to use some images twice - maybe the database is too small?</source>
+        <translation>Potrebno koristiti neke slike dva puta - da li je baza slika premala?</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3708"/>
-      <source>Sorry, it seems that i cannot create your mosaic with this database.</source>
-      <translation>Izvini, izgleda da ne mogu kreirati Vaš mozaik sa ovom bazom.</translation>
+        <source>Sorry, it seems that i cannot create your mosaic with this database.</source>
+        <translation>Izvini, izgleda da ne mogu kreirati Vaš mozaik sa ovom bazom.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3832"/>
-      <source>Something is seriously wrong, I could not load: %1</source>
-      <translation>Nešto je pošlo po zlu, ne mogu učitati: %1</translation>
+        <source>Something is seriously wrong, I could not load: %1</source>
+        <translation>Nešto je pošlo po zlu, ne mogu učitati: %1</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4079"/>
-      <source>Error</source>
-      <translation>Greška</translation>
+        <source>Error</source>
+        <translation>Greška</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4079"/>
-      <source>Sorry, I could not mix the image...</source>
-      <translation>Izvini, ne mogu spojiti sliku...</translation>
+        <source>Sorry, I could not mix the image...</source>
+        <translation>Izvini, ne mogu spojiti sliku...</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkNoMacs</name>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="248"/>
-      <source>Edit</source>
-      <translation>Uredi</translation>
+        <source>&amp;Sync</source>
+        <translation>&amp;Sinhronizacija</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="361"/>
-      <source>&amp;Sync</source>
-      <translation>&amp;Sinhronizacija</translation>
+        <source>Movie Toolbar</source>
+        <translation>Alatna traka za video</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="295"/>
-      <source>Movie Toolbar</source>
-      <translation>Alatna traka za video</translation>
+        <source>Pl&amp;ugins</source>
+        <translation>P&amp;riključci</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="365"/>
-      <source>Pl&amp;ugins</source>
-      <translation>P&amp;riključci</translation>
+        <source>Quit nomacs</source>
+        <translation>Napusti nomacs</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="626"/>
-      <source>Quit nomacs</source>
-      <translation>Napusti nomacs</translation>
+        <source>Do you want nomacs to save your tabs?</source>
+        <translation>Da li želite da nomacs sačuva kartice?</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="627"/>
-      <source>Do you want nomacs to save your tabs?</source>
-      <translation>Da li želite da nomacs sačuva kartice?</translation>
+        <source>&amp;Save and Quit</source>
+        <translation>&amp;Sačuvaj i napusti</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="629"/>
-      <source>&amp;Save and Quit</source>
-      <translation>&amp;Sačuvaj i napusti</translation>
+        <source>&amp;Quit</source>
+        <translation>&amp;Napusti</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="630"/>
-      <source>&amp;Quit</source>
-      <translation>&amp;Napusti</translation>
+        <source>Recursive Folder Scan is Now Enabled</source>
+        <translation>Rekurzivno skeniranje fascikli je sad uključeno</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="815"/>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="833"/>
-      <source>Sorry, I cannot Flip the Image...</source>
-      <translation>Izvini, ne mogu prevrnuti sliku...</translation>
+        <source>Recursive Folder Scan is Now Disabled</source>
+        <translation>Rekurzivno skeniranje fascikli je sad isključeno</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="817"/>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="835"/>
-      <source>Flipped</source>
-      <translation>Obrnuto</translation>
+        <source>Change Opacity</source>
+        <translation>Promjeni providnost</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="852"/>
-      <source>Sorry, I cannot Invert the Image...</source>
-      <translation>Izvini, ne mogu obrnuti sliku...</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="854"/>
-      <source>Inverted</source>
-      <translation>Izvrnuto</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="897"/>
-      <source>Sorry, I cannot convert the Image...</source>
-      <translation>Izvini, ne mogu konvertovati sliku...</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="899"/>
-      <source>Grayscale</source>
-      <translation>Crno-bijelo</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="916"/>
-      <source>The Image is Already Normalized...</source>
-      <translation>Slika je već normalizovana...</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="918"/>
-      <source>Normalized</source>
-      <translation>Normalizovano</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="935"/>
-      <source>Sorry, I cannot Auto Adjust</source>
-      <translation>Izvini, ne mogu automatski podesiti</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="937"/>
-      <source>Auto Adjust</source>
-      <translation>&amp;Automatsko podešavanje</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="949"/>
-      <source>Unsharp Mask</source>
-      <translation>&amp;Maska za izoštravanje</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="969"/>
-      <source>Tiny Planet</source>
-      <translation>Mala planeta</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1136"/>
-      <source>Recursive Folder Scan is Now Enabled</source>
-      <translation>Rekurzivno skeniranje fascikli je sad uključeno</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1138"/>
-      <source>Recursive Folder Scan is Now Disabled</source>
-      <translation>Rekurzivno skeniranje fascikli je sad isključeno</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1147"/>
-      <source>Change Opacity</source>
-      <translation>Promjeni providnost</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1222"/>
-      <source>Window Locked
+        <source>Window Locked
 To unlock: gain focus (ALT+Tab),
 then press CTRL+SHIFT+ALT+B</source>
-      <translation>Prozor zaključan
+        <translation>Prozor zaključan
 Za otključavanje: pritisnite (Alt+Tab),
 pa onda CTRL+SHIFT+ALT+B</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1225"/>
-      <source>You should first reduce opacity
+        <source>You should first reduce opacity
  before working through the window.</source>
-      <translation>Prvo treba da smanjite providnost
+        <translation>Prvo treba da smanjite providnost
  prije rada kroz prozor.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1316"/>
-      <source>File Explorer</source>
-      <translation>Pregledač fajlova</translation>
+        <source>File Explorer</source>
+        <translation>Pregledač fajlova</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1344"/>
-      <source>Meta Data Info</source>
-      <translation>Meta podaci</translation>
+        <source>Meta Data Info</source>
+        <translation>Meta podaci</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1362"/>
-      <source>History</source>
-      <translation>Historija</translation>
+        <source>History</source>
+        <translation>Historija</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1400"/>
-      <source>Thumbnails</source>
-      <translation>Sličice</translation>
+        <source>Thumbnails</source>
+        <translation>Sličice</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1437"/>
-      <source>Open an Image Directory</source>
-      <translation>Otvori fasciklu sa slikama</translation>
+        <source>Open an Image Directory</source>
+        <translation>Otvori fasciklu sa slikama</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1455"/>
-      <source>All Files (*.*)</source>
-      <translation>Svi fajlovi (*.*)</translation>
+        <source>All Files (*.*)</source>
+        <translation>Svi fajlovi (*.*)</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1458"/>
-      <source>Open Image</source>
-      <translation>Otvori sliku</translation>
+        <source>Open Image</source>
+        <translation>Otvori sliku</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1522"/>
-      <source>Sorry, the directory: %1  does not exist
+        <source>Sorry, the directory: %1  does not exist
 </source>
-      <translation>Izvini, fascikla: %1  ne postoji</translation>
+        <translation>Izvini, fascikla: %1  ne postoji
+</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1535"/>
-      <source>Rename:</source>
-      <translation>Preimenuj:</translation>
+        <source>Rename:</source>
+        <translation>Preimenuj:</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1550"/>
-      <source>Question</source>
-      <translation>Pitanje</translation>
+        <source>Question</source>
+        <translation>Pitanje</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1565"/>
-      <source>Sorry, I can't delete: %1</source>
-      <translation>Izvini, ne mogu izbrisati: %1</translation>
+        <source>Sorry, I can&apos;t delete: %1</source>
+        <translation>Izvini, ne mogu izbrisati: %1</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1580"/>
-      <source>Sorry, I can't rename: %1</source>
-      <translation>Izvini, ne mogu preimenovati: %1</translation>
+        <source>Sorry, I can&apos;t rename: %1</source>
+        <translation>Izvini, ne mogu preimenovati: %1</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1660"/>
-      <source>Go To Image</source>
-      <translation>Idi na sliku</translation>
+        <source>Go To Image</source>
+        <translation>Idi na sliku</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1660"/>
-      <source>Image Index:</source>
-      <translation>Indeks slike:</translation>
+        <source>Image Index:</source>
+        <translation>Indeks slike:</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1765"/>
-      <source>Resize</source>
-      <translation>Promijeni veličinu</translation>
+        <source>Resize</source>
+        <translation>Promijeni veličinu</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1789"/>
-      <source>Shall I move %1 to trash?</source>
-      <translation>Da li da prebacim %1 u otpad?</translation>
+        <source>Shall I move %1 to trash?</source>
+        <translation>Da li da prebacim %1 u otpad?</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1791"/>
-      <source>Do you want to permanently delete %1?</source>
-      <translation>Da li želite trajno da izbrišete %1?</translation>
+        <source>Do you want to permanently delete %1?</source>
+        <translation>Da li želite trajno da izbrišete %1?</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1796"/>
-      <source>Delete File</source>
-      <translation>Izbriši fajl</translation>
+        <source>Delete File</source>
+        <translation>Izbriši fajl</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1836"/>
-      <source>Mosaic</source>
-      <translation>Mozaik</translation>
+        <source>Mosaic</source>
+        <translation>Mozaik</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1866"/>
-      <source>Adjusted</source>
-      <translation>Prilagođeno</translation>
+        <source>Sorry, I could not create a wallpaper...</source>
+        <translation>Izvini, ne mogu napraviti pozadinu...</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1886"/>
-      <source>Sorry, I could not create a wallpaper...</source>
-      <translation>Izvini, ne mogu napraviti pozadinu...</translation>
+        <source>Save Thumbnails</source>
+        <translation>Sačuvaj sličice</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1930"/>
-      <source>Save Thumbnails</source>
-      <translation>Sačuvaj sličice</translation>
+        <source> [Private Mode]</source>
+        <translation> [Privatni režim]</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="2315"/>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="2331"/>
-      <source> [Private Mode]</source>
-      <translation>[Privatni režim]</translation>
+        <source>Already downloading update</source>
+        <translation>Već preuzimam ažuriranje</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="2413"/>
-      <source>Already downloading update</source>
-      <translation>Već preuzimam ažuriranje</translation>
+        <source>Downloading update...</source>
+        <translation>Preuzimam ažuriranje...</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="2440"/>
-      <source>Downloading update...</source>
-      <translation>Preuzimam ažuriranje...</translation>
+        <source>Cancel Update</source>
+        <translation>Otkaži ažuriranje</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="2440"/>
-      <source>Cancel Update</source>
-      <translation>Otkaži ažuriranje</translation>
+        <source>Unable to install new version&lt;br&gt;</source>
+        <translation>Nemoguće instalirati novu verziju&lt;br&gt;</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="2474"/>
-      <source>Unable to install new version&lt;br&gt;</source>
-      <translation>Nemoguće instalirati novu verziju&lt;br&gt;</translation>
+        <source>You can download the new version from our web page</source>
+        <translation>Možete preuzeti novu verziju sa naše internet stranice</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="2475"/>
-      <source>You can download the new version from our web page</source>
-      <translation>Možete preuzeti novu verziju sa naše internet stranice</translation>
+        <source>Error</source>
+        <translation>Greška</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1886"/>
-      <source>Error</source>
-      <translation>Greška</translation>
+        <source>Sorry, I can&apos;t write to the fileInfo: %1</source>
+        <translation>Izvini, ne mogu pisati u fajl: %1</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1526"/>
-      <source>Sorry, I can't write to the fileInfo: %1</source>
-      <translation>Izvini, ne mogu pisati u fajl: %1</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1551"/>
-      <source>The fileInfo: %1  already exists.
+        <source>The fileInfo: %1  already exists.
  Do you want to replace it?</source>
-      <translation>Fajl: %1 već postoji.
+        <translation>Fajl: %1 već postoji.
  Da li želite da ga zamjenite?</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="2489"/>
-      <source>Downloading new translations...</source>
-      <translation>Preuzimam nove prevode...</translation>
+        <source>Downloading new translations...</source>
+        <translation>Preuzimam nove prevode...</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="2489"/>
-      <source>Cancel</source>
-      <translation>Otkaži</translation>
+        <source>Cancel</source>
+        <translation>Otkaži</translation>
     </message>
-  </context>
-  <context>
+    <message>
+        <source>Edit Toolbar</source>
+        <translation>Uredi altanu traku</translation>
+    </message>
+    <message>
+        <source>Edit Image</source>
+        <translation>Uredi sliku</translation>
+    </message>
+    <message>
+        <source>The following duplicates were not added:</source>
+        <translation>Sljedeći duplikati nisu dodani:</translation>
+    </message>
+    <message>
+        <source>Text file (*.txt)</source>
+        <translation>Tekstualni fajl (*.txt)</translation>
+    </message>
+    <message>
+        <source>All files (*.*)</source>
+        <translation>Svi fajlovi (*.*)</translation>
+    </message>
+    <message>
+        <source>Save Tab List</source>
+        <translation>Snimi listu kartica</translation>
+    </message>
+</context>
+<context>
     <name>nmc::DkNoMacsSync</name>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="2861"/>
-      <source>Sorry, I could not find any clients.</source>
-      <translation>Izvini, ne mogu pronaći klijente.</translation>
+        <source>Sorry, I could not find any clients.</source>
+        <translation>Izvini, ne mogu pronaći klijente.</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkOpacityDialog</name>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2502"/>
-      <source>Window Opacity</source>
-      <translation>Providnost prozora</translation>
+        <source>Window Opacity</source>
+        <translation>Providnost prozora</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2507"/>
-      <source>&amp;OK</source>
-      <translation>&amp;U redu</translation>
+        <source>&amp;OK</source>
+        <translation>&amp;U redu</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2508"/>
-      <source>&amp;Cancel</source>
-      <translation>&amp;Otkaži</translation>
+        <source>&amp;Cancel</source>
+        <translation>&amp;Otkaži</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkPlayer</name>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="1256"/>
-      <source>Show previous image</source>
-      <translation>Prikaži prethodnu sliku</translation>
+        <source>Show previous image</source>
+        <translation>Prikaži prethodnu sliku</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="1268"/>
-      <source>Play/Pause</source>
-      <translation>Pusti/Pauziraj</translation>
+        <source>Play/Pause</source>
+        <translation>Reprodukuj/Pauziraj</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="1280"/>
-      <source>Show next image</source>
-      <translation>Prikaži sljedeću sliku</translation>
+        <source>Show next image</source>
+        <translation>Prikaži sljedeću sliku</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="1323"/>
-      <source>play</source>
-      <translation>pusti</translation>
+        <source>play</source>
+        <translation>pusti</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkPluginContainer</name>
     <message>
-      <location filename="../src/DkLoader/DkPluginManager.cpp" line="395"/>
-      <source>Author:</source>
-      <translation>Autor:</translation>
+        <source>Author:</source>
+        <translation>Autor:</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkPluginManager.cpp" line="396"/>
-      <source>Company:</source>
-      <translation>Kompanija:</translation>
+        <source>Company:</source>
+        <translation>Kompanija:</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkPluginManager.cpp" line="397"/>
-      <source>Created:</source>
-      <translation>Kreirano:</translation>
+        <source>Created:</source>
+        <translation>Kreirano:</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkPluginManager.cpp" line="398"/>
-      <source>Last Modified:</source>
-      <translation>Posljednja izmjena:</translation>
+        <source>Last Modified:</source>
+        <translation>Posljednja izmjena:</translation>
     </message>
-    <message>
-      <location filename="../src/DkLoader/DkPluginManager.cpp" line="399"/>
-      <source>Dependencies:</source>
-      <translation>Ovisnosti:</translation>
-    </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkPluginManagerDialog</name>
     <message>
-      <location filename="../src/DkLoader/DkPluginManager.cpp" line="507"/>
-      <source>Plugin Manager</source>
-      <translation>Upravljač priključaka</translation>
+        <source>Plugin Manager</source>
+        <translation>Upravljač priključaka</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkPluginManager.cpp" line="519"/>
-      <source>&amp;Close</source>
-      <translation>&amp;Zatvori</translation>
+        <source>&amp;Close</source>
+        <translation>&amp;Zatvori</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkPluginTableWidget</name>
     <message>
-      <location filename="../src/DkLoader/DkPluginManager.cpp" line="581"/>
-      <source>Search plugins</source>
-      <translation>Pretraži priključke</translation>
+        <source>Search plugins</source>
+        <translation>Pretraži priključke</translation>
     </message>
-    <message>
-      <location filename="../src/DkLoader/DkPluginManager.cpp" line="584"/>
-      <source>Add or Remove Plugins</source>
-      <translation>Dodaj ili ukloni priključke</translation>
-    </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkPongPort</name>
     <message>
-      <location filename="../src/DkGui/DkPong.cpp" line="336"/>
-      <source>PAUSED</source>
-      <translation>PAUZIRANO</translation>
+        <source>PAUSED</source>
+        <translation>PAUZIRANO</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPong.cpp" line="337"/>
-      <source>Press &lt;SPACE&gt; to start.</source>
-      <translation>Pritisni &lt;SPACE&gt; za početak.</translation>
+        <source>Press &lt;SPACE&gt; to start.</source>
+        <translation>Pritisni &lt;SPACE&gt; za početak.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPong.cpp" line="485"/>
-      <source>%1 won!</source>
-      <translation>%1 je pobijedio!</translation>
+        <source>%1 won!</source>
+        <translation>%1 je pobijedio!</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPong.cpp" line="486"/>
-      <source>Hit &lt;SPACE&gt; to start a new Game</source>
-      <translation>Pritisni &lt;SPACE&gt; za novu igru</translation>
+        <source>Hit &lt;SPACE&gt; to start a new Game</source>
+        <translation>Pritisni &lt;SPACE&gt; za novu igru</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkPreferenceWidget</name>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="65"/>
-      <source>next</source>
-      <translation>sljedeće</translation>
+        <source>next</source>
+        <translation>sljedeće</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="70"/>
-      <source>previous</source>
-      <translation>prethodno</translation>
+        <source>previous</source>
+        <translation>prethodno</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="89"/>
-      <source>Restart nomacs</source>
-      <translation>Ponovo pokreni nomacs</translation>
+        <source>Restart nomacs</source>
+        <translation>Ponovo pokreni nomacs</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkPrintPreviewDialog</name>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2186"/>
-      <source>Fit Width</source>
-      <translation>Prilagodi širinu</translation>
+        <source>Fit Width</source>
+        <translation>Prilagodi širinu</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2187"/>
-      <source>Fit Page</source>
-      <translation>Prilagodi stranici</translation>
+        <source>Fit Page</source>
+        <translation>Prilagodi stranici</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2197"/>
-      <source>Zoom in</source>
-      <translation>Uvećaj</translation>
+        <source>Zoom in</source>
+        <translation>Uvećaj</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2199"/>
-      <source>Zoom out</source>
-      <translation>Smanji</translation>
+        <source>Zoom out</source>
+        <translation>Smanji</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2204"/>
-      <source>Portrait</source>
-      <translation>Portret</translation>
+        <source>Portrait</source>
+        <translation>Portret</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2205"/>
-      <source>Landscape</source>
-      <translation>Pejzaž</translation>
+        <source>Landscape</source>
+        <translation>Pejzaž</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2216"/>
-      <source>Print</source>
-      <translation>Štampaj</translation>
+        <source>Print</source>
+        <translation>Štampaj</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2217"/>
-      <source>Page setup</source>
-      <translation>Podešavanje stranice</translation>
+        <source>Page setup</source>
+        <translation>Podešavanje stranice</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2222"/>
-      <source>Reset dpi</source>
-      <translation>Resetuj dpi</translation>
+        <source>Reset dpi</source>
+        <translation>Resetuj dpi</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2243"/>
-      <source>keep ALT key pressed to zoom with the mouse wheel</source>
-      <translation>držite ALT dugme pritisnuto za uvećavanje pomoću miša</translation>
+        <source>keep ALT key pressed to zoom with the mouse wheel</source>
+        <translation>držite ALT dugme pritisnuto za uvećavanje pomoću miša</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2084"/>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2265"/>
-      <source>Print Preview</source>
-      <translation>Pregled prije štampanja</translation>
+        <source>Print Preview</source>
+        <translation>Pregled prije štampanja</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
+    <name>nmc::DkProfileSummaryWidget</name>
+    <message>
+        <source>Summary: </source>
+        <translation>Sažetak: </translation>
+    </message>
+    <message>
+        <source>Files</source>
+        <translation>Fajlovi</translation>
+    </message>
+    <message>
+        <source>Input</source>
+        <translation>Ulaz</translation>
+    </message>
+    <message>
+        <source>Output</source>
+        <translation>Izlaz</translation>
+    </message>
+    <message>
+        <source>Functions</source>
+        <translation>Funkcije</translation>
+    </message>
+    <message>
+        <source>Update</source>
+        <translation>Ažuriraj</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation>Izbriši</translation>
+    </message>
+    <message>
+        <source>Export</source>
+        <translation>Izvezi</translation>
+    </message>
+</context>
+<context>
+    <name>nmc::DkProfileWidget</name>
+    <message>
+        <source>Create New Profile</source>
+        <translation>Napravi novi profil</translation>
+    </message>
+    <message>
+        <source>Apply Default</source>
+        <translation>Prihvati zadano</translation>
+    </message>
+    <message>
+        <source>inactive</source>
+        <translation>neaktivno</translation>
+    </message>
+    <message>
+        <source>Default</source>
+        <translation>Zadano</translation>
+    </message>
+    <message>
+        <source>Deleting Profile</source>
+        <translation>Brišem profil</translation>
+    </message>
+    <message>
+        <source>Sorry, I cannot delete %1</source>
+        <translation>Žao nam je, nemoguće izbrisati %1</translation>
+    </message>
+    <message>
+        <source>Export Batch Profile</source>
+        <translation>Izvezi grupni profil</translation>
+    </message>
+    <message>
+        <source>nomacs Batch Profile (*.%1)</source>
+        <translation>nomacs grupni profil (*.%1)</translation>
+    </message>
+    <message>
+        <source>Profile Name</source>
+        <translation>Ime profila</translation>
+    </message>
+    <message>
+        <source>Profile Name:</source>
+        <translation>Ime profila:</translation>
+    </message>
+    <message>
+        <source>Profile Already Exists</source>
+        <translation>Profil već postoji</translation>
+    </message>
+    <message>
+        <source>Do you want to overwrite %1?</source>
+        <translation>Da li želite da snimite preko %1?</translation>
+    </message>
+</context>
+<context>
     <name>nmc::DkQuickAccessEdit</name>
     <message>
-      <location filename="../src/DkGui/DkQuickAccess.cpp" line="139"/>
-      <source>Quick Launch (%1)</source>
-      <translation>Brzo pokreni (%1)</translation>
+        <source>Quick Launch (%1)</source>
+        <translation>Brzo pokreni (%1)</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkRatingLabel</name>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="1018"/>
-      <source>one star</source>
-      <translation>jedna zvijezda</translation>
+        <source>one star</source>
+        <translation>jedna zvijezda</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="1022"/>
-      <source>two stars</source>
-      <translation>svije zvijezde</translation>
+        <source>two stars</source>
+        <translation>svije zvijezde</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="1026"/>
-      <source>three star</source>
-      <translation>tri zvijezde</translation>
+        <source>three star</source>
+        <translation>tri zvijezde</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="1030"/>
-      <source>four star</source>
-      <translation>četiri zvijezde</translation>
+        <source>four star</source>
+        <translation>četiri zvijezde</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="1034"/>
-      <source>five star</source>
-      <translation>pet zvijezda</translation>
+        <source>five star</source>
+        <translation>pet zvijezda</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkRatingLabelBg</name>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="1055"/>
-      <source>no rating</source>
-      <translation>bez ocjene</translation>
+        <source>no rating</source>
+        <translation>bez ocjene</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="1059"/>
-      <source>one star</source>
-      <translation>jedna zvijezda</translation>
+        <source>one star</source>
+        <translation>jedna zvijezda</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="1063"/>
-      <source>two stars</source>
-      <translation>svije zvijezde</translation>
+        <source>two stars</source>
+        <translation>svije zvijezde</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="1067"/>
-      <source>three stars</source>
-      <translation>tri zvijezde</translation>
+        <source>three stars</source>
+        <translation>tri zvijezde</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="1071"/>
-      <source>four stars</source>
-      <translation>četiri zvijezde</translation>
+        <source>four stars</source>
+        <translation>četiri zvijezde</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="1075"/>
-      <source>five stars</source>
-      <translation>pet zvijezda</translation>
+        <source>five stars</source>
+        <translation>pet zvijezda</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkResizeDialog</name>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="850"/>
-      <source>Resize Image</source>
-      <translation>Promjeni veličinu slike</translation>
+        <source>Resize Image</source>
+        <translation>Promjeni veličinu slike</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="869"/>
-      <source>Original</source>
-      <translation>Originalna</translation>
+        <source>Original</source>
+        <translation>Originalna</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="871"/>
-      <source>New</source>
-      <translation>Nova</translation>
+        <source>New</source>
+        <translation>Nova</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="900"/>
-      <location filename="../src/DkGui/DkDialog.cpp" line="937"/>
-      <source>Width: </source>
-      <translation>Širina: </translation>
+        <source>Width: </source>
+        <translation>Širina: </translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="913"/>
-      <location filename="../src/DkGui/DkDialog.cpp" line="952"/>
-      <source>Height: </source>
-      <translation>Visina: </translation>
+        <source>Height: </source>
+        <translation>Visina: </translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="978"/>
-      <source>Resolution: </source>
-      <translation>Rezolucija: </translation>
+        <source>Resolution: </source>
+        <translation>Rezolucija: </translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="987"/>
-      <source>pixel/inch</source>
-      <translation>piksel/inč</translation>
+        <source>pixel/inch</source>
+        <translation>piksel/inč</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="988"/>
-      <source>pixel/cm</source>
-      <translation>piksel/cm</translation>
+        <source>pixel/cm</source>
+        <translation>piksel/cm</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="999"/>
-      <source>Resample Image:</source>
-      <translation>Izmjeni uzorak:</translation>
+        <source>Resample Image:</source>
+        <translation>Izmjeni uzorak:</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1006"/>
-      <source>Nearest Neighbor</source>
-      <translation>Najbliži susjed</translation>
+        <source>Nearest Neighbor</source>
+        <translation>Najbliži susjed</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1007"/>
-      <source>Area (best for downscaling)</source>
-      <translation>Oblast (najbolje za smanjivanje)</translation>
+        <source>Area (best for downscaling)</source>
+        <translation>Oblast (najbolje za smanjivanje)</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1008"/>
-      <source>Linear</source>
-      <translation>Linearno</translation>
+        <source>Linear</source>
+        <translation>Linearno</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1009"/>
-      <source>Bicubic (4x4 pixel interpolation)</source>
-      <translation>Bikubično (4×4 pikselna interpolacija)</translation>
+        <source>Bicubic (4x4 pixel interpolation)</source>
+        <translation>Bikubično (4×4 pikselna interpolacija)</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1010"/>
-      <source>Lanczos (8x8 pixel interpolation)</source>
-      <translation>Lanczos (8×8 pikselna interpolacija)</translation>
+        <source>Lanczos (8x8 pixel interpolation)</source>
+        <translation>Lanczos (8×8 pikselna interpolacija)</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1019"/>
-      <source>Gamma Correction</source>
-      <translation>Korekcija game</translation>
+        <source>Gamma Correction</source>
+        <translation>Korekcija game</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1030"/>
-      <source>&amp;OK</source>
-      <translation>&amp;U redu</translation>
+        <source>&amp;OK</source>
+        <translation>&amp;U redu</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1031"/>
-      <source>&amp;Cancel</source>
-      <translation>&amp;Otkaži</translation>
+        <source>&amp;Cancel</source>
+        <translation>&amp;Otkaži</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1418"/>
-      <source>Sorry, but the image size %1 x %2 is illegal.</source>
-      <translation>Izvini, ali veličina slike %1 × %2 je nedozvoljena.</translation>
+        <source>Sorry, but the image size %1 x %2 is illegal.</source>
+        <translation>Izvini, ali veličina slike %1 × %2 je nedozvoljena.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1430"/>
-      <source>Sorry, the image is too large: %1</source>
-      <translation>Izvini, slika je prevelika: %1</translation>
+        <source>Sorry, the image is too large: %1</source>
+        <translation>Izvini, slika je prevelika: %1</translation>
     </message>
-  </context>
-  <context>
-    <name>nmc::DkSaturation</name>
+</context>
+<context>
+    <name>nmc::DkRotateWidget</name>
     <message>
-      <location filename="../src/DkGui/DkManipulationWidgets.cpp" line="1063"/>
-      <source>Saturation</source>
-      <translation>Zasićenje</translation>
+        <source>Angle</source>
+        <translation>Ugao</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkSearchDialog</name>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="592"/>
-      <source>Find &amp; Filter</source>
-      <translation>Pronađi i filtriraj</translation>
+        <source>Find &amp; Filter</source>
+        <translation>Pronađi i filtriraj</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="594"/>
-      <source>Load All</source>
-      <translation>Učitaj sve</translation>
+        <source>Load All</source>
+        <translation>Učitaj sve</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="602"/>
-      <source>Type a search word or a regular expression</source>
-      <translation>Unesite rječ ili regularni izraz</translation>
+        <source>F&amp;ind</source>
+        <translation>Pr&amp;onađi</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="618"/>
-      <source>F&amp;ind</source>
-      <translation>Pr&amp;onađi</translation>
+        <source>&amp;Filter</source>
+        <translation>&amp;Filter</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="613"/>
-      <source>&amp;Filter</source>
-      <translation>&amp;Filter</translation>
+        <source>No Matching Items</source>
+        <translation>Nema stavki koje se poklapaju</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="660"/>
-      <source>No Matching Items</source>
-      <translation>Nema stavki koje se poklapaju</translation>
+        <source>Type search words or a regular expression</source>
+        <translation>Unesite pojam za pretragu ili regular expression</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
+    <name>nmc::DkSettingsModel</name>
+    <message>
+        <source>Settings</source>
+        <translation>Postavke</translation>
+    </message>
+    <message>
+        <source>Value</source>
+        <translation>Vrijednost</translation>
+    </message>
+</context>
+<context>
+    <name>nmc::DkSettingsWidget</name>
+    <message>
+        <source>Filter Settings</source>
+        <translation>Postavke filtera</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation>Izbriši</translation>
+    </message>
+</context>
+<context>
     <name>nmc::DkShortcutsDialog</name>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1874"/>
-      <source>Keyboard Shortcuts</source>
-      <translation>Prečice tastature</translation>
+        <source>Keyboard Shortcuts</source>
+        <translation>Prečice tastature</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1910"/>
-      <source>Set to &amp;Default</source>
-      <translation>&amp;Podesi kao standardne</translation>
+        <source>Set to &amp;Default</source>
+        <translation>&amp;Podesi kao standardne</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1911"/>
-      <source>Removes All Custom Shortcuts</source>
-      <translation>Uklanja sve prilagođene prečice</translation>
+        <source>Removes All Custom Shortcuts</source>
+        <translation>Uklanja sve prilagođene prečice</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1924"/>
-      <source>&amp;OK</source>
-      <translation>&amp;U redu</translation>
+        <source>&amp;OK</source>
+        <translation>&amp;U redu</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1925"/>
-      <source>&amp;Cancel</source>
-      <translation>&amp;Otkaži</translation>
+        <source>&amp;Cancel</source>
+        <translation>&amp;Otkaži</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkShortcutsModel</name>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1579"/>
-      <source>Name</source>
-      <translation>Ime</translation>
+        <source>Name</source>
+        <translation>Ime</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1579"/>
-      <source>Shortcut</source>
-      <translation>Prečica</translation>
+        <source>Shortcut</source>
+        <translation>Prečica</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1785"/>
-      <source>%1 already used by %2 &gt; %3
+        <source>%1 already used by %2 &gt; %3
 Press ESC to undo changes</source>
-      <translation>%1 već koristi %2 &gt; %3
+        <translation>%1 već koristi %2 &gt; %3
 Pritisni ESC za opoziv promijena</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1791"/>
-      <source>%1 already used by %2
+        <source>%1 already used by %2
 Press ESC to undo changes</source>
-      <translation>%1 već koristi %2
+        <translation>%1 već koristi %2
 Pritisni ESC za opoziv promijena</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkSplashScreen</name>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="126"/>
-      <source>CLOSE</source>
-      <translation>ZATVORI</translation>
+        <source>CLOSE</source>
+        <translation>ZATVORI</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="130"/>
-      <source>Close (ESC)</source>
-      <translation>Zatvori (ESC)</translation>
+        <source>Close (ESC)</source>
+        <translation>Zatvori (ESC)</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="184"/>
-      <source>Portable</source>
-      <translation>Prenosivo</translation>
+        <source>Portable</source>
+        <translation>Prenosivo</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkStatusBar</name>
     <message>
-      <location filename="../src/DkLoader/DkStatusBar.cpp" line="56"/>
-      <source>CTRL activates the crosshair cursor</source>
-      <translation>CTRL aktivira krstić kursor</translation>
+        <source>CTRL activates the crosshair cursor</source>
+        <translation>CTRL aktivira krstić kursor</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkTcpMenu</name>
     <message>
-      <location filename="../src/DkGui/DkMenu.cpp" line="227"/>
-      <source>no clients found</source>
-      <translation>klijenti nisu pronađeni</translation>
+        <source>no clients found</source>
+        <translation>klijenti nisu pronađeni</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkTextDialog</name>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1971"/>
-      <source>Text Editor</source>
-      <translation>Tekstualni editor</translation>
+        <source>Text Editor</source>
+        <translation>Tekstualni editor</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1981"/>
-      <source>&amp;Save</source>
-      <translation>&amp;Sačuvaj</translation>
+        <source>&amp;Save</source>
+        <translation>&amp;Sačuvaj</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1982"/>
-      <source>&amp;Close</source>
-      <translation>&amp;Zatvori</translation>
+        <source>&amp;Close</source>
+        <translation>&amp;Zatvori</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2006"/>
-      <source>Text File (*.txt)</source>
-      <translation>Tekstualni fajl (*.txt)</translation>
+        <source>Text File (*.txt)</source>
+        <translation>Tekstualni fajl (*.txt)</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2006"/>
-      <source>All Files (*.*)</source>
-      <translation>Svi fajlovi (*.*)</translation>
+        <source>All Files (*.*)</source>
+        <translation>Svi fajlovi (*.*)</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2009"/>
-      <source>Save Text File</source>
-      <translation>Sačuvaj tekstualni fajl</translation>
+        <source>Save Text File</source>
+        <translation>Sačuvaj tekstualni fajl</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2022"/>
-      <source>Error</source>
-      <translation>Greška</translation>
+        <source>Error</source>
+        <translation>Greška</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2022"/>
-      <source>Could not save: %1
+        <source>Could not save: %1
 %2</source>
-      <translation>Ne mogu sačuvati: %1
+        <translation>Ne mogu sačuvati: %1
 %2</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
+    <name>nmc::DkThresholdWidget</name>
+    <message>
+        <source>Threshold</source>
+        <translation>Prag</translation>
+    </message>
+    <message>
+        <source>Color</source>
+        <translation>Boja</translation>
+    </message>
+</context>
+<context>
     <name>nmc::DkThumbLabel</name>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="900"/>
-      <source>Name: </source>
-      <translation>Ime: </translation>
+        <source>Name: </source>
+        <translation>Ime: </translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="901"/>
-      <source>Size: </source>
-      <translation>Veličina: </translation>
+        <source>Size: </source>
+        <translation>Veličina: </translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="902"/>
-      <source>Created: </source>
-      <translation>Kreirano:</translation>
+        <source>Created: </source>
+        <translation>Kreirano: </translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkThumbScene</name>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1252"/>
-      <source>%1 Images</source>
-      <translation>%1 slika</translation>
+        <source>Error</source>
+        <translation>Greška</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1394"/>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1443"/>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1482"/>
-      <source>Error</source>
-      <translation>Greška</translation>
+        <source>Sorry, I cannot copy %1 to %2</source>
+        <translation>Izvini, ne mogu kopirati %1 u %2</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1394"/>
-      <source>Sorry, I cannot copy %1 to %2</source>
-      <translation>Izvini, ne mogu kopirati %1 u %2</translation>
+        <source>Shall I move %1 file(s) to trash?</source>
+        <translation>Da li da pomjerim %1 fajl(ova) u otpad?</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1415"/>
-      <source>Shall I move %1 file(s) to trash?</source>
-      <translation>Da li da pomjerim %1 fajl(ova) u otpad?</translation>
+        <source>Are you sure you want to permanently delete %1 file(s)?</source>
+        <translation>Da li ste sigurni da želite trajno obrisati %1 fajl(a)?</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1417"/>
-      <source>Are you sure you want to permanently delete %1 file(s)?</source>
-      <translation>Da li ste sigurni da želite trajno obrisati %1 fajl(a)?</translation>
+        <source>Delete File</source>
+        <translation>Izbriši fajl</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1422"/>
-      <source>Delete File</source>
-      <translation>Izbriši fajl</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1443"/>
-      <source>Sorry, I cannot delete:
+        <source>Sorry, I cannot delete:
 %1</source>
-      <translation>Izvini, ne mogu izbrisati:
+        <translation>Izvini, ne mogu izbrisati:
 %1</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1467"/>
-      <source>Rename File(s)</source>
-      <translation>Preimenuj fajl(ove)</translation>
+        <source>Rename File(s)</source>
+        <translation>Preimenuj fajl(ove)</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1468"/>
-      <source>New Filename:</source>
-      <translation>Novo ime fajla:</translation>
+        <source>New Filename:</source>
+        <translation>Novo ime fajla:</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1482"/>
-      <source>Sorry, I cannot rename: %1 to %2</source>
-      <translation>Izvini, ne mogu preimenovati: %1 u %2</translation>
+        <source>Sorry, I cannot rename: %1 to %2</source>
+        <translation>Izvini, ne mogu preimenovati: %1 u %2</translation>
     </message>
-  </context>
-  <context>
+    <message>
+        <source>%1 selected</source>
+        <translation>%1 izabran</translation>
+    </message>
+    <message>
+        <source>%1 images</source>
+        <translation>%1 slika</translation>
+    </message>
+</context>
+<context>
     <name>nmc::DkThumbScrollWidget</name>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1870"/>
-      <source>&amp;Sort</source>
-      <translation>&amp;Sortiraj</translation>
+        <source>&amp;Sort</source>
+        <translation>&amp;Sortiraj</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1847"/>
-      <source>Thumb Preview Toolbar</source>
-      <translation>Traka za pregled sličica</translation>
+        <source>Thumb Preview Toolbar</source>
+        <translation>Traka za pregled sličica</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1890"/>
-      <source>Filter Files (Ctrl + F)</source>
-      <translation>Filtriraj fajlove (Ctrl + F)</translation>
+        <source>Filter Files (Ctrl + F)</source>
+        <translation>Filtriraj fajlove (Ctrl + F)</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1903"/>
-      <source>Thumb</source>
-      <translation>Sličica</translation>
+        <source>Thumb</source>
+        <translation>Sličica</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkThumbsSaver</name>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="295"/>
-      <source>Cancel</source>
-      <translation>Otkaži</translation>
+        <source>Cancel</source>
+        <translation>Otkaži</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="295"/>
-      <source>
+        <source>
 Creating thumbnails...
 </source>
-      <translation>
-Kreiram sličice...</translation>
+        <translation>
+Kreiram sličice...
+</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="296"/>
-      <source>Thumbnails</source>
-      <translation>Sličice</translation>
+        <source>Thumbnails</source>
+        <translation>Sličice</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkTifDialog</name>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="65"/>
-      <source>TIF compression</source>
-      <translation>TIF kompresija</translation>
+        <source>TIF compression</source>
+        <translation>TIF kompresija</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="68"/>
-      <source>&amp;no compression</source>
-      <translation>&amp;bez kompresije</translation>
+        <source>&amp;no compression</source>
+        <translation>&amp;bez kompresije</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="69"/>
-      <source>&amp;LZW compression (lossless)</source>
-      <translation>&amp;LZW kompresija (bez gubitka)</translation>
+        <source>&amp;LZW compression (lossless)</source>
+        <translation>&amp;LZW kompresija (bez gubitka)</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="79"/>
-      <source>&amp;OK</source>
-      <translation>&amp;U redu</translation>
+        <source>&amp;OK</source>
+        <translation>&amp;U redu</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="80"/>
-      <source>&amp;Cancel</source>
-      <translation>&amp;Otkaži</translation>
+        <source>&amp;Cancel</source>
+        <translation>&amp;Otkaži</translation>
     </message>
-  </context>
-  <context>
-    <name>nmc::DkTinyPlanetDialog</name>
+</context>
+<context>
+    <name>nmc::DkTinyPlanetWidget</name>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3006"/>
-      <source>Tiny Planet</source>
-      <translation>Mala planeta</translation>
+        <source>Planet Size</source>
+        <translation>Veličina planete</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3040"/>
-      <source>Planet Size</source>
-      <translation>Veličina planete</translation>
+        <source>Angle</source>
+        <translation>Ugao</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3048"/>
-      <source>Angle</source>
-      <translation>Ugao</translation>
+        <source>Invert Planet</source>
+        <translation>Obrni planetu</translation>
     </message>
-    <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3054"/>
-      <source>Invert Planet</source>
-      <translation>Obrni planetu</translation>
-    </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkTrainDialog</name>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="254"/>
-      <source>Add New Image Format</source>
-      <translation>Dodaj novi format slike</translation>
+        <source>Add New Image Format</source>
+        <translation>Dodaj novi format slike</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="263"/>
-      <source>Load New Image Format</source>
-      <translation>Učitaj novi format slike</translation>
+        <source>Load New Image Format</source>
+        <translation>Učitaj novi format slike</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="270"/>
-      <source>&amp;Browse</source>
-      <translation>&amp;Pregledaj</translation>
+        <source>&amp;Browse</source>
+        <translation>&amp;Pregledaj</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="283"/>
-      <source>&amp;Add</source>
-      <translation>&amp;Dodaj</translation>
+        <source>&amp;Add</source>
+        <translation>&amp;Dodaj</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="285"/>
-      <source>&amp;Cancel</source>
-      <translation>&amp;Otkaži</translation>
+        <source>&amp;Cancel</source>
+        <translation>&amp;Otkaži</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="317"/>
-      <source>Open Image</source>
-      <translation>Otvori sliku</translation>
+        <source>Open Image</source>
+        <translation>Otvori sliku</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="318"/>
-      <source>All Files (*.*)</source>
-      <translation>Svi fajlovi (*.*)</translation>
+        <source>All Files (*.*)</source>
+        <translation>Svi fajlovi (*.*)</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="364"/>
-      <source>Sorry, currently we don't support: *.%1 files</source>
-      <translation>Izvini, trenutno ne podržavamo: *.%1 fajlove</translation>
+        <source>Sorry, currently we don&apos;t support: *.%1 files</source>
+        <translation>Izvini, trenutno ne podržavamo: *.%1 fajlove</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="369"/>
-      <source>*.%1 is already supported.</source>
-      <translation>*.%1 je već podržan.</translation>
+        <source>*.%1 is already supported.</source>
+        <translation>*.%1 je već podržan.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="373"/>
-      <source>*.%1 is supported.</source>
-      <translation>*.%1 je podržan.</translation>
+        <source>*.%1 is supported.</source>
+        <translation>*.%1 je podržan.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="390"/>
-      <source>Please name the new format:</source>
-      <translation>Molimo imenujte novi format:</translation>
+        <source>Please name the new format:</source>
+        <translation>Molimo imenujte novi format:</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkTransferToolBar</name>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="538"/>
-      <source>Enable</source>
-      <translation>Uključi</translation>
+        <source>Enable</source>
+        <translation>Uključi</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="622"/>
-      <source>Resets the Pseudo Color function</source>
-      <translation>Resetuj funkciju pseudo-boja</translation>
+        <source>Resets the Pseudo Color function</source>
+        <translation>Resetuj funkciju pseudo-boja</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="796"/>
-      <source>Disables the Pseudo Color function</source>
-      <translation>Isključuje funkciju pseudo-boja</translation>
+        <source>Disables the Pseudo Color function</source>
+        <translation>Isključuje funkciju pseudo-boja</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="548"/>
-      <source>Changes the displayed color channel</source>
-      <translation>Mijenja prikazani kanal boja</translation>
+        <source>Changes the displayed color channel</source>
+        <translation>Mijenja prikazani kanal boja</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="533"/>
-      <source>Pseudo Color Toolbar</source>
-      <translation>Traka za pseudo-boje</translation>
+        <source>Pseudo Color Toolbar</source>
+        <translation>Traka za pseudo-boje</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="553"/>
-      <source>Delete</source>
-      <translation>Izbriši</translation>
+        <source>Delete</source>
+        <translation>Izbriši</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="568"/>
-      <source>Click into the field for a new slider</source>
-      <translation>Klikni u polje za novi klizač</translation>
+        <source>Click into the field for a new slider</source>
+        <translation>Klikni u polje za novi klizač</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="621"/>
-      <source>Reset</source>
-      <translation>Resetuj</translation>
+        <source>Reset</source>
+        <translation>Resetuj</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="627"/>
-      <source>Select Color</source>
-      <translation>Izaberi boju</translation>
+        <source>Select Color</source>
+        <translation>Izaberi boju</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="628"/>
-      <source>Adds a slider at the selected color value</source>
-      <translation>Dodaje slajder za izabranu boju</translation>
+        <source>Adds a slider at the selected color value</source>
+        <translation>Dodaje slajder za izabranu boju</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="633"/>
-      <source>Save Gradient</source>
-      <translation>Sačuvaj prelaz</translation>
+        <source>Save Gradient</source>
+        <translation>Sačuvaj prelaz</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="634"/>
-      <source>Saves the current Gradient</source>
-      <translation>Sačuva trenutni prelaz</translation>
+        <source>Saves the current Gradient</source>
+        <translation>Sačuva trenutni prelaz</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="762"/>
-      <source>Gray</source>
-      <translation>Siva</translation>
+        <source>Gray</source>
+        <translation>Siva</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="765"/>
-      <source>RGB</source>
-      <translation>RGB</translation>
+        <source>RGB</source>
+        <translation>RGB</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="766"/>
-      <source>Red</source>
-      <translation>Crvena</translation>
+        <source>Red</source>
+        <translation>Crvena</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="767"/>
-      <source>Green</source>
-      <translation>Zelena</translation>
+        <source>Green</source>
+        <translation>Zelena</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="768"/>
-      <source>Blue</source>
-      <translation>Plava</translation>
+        <source>Blue</source>
+        <translation>Plava</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="539"/>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="798"/>
-      <source>Enables the Pseudo Color function</source>
-      <translation>Uključuje traku sa funckijom za pseudo-boje</translation>
+        <source>Enables the Pseudo Color function</source>
+        <translation>Uključuje traku sa funckijom za pseudo-boje</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkTranslationUpdater</name>
     <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="557"/>
-      <source>Unable to download translation</source>
-      <translation>Nemoguće preuzimanje prevoda</translation>
+        <source>Unable to download translation</source>
+        <translation>Nemoguće preuzimanje prevoda</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="557"/>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="591"/>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="613"/>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="618"/>
-      <source>update</source>
-      <translation>ažuriranje</translation>
+        <source>update</source>
+        <translation>ažuriranje</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="591"/>
-      <source>Unable to update translation</source>
-      <translation>Nemoguće ažurirati prevod</translation>
+        <source>Unable to update translation</source>
+        <translation>Nemoguće ažurirati prevod</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="613"/>
-      <source>Translation updated</source>
-      <translation>Prevod ažuriran</translation>
+        <source>Translation updated</source>
+        <translation>Prevod ažuriran</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="618"/>
-      <source>No newer translations found</source>
-      <translation>Nisu pronađeni novi prevodi</translation>
+        <source>No newer translations found</source>
+        <translation>Nisu pronađeni novi prevodi</translation>
     </message>
-  </context>
-  <context>
-    <name>nmc::DkUndoRedo</name>
+</context>
+<context>
+    <name>nmc::DkUnsharpMaskWidget</name>
     <message>
-      <location filename="../src/DkGui/DkManipulationWidgets.cpp" line="1471"/>
-      <source>&amp;Undo</source>
-      <translation>&amp;Opozovi</translation>
+        <source>Sigma</source>
+        <translation>Sigma</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkManipulationWidgets.cpp" line="1473"/>
-      <source>&amp;Redo</source>
-      <translation>&amp;Ponovi</translation>
+        <source>Amount</source>
+        <translation>Iznos</translation>
     </message>
-  </context>
-  <context>
-    <name>nmc::DkUnsharpDialog</name>
-    <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2826"/>
-      <source>Sharpen Image</source>
-      <translation>Izoštri sliku</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2860"/>
-      <source>Sigma</source>
-      <translation>Sigma</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2865"/>
-      <source>Amount</source>
-      <translation>Iznos</translation>
-    </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkUpdateDialog</name>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2045"/>
-      <source>nomacs updater</source>
-      <translation>nomacs ažuriranje</translation>
+        <source>nomacs updater</source>
+        <translation>nomacs ažuriranje</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2053"/>
-      <source>Install Now</source>
-      <translation>Instaliraj sada</translation>
+        <source>Install Now</source>
+        <translation>Instaliraj sada</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2054"/>
-      <source>Cancel</source>
-      <translation>Otkaži</translation>
+        <source>Cancel</source>
+        <translation>Otkaži</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkUpdater</name>
     <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="395"/>
-      <source>sorry, I could not check for newer versions</source>
-      <translation>izvini, ne mogu provjeriti za nove verzije</translation>
+        <source>sorry, I could not check for newer versions</source>
+        <translation>izvini, ne mogu provjeriti za nove verzije</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="395"/>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="415"/>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="418"/>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="426"/>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="496"/>
-      <source>updates</source>
-      <translation>ažuriranja</translation>
+        <source>updates</source>
+        <translation>ažuriranja</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="407"/>
-      <source>A new version</source>
-      <translation>Nova verzija</translation>
+        <source>A new version</source>
+        <translation>Nova verzija</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="407"/>
-      <source>is available</source>
-      <translation>je dostupna</translation>
+        <source>is available</source>
+        <translation>je dostupna</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="408"/>
-      <source>Do you want to download and install it now?</source>
-      <translation>Da li je želite preuzeti i instalirati?</translation>
+        <source>Do you want to download and install it now?</source>
+        <translation>Da li je želite preuzeti i instalirati?</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="409"/>
-      <source>For more information see </source>
-      <translation>Za više informacija pogledajte</translation>
+        <source>For more information see </source>
+        <translation>Za više informacija pogledajte </translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="426"/>
-      <source>sorry, unable to download the new version</source>
-      <translation>izvini, nemoguće preuzimanje nove verzije</translation>
+        <source>sorry, unable to download the new version</source>
+        <translation>izvini, nemoguće preuzimanje nove verzije</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="496"/>
-      <source>Unable to connect to server ... please try again later</source>
-      <translation>Nemoguće spajanje na server ... molimo pokušajte kasnije</translation>
+        <source>Unable to connect to server ... please try again later</source>
+        <translation>Nemoguće spajanje na server ... molimo pokušajte kasnije</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="418"/>
-      <source>nomacs is up-to-date</source>
-      <translation>nomacs je ažuran</translation>
+        <source>nomacs is up-to-date</source>
+        <translation>nomacs je ažuran</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkViewPort</name>
     <message>
-      <location filename="../src/DkGui/DkViewPort.cpp" line="226"/>
-      <source>Original Image</source>
-      <translation>Originalna slika</translation>
+        <source>Original Image</source>
+        <translation>Originalna slika</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkViewPort.cpp" line="627"/>
-      <source>connected with: </source>
-      <translation>povezan sa: </translation>
+        <source>connected with: </source>
+        <translation>povezan sa: </translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkViewPort.cpp" line="631"/>
-      <source>disconnected with: </source>
-      <translation>nepovezan sa: </translation>
+        <source>disconnected with: </source>
+        <translation>nepovezan sa: </translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkViewPort.cpp" line="1283"/>
-      <source>Transparency Pattern Enabled</source>
-      <translation>Providnost uključena</translation>
+        <source>Transparency Pattern Enabled</source>
+        <translation>Providnost uključena</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkViewPort.cpp" line="1283"/>
-      <source>Transparency Pattern Disabled</source>
-      <translation>Providnost isključena</translation>
+        <source>Transparency Pattern Disabled</source>
+        <translation>Providnost isključena</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkViewPort.cpp" line="1324"/>
-      <source>Lena</source>
-      <translation>Lena</translation>
+        <source>Lena</source>
+        <translation>Lena</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkViewPort.cpp" line="1324"/>
-      <source>A remarkable woman</source>
-      <translation>Izuzetna žena</translation>
+        <source>A remarkable woman</source>
+        <translation>Izuzetna žena</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkViewPort.cpp" line="1334"/>
-      <source>you cannot cancel this</source>
-      <translation>ne možete otkazati ovo</translation>
+        <source>you cannot cancel this</source>
+        <translation>ne možete otkazati ovo</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkViewPort.cpp" line="1342"/>
-      <source>did you understand the brainteaser?</source>
-      <translation>razumijete li slagalicu?</translation>
+        <source>did you understand the brainteaser?</source>
+        <translation>razumijete li slagalicu?</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkViewPort.cpp" line="1344"/>
-      <source>%1 is wrong...</source>
-      <translation>%1 je pogrešno...</translation>
+        <source>%1 is wrong...</source>
+        <translation>%1 je pogrešno...</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkViewPort.cpp" line="1385"/>
-      <location filename="../src/DkGui/DkViewPort.cpp" line="1410"/>
-      <source>Attempted to set NULL image</source>
-      <translation>Pokušaj da se postavi NULL slika</translation>
+        <source>Attempted to set NULL image</source>
+        <translation>Pokušaj da se postavi NULL slika</translation>
     </message>
-  </context>
-  <context>
+    <message>
+        <source>Busy</source>
+        <translation>Zauzet</translation>
+    </message>
+</context>
+<context>
     <name>nmc::DkViewPortFrameless</name>
     <message>
-      <location filename="../src/DkGui/DkViewPort.cpp" line="1943"/>
-      <source>Press F10 to exit Frameless view</source>
-      <translation>Pritisni F10 za izlaz iz pregleda bez okvira</translation>
+        <source>Press F10 to exit Frameless view</source>
+        <translation>Pritisni F10 za izlaz iz pregleda bez okvira</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkWelcomeDialog</name>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4188"/>
-      <source>Welcome</source>
-      <translation>Dobrodošli</translation>
+        <source>Welcome</source>
+        <translation>Dobrodošli</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4197"/>
-      <source>Welcome to nomacs, please choose your preferred language below.</source>
-      <translation>Dobrodošli u nomacs, molimo izaberite željeni jezik.</translation>
+        <source>Welcome to nomacs, please choose your preferred language below.</source>
+        <translation>Dobrodošli u nomacs, molimo izaberite željeni jezik.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4202"/>
-      <source>&amp;Register File Associations</source>
-      <translation>Prijavi asocijacije za fajlove</translation>
+        <source>&amp;Register File Associations</source>
+        <translation>P&amp;rijavi asocijacije za fajlove</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4205"/>
-      <source>Set As &amp;Default Viewer</source>
-      <translation>Postavi kao po&amp;drazumijevani pregledač slika</translation>
+        <source>Set As &amp;Default Viewer</source>
+        <translation>Postavi kao po&amp;drazumijevani pregledač slika</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4210"/>
-      <source>&amp;OK</source>
-      <translation>&amp;U redu</translation>
+        <source>&amp;OK</source>
+        <translation>&amp;U redu</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4211"/>
-      <source>&amp;Cancel</source>
-      <translation>&amp;Otkaži</translation>
+        <source>&amp;Cancel</source>
+        <translation>&amp;Otkaži</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4249"/>
-      <source>Image</source>
-      <translation>Slika</translation>
+        <source>Image</source>
+        <translation>Slika</translation>
     </message>
-  </context>
+</context>
 </TS>

--- a/ImageLounge/translations/nomacs_hr.ts
+++ b/ImageLounge/translations/nomacs_hr.ts
@@ -1,5881 +1,6310 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
 <TS version="2.1" language="hr" sourcelanguage="en">
-  <context>
-    <name>DkNoMacsClass</name>
-    <message>
-      <location filename="../src/nomacs.ui" line="16"/>
-      <source>nomacs - image lounge</source>
-      <translation>nomacs - salon slika</translation>
-    </message>
-  </context>
-  <context>
+<context>
     <name>QObject</name>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="175"/>
-      <source>&amp;Photoshop</source>
-      <translation>&amp;Photoshop</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="181"/>
+        <source>&amp;Photoshop</source>
+        <translation>&amp;Photoshop</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="186"/>
-      <source>Pic&amp;asa</source>
-      <translation>Pic&amp;asa</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="192"/>
+        <source>Pic&amp;asa</source>
+        <translation>Pic&amp;asa</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="197"/>
-      <source>Picasa Ph&amp;oto Viewer</source>
-      <translation type="unfinished">Picasa Ph&amp;oto Viewer</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="203"/>
+        <source>Picasa Ph&amp;oto Viewer</source>
+        <translation>Picasa Ph&amp;oto Viewer</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="208"/>
-      <source>&amp;IrfanView</source>
-      <translation>&amp;IrfanView</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="214"/>
+        <source>&amp;IrfanView</source>
+        <translation>&amp;IrfanView</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="218"/>
-      <source>&amp;Explorer</source>
-      <translation type="unfinished">&amp;Explorer</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="224"/>
+        <source>&amp;Explorer</source>
+        <translation>Pregl&amp;edač</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="355"/>
-      <source>&amp;File</source>
-      <translation>&amp;Datoteka</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="362"/>
+        <source>&amp;File</source>
+        <translation>&amp;Datoteka</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="396"/>
-      <source>&amp;Open With</source>
-      <translation>&amp;Otvori sa</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="410"/>
+        <source>&amp;Open With</source>
+        <translation>&amp;Otvori sa</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="427"/>
-      <source>S&amp;ort</source>
-      <translation type="unfinished">S&amp;ort</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="441"/>
+        <source>S&amp;ort</source>
+        <translation>S&amp;ortiraj</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="441"/>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="650"/>
-      <source>&amp;View</source>
-      <translation type="unfinished">&amp;View</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="455"/>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="670"/>
+        <source>&amp;View</source>
+        <translation>&amp;Pregled</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="486"/>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="656"/>
-      <source>&amp;Edit</source>
-      <translation>&amp;Uredi</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="504"/>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="676"/>
+        <source>&amp;Edit</source>
+        <translation>&amp;Uredi</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="527"/>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="635"/>
-      <source>&amp;Panels</source>
-      <translation type="unfinished">&amp;Panels</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="542"/>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="654"/>
+        <source>&amp;Panels</source>
+        <translation>&amp;Paneli</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="529"/>
-      <source>Tool&amp;bars</source>
-      <translation type="unfinished">Tool&amp;bars</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="544"/>
+        <source>Tool&amp;bars</source>
+        <translation>&amp;Alatne trake</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="556"/>
-      <source>&amp;Tools</source>
-      <translation>&amp;Alati</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="574"/>
+        <source>&amp;Tools</source>
+        <translation>&amp;Alati</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="2742"/>
-      <source>&amp;Synchronize</source>
-      <translation type="unfinished">&amp;Synchronize</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="2436"/>
+        <source>&amp;Synchronize</source>
+        <translation>&amp;Sinhronizuj</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="2748"/>
-      <source>&amp;LAN Synchronize</source>
-      <translation type="unfinished">&amp;LAN Synchronize</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="2442"/>
+        <source>&amp;LAN Synchronize</source>
+        <translation>&amp;LAN sinhronizacija</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="604"/>
-      <source>&amp;?</source>
-      <translation>&amp;Pomoć</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="618"/>
+        <source>&amp;?</source>
+        <translation>&amp;Pomoć?</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="963"/>
-      <source>&amp;Open</source>
-      <translation>&amp;Otvori</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="969"/>
+        <source>&amp;Open</source>
+        <translation>&amp;Otvori</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="965"/>
-      <source>Open an image</source>
-      <translation type="unfinished">Open an image</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="971"/>
+        <source>Open an image</source>
+        <translation>Otvori sliku</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="967"/>
-      <source>Open &amp;Directory</source>
-      <translation type="unfinished">Open &amp;Directory</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="973"/>
+        <source>Open &amp;Directory</source>
+        <translation>Otvori &amp;direktorij</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="969"/>
-      <source>Open a directory and load its first image</source>
-      <translation type="unfinished">Open a directory and load its first image</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="975"/>
+        <source>Open a directory and load its first image</source>
+        <translation>Otvori direktorij i učitaj prvu sliku</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="971"/>
-      <source>&amp;Quick Launch</source>
-      <translation type="unfinished">&amp;Quick Launch</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="980"/>
+        <source>&amp;Quick Launch</source>
+        <translation>&amp;Brzo otvori</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="978"/>
-      <source>&amp;Manage Applications</source>
-      <translation type="unfinished">&amp;Manage Applications</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="987"/>
+        <source>&amp;Manage Applications</source>
+        <translation>&amp;Upravljaj aplikacijama</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="979"/>
-      <source>Manage Applications which are Automatically Opened</source>
-      <translation type="unfinished">Manage Applications which are Automatically Opened</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="988"/>
+        <source>Manage Applications which are Automatically Opened</source>
+        <translation>Upravljaj aplikacijama koje se automatski otvaraju</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="982"/>
-      <source>Re&amp;name</source>
-      <translation type="unfinished">Re&amp;name</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="991"/>
+        <source>Re&amp;name</source>
+        <translation>Preime&amp;nuj</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="985"/>
-      <source>Rename an image</source>
-      <translation type="unfinished">Rename an image</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="994"/>
+        <source>Rename an image</source>
+        <translation>Preimenuj sliku</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="987"/>
-      <source>&amp;Go To</source>
-      <translation type="unfinished">&amp;Go To</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="996"/>
+        <source>&amp;Go To</source>
+        <translation>&amp;Idi на</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="989"/>
-      <source>Go To an image</source>
-      <translation type="unfinished">Go To an image</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="998"/>
+        <source>Go To an image</source>
+        <translation>Idi na sliku</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="991"/>
-      <source>&amp;Save</source>
-      <translation>&amp;Sačuvaj</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1000"/>
+        <source>&amp;Save</source>
+        <translation>&amp;Sačuvaj</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="993"/>
-      <source>Save an image</source>
-      <translation>Spremanje slike</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1002"/>
+        <source>Save an image</source>
+        <translation>Spremanje slike</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="995"/>
-      <source>&amp;Save As</source>
-      <translation type="unfinished">&amp;Save As</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1004"/>
+        <source>&amp;Save As</source>
+        <translation>&amp;Sačuvaj kao</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="997"/>
-      <source>Save an image as</source>
-      <translation type="unfinished">Save an image as</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1006"/>
+        <source>Save an image as</source>
+        <translation>Sačuvaj sliku kao</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="999"/>
-      <source>&amp;Save for Web</source>
-      <translation type="unfinished">&amp;Save for Web</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1011"/>
+        <source>&amp;Save for Web</source>
+        <translation>Sni&amp;mi za Web</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1000"/>
-      <source>Save an Image for Web Applications</source>
-      <translation type="unfinished">Save an Image for Web Applications</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1012"/>
+        <source>Save an Image for Web Applications</source>
+        <translation>Sačuvaj sliku za web aplikaciju</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1002"/>
-      <source>&amp;Print</source>
-      <translation>&amp;Ispis</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1014"/>
+        <source>&amp;Print</source>
+        <translation>&amp;Ispis</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1004"/>
-      <source>Print an image</source>
-      <translation>Ispiši sliku</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1016"/>
+        <source>Print an image</source>
+        <translation>Ispiši sliku</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1012"/>
-      <source>&amp;Reload File</source>
-      <translation type="unfinished">&amp;Reload File</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1024"/>
+        <source>&amp;Reload File</source>
+        <translation>&amp;Ponovo učitaj fajl</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1015"/>
-      <source>Reload File</source>
-      <translation type="unfinished">Reload File</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1027"/>
+        <source>Reload File</source>
+        <translation>Ponovo učitaj fajl</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1017"/>
-      <source>Ne&amp;xt File</source>
-      <translation type="unfinished">Ne&amp;xt File</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1029"/>
+        <source>Ne&amp;xt File</source>
+        <translation>Slj&amp;edeći fajl</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1020"/>
-      <source>Load next image</source>
-      <translation type="unfinished">Load next image</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1032"/>
+        <source>Load next image</source>
+        <translation>Učitaj sljedeću sliku</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1022"/>
-      <source>Pre&amp;vious File</source>
-      <translation type="unfinished">Pre&amp;vious File</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1034"/>
+        <source>Pre&amp;vious File</source>
+        <translation>Pret&amp;hodni fajl</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1027"/>
-      <source>Add Image Format</source>
-      <translation type="unfinished">Add Image Format</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1400"/>
+        <source>Add Image Format</source>
+        <translation>Dodaj format slike</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1028"/>
-      <source>Add a new image format to nomacs</source>
-      <translation type="unfinished">Add a new image format to nomacs</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1401"/>
+        <source>Add a new image format to nomacs</source>
+        <translation>Dodaj novi format slika u nomacs</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1030"/>
-      <source>St&amp;art New Instance</source>
-      <translation type="unfinished">St&amp;art New Instance</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1039"/>
+        <source>St&amp;art New Instance</source>
+        <translation>Po&amp;čni novu instancu</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1025"/>
-      <source>Load previous file</source>
-      <translation type="unfinished">Load previous file</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1037"/>
+        <source>Load previous file</source>
+        <translation>Učitaj prethodni fajl</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1006"/>
-      <source>&amp;Recent Files</source>
-      <translation type="unfinished">&amp;Recent Files</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1018"/>
+        <source>&amp;Recent Files</source>
+        <translation>&amp;Nedavni fajlovi</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1010"/>
-      <source>Show Recent Files</source>
-      <translation type="unfinished">Show Recent Files</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1022"/>
+        <source>Show Recent Files</source>
+        <translation>Prikaži nedavne fajlove</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1032"/>
-      <source>Open file in new instance</source>
-      <translation type="unfinished">Open file in new instance</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1041"/>
+        <source>Open file in new instance</source>
+        <translation>Otvori fajl u novoj instanci</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1034"/>
-      <source>St&amp;art Private Instance</source>
-      <translation type="unfinished">St&amp;art Private Instance</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1043"/>
+        <source>St&amp;art Private Instance</source>
+        <translation>Pokreni privatnu ins&amp;tancu</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1036"/>
-      <source>Open private instance</source>
-      <translation type="unfinished">Open private instance</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1045"/>
+        <source>Open private instance</source>
+        <translation>Otvori privatnu instancu</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1038"/>
-      <source>&amp;Find &amp;&amp; Filter</source>
-      <translation type="unfinished">&amp;Find &amp;&amp; Filter</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1047"/>
+        <source>&amp;Find &amp;&amp; Filter</source>
+        <translation>&amp;Pronađi &amp;&amp; filtriraj</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1040"/>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1389"/>
-      <source>Find an image</source>
-      <translation type="unfinished">Find an image</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1049"/>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1379"/>
+        <source>Find an image</source>
+        <translation>Pronađi sliku</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1042"/>
-      <source>Scan Folder Re&amp;cursive</source>
-      <translation type="unfinished">Scan Folder Re&amp;cursive</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1051"/>
+        <source>Scan Folder Re&amp;cursive</source>
+        <translation>Skeniraj fasciklu rekurziv&amp;no</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1043"/>
-      <source>Step through Folder and Sub Folders</source>
-      <translation type="unfinished">Step through Folder and Sub Folders</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1052"/>
+        <source>Step through Folder and Sub Folders</source>
+        <translation>Prolistaj kroz fasciklu i pod fascikle</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1047"/>
-      <source>&amp;Exit</source>
-      <translation type="unfinished">&amp;Exit</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1056"/>
+        <source>&amp;Exit</source>
+        <translation>&amp;Napusti</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1048"/>
-      <source>Exit</source>
-      <translation type="unfinished">Exit</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1057"/>
+        <source>Exit</source>
+        <translation>Napusti</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1053"/>
-      <source>by &amp;Filename</source>
-      <translation type="unfinished">by &amp;Filename</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1062"/>
+        <source>by &amp;Filename</source>
+        <translation>po &amp;imenu fajla</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1055"/>
-      <source>Sort by Filename</source>
-      <translation type="unfinished">Sort by Filename</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1064"/>
+        <source>Sort by Filename</source>
+        <translation>Sortiraj po imenu fajla</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1059"/>
-      <source>by Date &amp;Created</source>
-      <translation type="unfinished">by Date &amp;Created</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1068"/>
+        <source>by Date &amp;Created</source>
+        <translation>po datumu &amp;kreiranja</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1061"/>
-      <source>Sort by Date Created</source>
-      <translation type="unfinished">Sort by Date Created</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1070"/>
+        <source>Sort by Date Created</source>
+        <translation>Sortiraju po datumu kreiranja</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1065"/>
-      <source>by Date Modified</source>
-      <translation type="unfinished">by Date Modified</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1074"/>
+        <source>by Date Modified</source>
+        <translation>po datumu izmjene</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1067"/>
-      <source>Sort by Date Last Modified</source>
-      <translation type="unfinished">Sort by Date Last Modified</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1076"/>
+        <source>Sort by Date Last Modified</source>
+        <translation>Sortiraj po datumu posljednje izmjene</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1071"/>
-      <source>Random</source>
-      <translation type="unfinished">Random</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1080"/>
+        <source>Random</source>
+        <translation>Nasumično</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1073"/>
-      <source>Sort in Random Order</source>
-      <translation type="unfinished">Sort in Random Order</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1082"/>
+        <source>Sort in Random Order</source>
+        <translation>Sortiraj nasumično</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1077"/>
-      <source>&amp;Ascending</source>
-      <translation type="unfinished">&amp;Ascending</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1086"/>
+        <source>&amp;Ascending</source>
+        <translation>&amp;Uzlazno</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1079"/>
-      <source>Sort in Ascending Order</source>
-      <translation type="unfinished">Sort in Ascending Order</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1088"/>
+        <source>Sort in Ascending Order</source>
+        <translation>Sortiraj uzlazno</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1083"/>
-      <source>&amp;Descending</source>
-      <translation type="unfinished">&amp;Descending</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1092"/>
+        <source>&amp;Descending</source>
+        <translation>&amp;Silazno</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1085"/>
-      <source>Sort in Descending Order</source>
-      <translation type="unfinished">Sort in Descending Order</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1094"/>
+        <source>Sort in Descending Order</source>
+        <translation>Sortiraj silazno</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1092"/>
-      <source>9&amp;0%1 Clockwise</source>
-      <translation type="unfinished">9&amp;0%1 Clockwise</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1101"/>
+        <source>9&amp;0%1 Clockwise</source>
+        <translation>9&amp;0%1 u smjeru kazaljke na satu</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1095"/>
-      <source>rotate the image 90%1 clockwise</source>
-      <translation type="unfinished">rotate the image 90%1 clockwise</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1104"/>
+        <source>rotate the image 90%1 clockwise</source>
+        <translation>rotiraj sliku 90%1 u smjeru kazaljke na satu</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1097"/>
-      <source>&amp;90%1 Counter Clockwise</source>
-      <translation type="unfinished">&amp;90%1 Counter Clockwise</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1106"/>
+        <source>&amp;90%1 Counter Clockwise</source>
+        <translation>&amp;90%1 suprotno kazaljci na satu</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1100"/>
-      <source>rotate the image 90%1 counter clockwise</source>
-      <translation type="unfinished">rotate the image 90%1 counter clockwise</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1109"/>
+        <source>rotate the image 90%1 counter clockwise</source>
+        <translation>rotiraj sliku 90%1 suprotno kazaljci na satu</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1102"/>
-      <source>180%1</source>
-      <translation type="unfinished">180%1</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1111"/>
+        <source>180%1</source>
+        <translation>180%1</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1103"/>
-      <source>rotate the image by 180%1</source>
-      <translation type="unfinished">rotate the image by 180%1</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1112"/>
+        <source>rotate the image by 180%1</source>
+        <translation>rotiraj sliku 180%1</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1105"/>
-      <source>&amp;Undo</source>
-      <translation>&amp;Opozovi</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1114"/>
+        <source>&amp;Undo</source>
+        <translation>&amp;Opozovi</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1108"/>
-      <source>Undo Last Action</source>
-      <translation type="unfinished">Undo Last Action</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1117"/>
+        <source>Undo Last Action</source>
+        <translation>Poništi zadnju radnju</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1110"/>
-      <source>&amp;Redo</source>
-      <translation>&amp;Ponovi</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1119"/>
+        <source>&amp;Redo</source>
+        <translation>&amp;Ponovi</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1113"/>
-      <source>Redo Last Action</source>
-      <translation type="unfinished">Redo Last Action</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1122"/>
+        <source>Redo Last Action</source>
+        <translation>Ponovi zadnju radnju</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1115"/>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1517"/>
-      <source>&amp;Copy</source>
-      <translation type="unfinished">&amp;Copy</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1124"/>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1502"/>
+        <source>&amp;Copy</source>
+        <translation>&amp;Kopiraj</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1118"/>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1123"/>
-      <source>copy image</source>
-      <translation type="unfinished">copy image</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1127"/>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1132"/>
+        <source>copy image</source>
+        <translation>kopiraj sliku</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1120"/>
-      <source>Copy &amp;Buffer</source>
-      <translation type="unfinished">Copy &amp;Buffer</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1129"/>
+        <source>Copy &amp;Buffer</source>
+        <translation>Kopiraj &amp;pufer</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1125"/>
-      <source>Copy Co&amp;lor</source>
-      <translation type="unfinished">Copy Co&amp;lor</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1134"/>
+        <source>Copy Co&amp;lor</source>
+        <translation>Kopiraj bo&amp;ju</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1128"/>
-      <source>copy pixel color value as HEX</source>
-      <translation type="unfinished">copy pixel color value as HEX</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1137"/>
+        <source>copy pixel color value as HEX</source>
+        <translation>kopiraj vrijednost boja piksela kao HEX</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1133"/>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1520"/>
-      <source>&amp;Paste</source>
-      <translation type="unfinished">&amp;Paste</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1142"/>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1505"/>
+        <source>&amp;Paste</source>
+        <translation>&amp;Nalijepi</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1136"/>
-      <source>paste image</source>
-      <translation type="unfinished">paste image</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1145"/>
+        <source>paste image</source>
+        <translation>nalijepi sliku</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1138"/>
-      <source>R&amp;esize Image</source>
-      <translation type="unfinished">R&amp;esize Image</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1167"/>
+        <source>R&amp;esize Image</source>
+        <translation>Pr&amp;omijeni veličinu slike</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1141"/>
-      <source>resize the current image</source>
-      <translation type="unfinished">resize the current image</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1170"/>
+        <source>resize the current image</source>
+        <translation>promijeni veličinu trenutne slike</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1143"/>
-      <source>Cr&amp;op Image</source>
-      <translation type="unfinished">Cr&amp;op Image</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1172"/>
+        <source>Cr&amp;op Image</source>
+        <translation>I&amp;sjeci sliku</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1146"/>
-      <source>cut the current image</source>
-      <translation type="unfinished">cut the current image</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1175"/>
+        <source>cut the current image</source>
+        <translation>isjeci trenutnu sliku</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1150"/>
-      <source>Flip &amp;Horizontal</source>
-      <translation>Prevrni &amp;vodoravno</translation>
+        <location filename="../src/DkCore/DkManipulators.cpp" line="101"/>
+        <source>Flip &amp;Horizontal</source>
+        <translation>Prevrni &amp;vodoravno</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1151"/>
-      <source>Flip Image Horizontally</source>
-      <translation type="unfinished">Flip Image Horizontally</translation>
+        <location filename="../src/DkCore/DkManipulators.cpp" line="102"/>
+        <source>Flip Image Horizontally</source>
+        <translation>Prevrni sliku vodoravno</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1153"/>
-      <source>Flip &amp;Vertical</source>
-      <translation>Prevrni &amp;uspravno</translation>
+        <location filename="../src/DkCore/DkManipulators.cpp" line="106"/>
+        <source>Flip &amp;Vertical</source>
+        <translation>Prevrni &amp;uspravno</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1154"/>
-      <source>Flip Image Vertically</source>
-      <translation type="unfinished">Flip Image Vertically</translation>
+        <location filename="../src/DkCore/DkManipulators.cpp" line="107"/>
+        <source>Flip Image Vertically</source>
+        <translation>Prevrni sliku uspravno</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1156"/>
-      <source>Nor&amp;malize Image</source>
-      <translation type="unfinished">Nor&amp;malize Image</translation>
+        <location filename="../src/DkCore/DkManipulators.cpp" line="95"/>
+        <source>Nor&amp;malize Image</source>
+        <translation>Norm&amp;alizuj sliku</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1159"/>
-      <source>Normalize the Image</source>
-      <translation type="unfinished">Normalize the Image</translation>
+        <location filename="../src/DkCore/DkManipulators.cpp" line="97"/>
+        <source>Normalize the Image</source>
+        <translation>Normalizuj sliku</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1161"/>
-      <source>&amp;Auto Adjust</source>
-      <translation type="unfinished">&amp;Auto Adjust</translation>
+        <location filename="../src/DkCore/DkManipulators.cpp" line="89"/>
+        <source>&amp;Auto Adjust</source>
+        <translation>&amp;Automatsko podešavanje</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1164"/>
-      <source>Auto Adjust Image Contrast and Color Balance</source>
-      <translation type="unfinished">Auto Adjust Image Contrast and Color Balance</translation>
+        <location filename="../src/DkCore/DkManipulators.cpp" line="84"/>
+        <source>&amp;Grayscale</source>
+        <translation>&amp;Crno-bijelo</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1166"/>
-      <source>&amp;Invert Image</source>
-      <translation type="unfinished">&amp;Invert Image</translation>
+        <location filename="../src/DkCore/DkManipulators.cpp" line="91"/>
+        <source>Auto Adjust Image Contrast and Color Balance</source>
+        <translation>Automatski podešava kontrast i balans boja slike</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1167"/>
-      <source>Invert the Image</source>
-      <translation type="unfinished">Invert the Image</translation>
+        <location filename="../src/DkCore/DkManipulators.cpp" line="111"/>
+        <source>&amp;Invert Image</source>
+        <translation>&amp;Obrni sliku</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1169"/>
-      <source>&amp;Convert to Grayscale</source>
-      <translation type="unfinished">&amp;Convert to Grayscale</translation>
+        <location filename="../src/DkCore/DkManipulators.cpp" line="112"/>
+        <source>Invert the Image</source>
+        <translation>Obrni sliku</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1170"/>
-      <source>Convert to Grayscale</source>
-      <translation type="unfinished">Convert to Grayscale</translation>
+        <location filename="../src/DkCore/DkManipulators.cpp" line="117"/>
+        <source>&amp;Tiny Planet...</source>
+        <translation>Mala plane&amp;ta...</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1172"/>
-      <source>&amp;Unsharp Mask</source>
-      <translation type="unfinished">&amp;Unsharp Mask</translation>
+        <location filename="../src/DkCore/DkManipulators.cpp" line="118"/>
+        <source>Create a Tiny Planet</source>
+        <translation>Napravi malu planetu</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1173"/>
-      <source>Stretches the Local Contrast of an Image</source>
-      <translation type="unfinished">Stretches the Local Contrast of an Image</translation>
+        <location filename="../src/DkCore/DkManipulators.cpp" line="122"/>
+        <source>&amp;Sharpen...</source>
+        <translation>Izo&amp;štri...</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1175"/>
-      <source>&amp;Tiny Planet</source>
-      <translation type="unfinished">&amp;Tiny Planet</translation>
+        <location filename="../src/DkCore/DkManipulators.cpp" line="123"/>
+        <source>Sharpens the image by applying an unsharp mask</source>
+        <translation>Izoštrava sliku metodom neoštre maske</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1176"/>
-      <source>Computes a tiny planet image</source>
-      <translation type="unfinished">Computes a tiny planet image</translation>
+        <location filename="../src/DkCore/DkManipulators.cpp" line="127"/>
+        <source>&amp;Rotate...</source>
+        <translation>&amp;Rotiraj...</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1178"/>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1514"/>
-      <source>&amp;Delete</source>
-      <translation>&amp;Ukloni</translation>
+        <location filename="../src/DkCore/DkManipulators.cpp" line="128"/>
+        <source>Rotate the image</source>
+        <translation>Rotira sliku</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1181"/>
-      <source>delete current fileInfo</source>
-      <translation type="unfinished">delete current fileInfo</translation>
+        <location filename="../src/DkCore/DkManipulators.cpp" line="132"/>
+        <source>&amp;Threshold...</source>
+        <translation>&amp;Prag...</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1183"/>
-      <source>&amp;Wallpaper</source>
-      <translation type="unfinished">&amp;Wallpaper</translation>
+        <location filename="../src/DkCore/DkManipulators.cpp" line="133"/>
+        <source>Threshold the image</source>
+        <translation>Primjenjuje prag na sliku</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1184"/>
-      <source>set the current image as wallpaper</source>
-      <translation type="unfinished">set the current image as wallpaper</translation>
+        <location filename="../src/DkCore/DkManipulators.cpp" line="137"/>
+        <source>&amp;Hue/Saturation...</source>
+        <translation>&amp;Nijansa/Zasićenje...</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1186"/>
-      <source>&amp;Keyboard Shortcuts</source>
-      <translation type="unfinished">&amp;Keyboard Shortcuts</translation>
+        <location filename="../src/DkCore/DkManipulators.cpp" line="138"/>
+        <source>Change Hue and Saturation</source>
+        <translation>Izmjeni nijansu i zasićenje</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1188"/>
-      <source>lets you customize your keyboard shortcuts</source>
-      <translation type="unfinished">lets you customize your keyboard shortcuts</translation>
+        <location filename="../src/DkCore/DkManipulators.cpp" line="142"/>
+        <source>&amp;Exposure...</source>
+        <translation>&amp;Eksponiranje...</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1190"/>
-      <source>&amp;Settings</source>
-      <translation type="unfinished">&amp;Settings</translation>
+        <location filename="../src/DkCore/DkManipulators.cpp" line="143"/>
+        <source>Change the Exposure and Gamma</source>
+        <translation>Izmjeni eksponiranje i gamu</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1192"/>
-      <source>settings</source>
-      <translation type="unfinished">settings</translation>
+        <location filename="../src/DkCore/DkManipulators.cpp" line="85"/>
+        <source>Convert to Grayscale</source>
+        <translation>Konvertuj u crno-bijelo</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1196"/>
-      <source>&amp;Menu</source>
-      <translation type="unfinished">&amp;Menu</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1147"/>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1499"/>
+        <source>&amp;Delete</source>
+        <translation>&amp;Ukloni</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1197"/>
-      <source>Hides the Menu and Shows it Again on ALT</source>
-      <translation type="unfinished">Hides the Menu and Shows it Again on ALT</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1150"/>
+        <source>delete current fileInfo</source>
+        <translation>izbriši informacije trenutnog fajla</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1200"/>
-      <source>Tool&amp;bar</source>
-      <translation type="unfinished">Tool&amp;bar</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1397"/>
+        <source>&amp;Wallpaper</source>
+        <translation>Po&amp;zadinska slika</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1202"/>
-      <source>Show Toolbar</source>
-      <translation>Prikaži alatnu traku</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1398"/>
+        <source>set the current image as wallpaper</source>
+        <translation>postavi trenutnu sliku kao pozadinu</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1205"/>
-      <source>&amp;Statusbar</source>
-      <translation type="unfinished">&amp;Statusbar</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1152"/>
+        <source>&amp;Keyboard Shortcuts</source>
+        <translation>&amp;Prečice tastature</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1207"/>
-      <source>Show Statusbar</source>
-      <translation>Prikaži statusnu traku</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="526"/>
+        <source>&amp;Adjustments</source>
+        <translation>&amp;Podešavanja</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1210"/>
-      <source>&amp;Pseudocolor Function</source>
-      <translation type="unfinished">&amp;Pseudocolor Function</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="966"/>
+        <source>&amp;Close All Tabs</source>
+        <translation>&amp;Zatvori sve kartice</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1212"/>
-      <source>Show Pseudocolor Function</source>
-      <translation type="unfinished">Show Pseudocolor Function</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="967"/>
+        <source>Close all open tabs</source>
+        <translation>Zatvori sve otvorene kartice</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1216"/>
-      <source>O&amp;verview</source>
-      <translation type="unfinished">O&amp;verview</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="977"/>
+        <source>&amp;Open Tabs</source>
+        <translation>&amp;Otvori kartice</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1218"/>
-      <source>Shows the Zoom Overview</source>
-      <translation type="unfinished">Shows the Zoom Overview</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="978"/>
+        <source>Open a texfile containing a list of filepaths, and open tabs for them</source>
+        <translation>Otvori tekstualni fajl koji sadrži listu putanja i otvori kartice za njiih</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1222"/>
-      <source>Pla&amp;yer</source>
-      <translation type="unfinished">Pla&amp;yer</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1008"/>
+        <source>&amp;Save Tabs</source>
+        <translation>&amp;Sačuvaj kartice</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1224"/>
-      <source>Shows the Slide Show Player</source>
-      <translation type="unfinished">Shows the Slide Show Player</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1009"/>
+        <source>Save a newline separated list of the filenames of the open tabs</source>
+        <translation>Sačuvaj listu imena fajlova otvorenih kartica</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1227"/>
-      <source>File &amp;Explorer</source>
-      <translation type="unfinished">File &amp;Explorer</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1154"/>
+        <source>lets you customize your keyboard shortcuts</source>
+        <translation>omogućava prilagođavanje prečica na tastaturi</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1229"/>
-      <source>Show File Explorer</source>
-      <translation type="unfinished">Show File Explorer</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1156"/>
+        <source>&amp;Settings</source>
+        <translation>&amp;Postavke</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1232"/>
-      <source>Metadata &amp;Info</source>
-      <translation type="unfinished">Metadata &amp;Info</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1158"/>
+        <source>settings</source>
+        <translation>postavke</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1234"/>
-      <source>Show Metadata Info</source>
-      <translation type="unfinished">Show Metadata Info</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1161"/>
+        <source>Image &amp;Adjustments</source>
+        <translation>Podeš&amp;avanja slike</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1237"/>
-      <source>&amp;Thumbnails</source>
-      <translation type="unfinished">&amp;Thumbnails</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1164"/>
+        <source>open image manipulation toolbox</source>
+        <translation>otvori alatke za manipulaciju slikom</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1239"/>
-      <source>Show Thumbnails</source>
-      <translation type="unfinished">Show Thumbnails</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1181"/>
+        <source>&amp;Menu</source>
+        <translation>&amp;Izbornik</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1242"/>
-      <source>&amp;Thumbnail Preview</source>
-      <translation type="unfinished">&amp;Thumbnail Preview</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1182"/>
+        <source>Hides the Menu and Shows it Again on ALT</source>
+        <translation>Skriva izbornik i pokazuje ga opet na ALT</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1244"/>
-      <source>Show Thumbnails Preview</source>
-      <translation type="unfinished">Show Thumbnails Preview</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1185"/>
+        <source>Tool&amp;bar</source>
+        <translation>Alatna tra&amp;ka</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1247"/>
-      <source>&amp;Folder Scrollbar</source>
-      <translation type="unfinished">&amp;Folder Scrollbar</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1187"/>
+        <source>Show Toolbar</source>
+        <translation>Prikaži alatnu traku</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1249"/>
-      <source>Show Folder Scrollbar</source>
-      <translation type="unfinished">Show Folder Scrollbar</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1190"/>
+        <source>&amp;Statusbar</source>
+        <translation>&amp;Statusna traka</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1252"/>
-      <source>&amp;Metadata</source>
-      <translation type="unfinished">&amp;Metadata</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1192"/>
+        <source>Show Statusbar</source>
+        <translation>Prikaži statusnu traku</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1254"/>
-      <source>Shows the Metadata Panel</source>
-      <translation type="unfinished">Shows the Metadata Panel</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1195"/>
+        <source>&amp;Pseudocolor Function</source>
+        <translation>&amp;Pseudo-boja funkcija</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1257"/>
-      <source>File &amp;Info</source>
-      <translation type="unfinished">File &amp;Info</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1197"/>
+        <source>Show Pseudocolor Function</source>
+        <translation>Prikaži funkciju pseudo-boja</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1259"/>
-      <source>Shows the Info Panel</source>
-      <translation type="unfinished">Shows the Info Panel</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1201"/>
+        <source>O&amp;verview</source>
+        <translation>P&amp;regled</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1262"/>
-      <source>&amp;Histogram</source>
-      <translation type="unfinished">&amp;Histogram</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1203"/>
+        <source>Shows the Zoom Overview</source>
+        <translation>Prikaže zumirani pregled</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1264"/>
-      <source>Shows the Histogram Panel</source>
-      <translation type="unfinished">Shows the Histogram Panel</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1207"/>
+        <source>Pla&amp;yer</source>
+        <translation>Ple&amp;jer</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1267"/>
-      <source>Image &amp;Notes</source>
-      <translation type="unfinished">Image &amp;Notes</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1209"/>
+        <source>Shows the Slide Show Player</source>
+        <translation>Prikazuje slajdšou plejer</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1269"/>
-      <source>Shows Image Notes</source>
-      <translation type="unfinished">Shows Image Notes</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1212"/>
+        <source>&amp;Hide All Panels</source>
+        <translation>&amp;Sakrij sve panele</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1272"/>
-      <source>Edit &amp;History</source>
-      <translation type="unfinished">Edit &amp;History</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1214"/>
+        <source>Hide all panels</source>
+        <translation>Sakrij sve panele</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1273"/>
-      <source>Shows the edit history</source>
-      <translation type="unfinished">Shows the edit history</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1217"/>
+        <source>File &amp;Explorer</source>
+        <translation>Pregledač &amp;fajlova</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1279"/>
-      <source>&amp;Fit Window</source>
-      <translation type="unfinished">&amp;Fit Window</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1219"/>
+        <source>Show File Explorer</source>
+        <translation>Prikaži pregledač fajlova</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1281"/>
-      <source>Fit window to the image</source>
-      <translation type="unfinished">Fit window to the image</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1222"/>
+        <source>Metadata &amp;Info</source>
+        <translation>Meta &amp;podaci</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1286"/>
-      <source>Fu&amp;ll Screen</source>
-      <translation type="unfinished">Fu&amp;ll Screen</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1224"/>
+        <source>Show Metadata Info</source>
+        <translation>Prikaži meta podatke</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1288"/>
-      <source>Full Screen</source>
-      <translation type="unfinished">Full Screen</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1227"/>
+        <source>&amp;Thumbnails</source>
+        <translation>&amp;Sličice</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1290"/>
-      <source>&amp;Zoom to Fit</source>
-      <translation type="unfinished">&amp;Zoom to Fit</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1229"/>
+        <source>Show Thumbnails</source>
+        <translation>Prikaži sličice</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1292"/>
-      <source>Shows the initial view (no zooming)</source>
-      <translation type="unfinished">Shows the initial view (no zooming)</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1232"/>
+        <source>&amp;Thumbnail Preview</source>
+        <translation>&amp;Pregled sličica</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1294"/>
-      <source>Show &amp;100%</source>
-      <translation type="unfinished">Show &amp;100%</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1234"/>
+        <source>Show Thumbnails Preview</source>
+        <translation>Prikaži pregled sličica</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1296"/>
-      <source>Shows the image at 100%</source>
-      <translation type="unfinished">Shows the image at 100%</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1237"/>
+        <source>&amp;Folder Scrollbar</source>
+        <translation>&amp;Klizač fascikle</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1298"/>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1497"/>
-      <source>Zoom &amp;In</source>
-      <translation type="unfinished">Zoom &amp;In</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1238"/>
+        <source>Show Folder Scrollbar</source>
+        <translation>Prikaži klizač fascikle</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1300"/>
-      <source>zoom in</source>
-      <translation type="unfinished">zoom in</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1241"/>
+        <source>&amp;Metadata</source>
+        <translation>&amp;Meta podaci</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1302"/>
-      <source>&amp;Zoom Out</source>
-      <translation type="unfinished">&amp;Zoom Out</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1243"/>
+        <source>Shows the Metadata Panel</source>
+        <translation>Prikaže panel sa meta podacima</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1304"/>
-      <source>zoom out</source>
-      <translation type="unfinished">zoom out</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1246"/>
+        <source>File &amp;Info</source>
+        <translation>Informacije o &amp;fajlu</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1306"/>
-      <source>&amp;Anti Aliasing</source>
-      <translation type="unfinished">&amp;Anti Aliasing</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1248"/>
+        <source>Shows the Info Panel</source>
+        <translation>Prikaže panel sa informacijama</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1308"/>
-      <source>if checked images are smoother</source>
-      <translation type="unfinished">if checked images are smoother</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1251"/>
+        <source>&amp;Histogram</source>
+        <translation>&amp;Histogram</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1312"/>
-      <source>&amp;Transparency Pattern</source>
-      <translation type="unfinished">&amp;Transparency Pattern</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1253"/>
+        <source>Shows the Histogram Panel</source>
+        <translation>Prikaže panel sa histogramom</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1314"/>
-      <source>if checked, a pattern will be displayed for transparent objects</source>
-      <translation type="unfinished">if checked, a pattern will be displayed for transparent objects</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1256"/>
+        <source>Image &amp;Notes</source>
+        <translation>Napomene &amp;o slici</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1318"/>
-      <source>&amp;Frameless</source>
-      <translation type="unfinished">&amp;Frameless</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1258"/>
+        <source>Shows Image Notes</source>
+        <translation>Prikaže napomene o slici</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1320"/>
-      <source>shows a frameless window</source>
-      <translation type="unfinished">shows a frameless window</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1261"/>
+        <source>Edit &amp;History</source>
+        <translation>Uredi &amp;povijest</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1324"/>
-      <source>New &amp;Tab</source>
-      <translation type="unfinished">New &amp;Tab</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1262"/>
+        <source>Shows the edit history</source>
+        <translation>Prikazuje povijest uređivanja</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1326"/>
-      <source>Open a new tab</source>
-      <translation type="unfinished">Open a new tab</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1268"/>
+        <source>&amp;Fit Window</source>
+        <translation>&amp;Prilagodi prozor</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1328"/>
-      <source>&amp;Close Tab</source>
-      <translation type="unfinished">&amp;Close Tab</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1270"/>
+        <source>Fit window to the image</source>
+        <translation>Prilagođava prozor slici</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1330"/>
-      <source>Close current tab</source>
-      <translation type="unfinished">Close current tab</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1275"/>
+        <source>Fu&amp;ll Screen</source>
+        <translation>&amp;Cijeli ekran</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1332"/>
-      <source>&amp;Previous Tab</source>
-      <translation type="unfinished">&amp;Previous Tab</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1277"/>
+        <source>Full Screen</source>
+        <translation>Cijeli ekran</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1334"/>
-      <source>Switch to previous tab</source>
-      <translation type="unfinished">Switch to previous tab</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1279"/>
+        <source>&amp;Zoom to Fit</source>
+        <translation>&amp;Zumiraj da odgovara</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1336"/>
-      <source>&amp;Next Tab</source>
-      <translation type="unfinished">&amp;Next Tab</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1281"/>
+        <source>Shows the initial view (no zooming)</source>
+        <translation>Prikaže početni pogled (bez zumiranja)</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1338"/>
-      <source>Switch to next tab</source>
-      <translation type="unfinished">Switch to next tab</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1283"/>
+        <source>Show &amp;100%</source>
+        <translation>Prikaži &amp;100%</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1340"/>
-      <source>&amp;Change Opacity</source>
-      <translation type="unfinished">&amp;Change Opacity</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1285"/>
+        <source>Shows the image at 100%</source>
+        <translation>Prikaže sliku pri punoj veličini</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1342"/>
-      <source>change the window opacity</source>
-      <translation type="unfinished">change the window opacity</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1287"/>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1482"/>
+        <source>Zoom &amp;In</source>
+        <translation>Uveć&amp;aj</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1344"/>
-      <source>Opacity &amp;Up</source>
-      <translation type="unfinished">Opacity &amp;Up</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1289"/>
+        <source>zoom in</source>
+        <translation>uvećaj</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1346"/>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1350"/>
-      <source>changes the window opacity</source>
-      <translation type="unfinished">changes the window opacity</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1291"/>
+        <source>&amp;Zoom Out</source>
+        <translation>&amp;Umanji</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1348"/>
-      <source>Opacity &amp;Down</source>
-      <translation type="unfinished">Opacity &amp;Down</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1293"/>
+        <source>zoom out</source>
+        <translation>umanji</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1352"/>
-      <source>To&amp;ggle Opacity</source>
-      <translation type="unfinished">To&amp;ggle Opacity</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1295"/>
+        <source>&amp;Anti Aliasing</source>
+        <translation>&amp;Omekšavanje</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1354"/>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1441"/>
-      <source>toggle the window opacity</source>
-      <translation type="unfinished">toggle the window opacity</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1297"/>
+        <source>if checked images are smoother</source>
+        <translation>ako je označeno, slike imaju blaže ivice</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1356"/>
-      <source>Lock &amp;Window</source>
-      <translation type="unfinished">Lock &amp;Window</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1301"/>
+        <source>&amp;Transparency Pattern</source>
+        <translation>Mus&amp;tra za proznirno</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1358"/>
-      <source>lock the window</source>
-      <translation type="unfinished">lock the window</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1303"/>
+        <source>if checked, a pattern will be displayed for transparent objects</source>
+        <translation>ako je označeno, mustra će biti prikazana za providne objekte</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1362"/>
-      <source>&amp;Toggle Slideshow</source>
-      <translation type="unfinished">&amp;Toggle Slideshow</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1307"/>
+        <source>&amp;Frameless</source>
+        <translation>&amp;Bez okvira</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1363"/>
-      <source>Start/Pause the slideshow</source>
-      <translation type="unfinished">Start/Pause the slideshow</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1309"/>
+        <source>shows a frameless window</source>
+        <translation>prikazuje prozor bez okvira</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1366"/>
-      <source>&amp;Pause Movie</source>
-      <translation type="unfinished">&amp;Pause Movie</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="958"/>
+        <source>New &amp;Tab</source>
+        <translation>Nova &amp;kartica</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1367"/>
-      <source>pause the current movie</source>
-      <translation type="unfinished">pause the current movie</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="960"/>
+        <source>Open a new tab</source>
+        <translation>Otvori novu karticu</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1371"/>
-      <source>P&amp;revious Frame</source>
-      <translation type="unfinished">P&amp;revious Frame</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="962"/>
+        <source>&amp;Close Tab</source>
+        <translation>&amp;Zatvori karticu</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1372"/>
-      <source>show previous frame</source>
-      <translation type="unfinished">show previous frame</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="964"/>
+        <source>Close current tab</source>
+        <translation>Zatvori trenutnu karticu</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1374"/>
-      <source>&amp;Next Frame</source>
-      <translation type="unfinished">&amp;Next Frame</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1313"/>
+        <source>F&amp;irst Tab</source>
+        <translation>Prva kart&amp;ica</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1375"/>
-      <source>show next frame</source>
-      <translation type="unfinished">show next frame</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1314"/>
+        <source>Switch to first tab</source>
+        <translation>Prebaci na prvu karticu</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1377"/>
-      <source>Show G&amp;PS Coordinates</source>
-      <translation type="unfinished">Show G&amp;PS Coordinates</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1316"/>
+        <source>&amp;Previous Tab</source>
+        <translation>&amp;Prethodna kartica</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1378"/>
-      <source>shows the GPS coordinates</source>
-      <translation type="unfinished">shows the GPS coordinates</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1318"/>
+        <source>Switch to previous tab</source>
+        <translation>Prebaci na prethodnu karticu</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1384"/>
-      <source>Compute &amp;Thumbnails</source>
-      <translation type="unfinished">Compute &amp;Thumbnails</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1320"/>
+        <source>&amp;Go to Tab</source>
+        <translation>&amp;Idi na karticu</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1385"/>
-      <source>compute all thumbnails of the current folder</source>
-      <translation type="unfinished">compute all thumbnails of the current folder</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1321"/>
+        <source>Go to tab by index</source>
+        <translation>Idi na karticu po broju</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1388"/>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1511"/>
-      <source>&amp;Filter</source>
-      <translation type="unfinished">&amp;Filter</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1323"/>
+        <source>&amp;Next Tab</source>
+        <translation>&amp;Sljedeća kartica</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1393"/>
-      <source>Image &amp;Manipulation</source>
-      <translation type="unfinished">Image &amp;Manipulation</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1325"/>
+        <source>Switch to next tab</source>
+        <translation>Prebaci na sljedeću karticu</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1395"/>
-      <source>modify the current image</source>
-      <translation type="unfinished">modify the current image</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1327"/>
+        <source>La&amp;st Tab</source>
+        <translation>Po&amp;sljednja kartica</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1397"/>
-      <source>Export Multipage &amp;TIFF</source>
-      <translation type="unfinished">Export Multipage &amp;TIFF</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1328"/>
+        <source>Switch to last tab</source>
+        <translation>Prebaci na posljednju karticu</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1398"/>
-      <source>Export TIFF pages to multiple tiff files</source>
-      <translation type="unfinished">Export TIFF pages to multiple tiff files</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1330"/>
+        <source>&amp;Change Opacity</source>
+        <translation>&amp;Izmjeni providnost</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1400"/>
-      <source>Extract From Archive</source>
-      <translation type="unfinished">Extract From Archive</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1332"/>
+        <source>change the window opacity</source>
+        <translation>promijeni providnost prozora</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1401"/>
-      <source>Extract images from an archive (%1)</source>
-      <translation type="unfinished">Extract images from an archive (%1)</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1334"/>
+        <source>Opacity &amp;Up</source>
+        <translation>Smanji &amp;providnost</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1404"/>
-      <source>&amp;Mosaic Image</source>
-      <translation type="unfinished">&amp;Mosaic Image</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1336"/>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1340"/>
+        <source>changes the window opacity</source>
+        <translation>mijenja providnost prozora</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1405"/>
-      <source>Create a Mosaic Image</source>
-      <translation type="unfinished">Create a Mosaic Image</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1338"/>
+        <source>Opacity &amp;Down</source>
+        <translation>Uvećaj &amp;providnost</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1407"/>
-      <source>Batch Processing</source>
-      <translation type="unfinished">Batch Processing</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1342"/>
+        <source>To&amp;ggle Opacity</source>
+        <translation>&amp;Izmjeni providnost</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1408"/>
-      <source>Apply actions to multiple images</source>
-      <translation type="unfinished">Apply actions to multiple images</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1344"/>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1430"/>
+        <source>toggle the window opacity</source>
+        <translation>izmjeni providnost prozora</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1413"/>
-      <source>&amp;About Nomacs</source>
-      <translation type="unfinished">&amp;About Nomacs</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1346"/>
+        <source>Lock &amp;Window</source>
+        <translation>Zaključaj &amp;prozor</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1415"/>
-      <source>about</source>
-      <translation type="unfinished">about</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1348"/>
+        <source>lock the window</source>
+        <translation>zaključaj prozor</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1417"/>
-      <source>&amp;Documentation</source>
-      <translation type="unfinished">&amp;Documentation</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1352"/>
+        <source>&amp;Toggle Slideshow</source>
+        <translation>&amp;Uključu slajdšou prikaz</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1418"/>
-      <source>Online Documentation</source>
-      <translation type="unfinished">Online Documentation</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1353"/>
+        <source>Start/Pause the slideshow</source>
+        <translation>Pokreni/pauziraj slajdšou</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1420"/>
-      <source>&amp;Report a Bug</source>
-      <translation type="unfinished">&amp;Report a Bug</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1356"/>
+        <source>&amp;Pause Movie</source>
+        <translation>&amp;Pauziraj video</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1421"/>
-      <source>Report a Bug</source>
-      <translation type="unfinished">Report a Bug</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1357"/>
+        <source>pause the current movie</source>
+        <translation>pauzira trenutni video</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1423"/>
-      <source>&amp;Feature Request</source>
-      <translation type="unfinished">&amp;Feature Request</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1361"/>
+        <source>P&amp;revious Frame</source>
+        <translation>P&amp;retnodni frejm</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1424"/>
-      <source>Feature Request</source>
-      <translation type="unfinished">Feature Request</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1362"/>
+        <source>show previous frame</source>
+        <translation>prikaže prethodni frejm</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1426"/>
-      <source>&amp;Check for Updates</source>
-      <translation type="unfinished">&amp;Check for Updates</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1364"/>
+        <source>&amp;Next Frame</source>
+        <translation>&amp;Sljedeći frejm</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1427"/>
-      <source>check for updates</source>
-      <translation type="unfinished">check for updates</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1365"/>
+        <source>show next frame</source>
+        <translation>prikaže sljedeću slikicu</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1429"/>
-      <source>&amp;Update Translation</source>
-      <translation type="unfinished">&amp;Update Translation</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1367"/>
+        <source>Show G&amp;PS Coordinates</source>
+        <translation>Prikaži G&amp;PS koordinate</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1430"/>
-      <source>Checks for a new version of the translations of the current language</source>
-      <translation type="unfinished">Checks for a new version of the translations of the current language</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1368"/>
+        <source>shows the GPS coordinates</source>
+        <translation>prikaže GPS koordinate</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1434"/>
-      <source>Synchronize &amp;View</source>
-      <translation type="unfinished">Synchronize &amp;View</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1374"/>
+        <source>Compute &amp;Thumbnails</source>
+        <translation>Izračunaj &amp;sličice</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1436"/>
-      <source>synchronize the current view</source>
-      <translation type="unfinished">synchronize the current view</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1375"/>
+        <source>compute all thumbnails of the current folder</source>
+        <translation>stvara sličice za sve slike u trenutnoj fascikli</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1439"/>
-      <source>&amp;Window Overlay</source>
-      <translation type="unfinished">&amp;Window Overlay</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1378"/>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1496"/>
+        <source>&amp;Filter</source>
+        <translation>&amp;Filter</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1444"/>
-      <source>Arrange Instances</source>
-      <translation type="unfinished">Arrange Instances</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1383"/>
+        <source>Export Multipage &amp;TIFF</source>
+        <translation>Eksportuj višestrani &amp;TIFF</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1446"/>
-      <source>arrange connected instances</source>
-      <translation type="unfinished">arrange connected instances</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1384"/>
+        <source>Export TIFF pages to multiple tiff files</source>
+        <translation>Eksportuje TIFF stranice u više tiff fajlova</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1449"/>
-      <source>Connect &amp;All</source>
-      <translation type="unfinished">Connect &amp;All</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1386"/>
+        <source>Extract From Archive</source>
+        <translation>Raspakuj iz arhive</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1452"/>
-      <source>connect all instances</source>
-      <translation type="unfinished">connect all instances</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1387"/>
+        <source>Extract images from an archive (%1)</source>
+        <translation>Raspakuje slike iz arhive (%1)</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1454"/>
-      <source>&amp;Sync All Actions</source>
-      <translation type="unfinished">&amp;Sync All Actions</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1390"/>
+        <source>&amp;Mosaic Image</source>
+        <translation>&amp;Mozaik slika</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1455"/>
-      <source>Transmit All Signals Automatically.</source>
-      <translation type="unfinished">Transmit All Signals Automatically.</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1391"/>
+        <source>Create a Mosaic Image</source>
+        <translation>Pravi mozaik sliku</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1459"/>
-      <source>&amp;Start Upnp</source>
-      <translation type="unfinished">&amp;Start Upnp</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1393"/>
+        <source>Batch Processing</source>
+        <translation>Grupno podešavanje</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1460"/>
-      <source>Starts a Upnp Media Renderer.</source>
-      <translation type="unfinished">Starts a Upnp Media Renderer.</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1394"/>
+        <source>Apply actions to multiple images</source>
+        <translation>Prihvati radnje na više slika</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1463"/>
-      <source>&amp;Remote Control</source>
-      <translation type="unfinished">&amp;Remote Control</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1405"/>
+        <source>&amp;About Nomacs</source>
+        <translation>&amp;O programu Nomacs</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1465"/>
-      <source>Automatically Receive Images From Your Remote Instance.</source>
-      <translation type="unfinished">Automatically Receive Images From Your Remote Instance.</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1407"/>
+        <source>about</source>
+        <translation>o programu</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1468"/>
-      <source>Remote &amp;Display</source>
-      <translation type="unfinished">Remote &amp;Display</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1409"/>
+        <source>&amp;Documentation</source>
+        <translation>&amp;Dokumentacija</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1469"/>
-      <source>Automatically Send Images to a Remote Instance.</source>
-      <translation type="unfinished">Automatically Send Images to a Remote Instance.</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1410"/>
+        <source>Online Documentation</source>
+        <translation>Internet dokumentacija</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1475"/>
-      <source>Start &amp;Server</source>
-      <translation type="unfinished">Start &amp;Server</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1412"/>
+        <source>&amp;Report a Bug</source>
+        <translation>&amp;Prijavi grešku</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1480"/>
-      <source>Send &amp;Image</source>
-      <translation type="unfinished">Send &amp;Image</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1413"/>
+        <source>Report a Bug</source>
+        <translation>Prijavi grešku</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1483"/>
-      <source>Sends the current image to all clients.</source>
-      <translation type="unfinished">Sends the current image to all clients.</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1415"/>
+        <source>&amp;Check for Updates</source>
+        <translation>&amp;Provjeri ažuriranje</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1487"/>
-      <source>&amp;Plugin Manager</source>
-      <translation type="unfinished">&amp;Plugin Manager</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1416"/>
+        <source>check for updates</source>
+        <translation>provjeri ažuriranje</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1488"/>
-      <source>manage installed plugins and download new ones</source>
-      <translation type="unfinished">manage installed plugins and download new ones</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1418"/>
+        <source>&amp;Update Translation</source>
+        <translation>&amp;Ažuriraj prevod</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1493"/>
-      <source>Select &amp;All</source>
-      <translation type="unfinished">Select &amp;All</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1419"/>
+        <source>Checks for a new version of the translations of the current language</source>
+        <translation>Provjerava da li postoji nova verzija prevoda za trenutni jezik</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1500"/>
-      <source>Zoom &amp;Out</source>
-      <translation type="unfinished">Zoom &amp;Out</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1423"/>
+        <source>Synchronize &amp;View</source>
+        <translation>Sinhroniziraj &amp;pogled</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1503"/>
-      <source>Display &amp;Squares</source>
-      <translation type="unfinished">Display &amp;Squares</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1425"/>
+        <source>synchronize the current view</source>
+        <translation>sinhronizuj trenutni pogled</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1507"/>
-      <source>Show &amp;Filename</source>
-      <translation type="unfinished">Show &amp;Filename</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1428"/>
+        <source>&amp;Window Overlay</source>
+        <translation>&amp;Preklapanje prozora</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1523"/>
-      <source>&amp;Rename</source>
-      <translation type="unfinished">&amp;Rename</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1433"/>
+        <source>Arrange Instances</source>
+        <translation>Aranžiraj instance</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1526"/>
-      <source>&amp;Batch Process</source>
-      <translation type="unfinished">&amp;Batch Process</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1435"/>
+        <source>arrange connected instances</source>
+        <translation>aranžira povezane instance</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1527"/>
-      <source>Adds selected files to batch processing.</source>
-      <translation type="unfinished">Adds selected files to batch processing.</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1438"/>
+        <source>Connect &amp;All</source>
+        <translation>Poveži &amp;sve</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1542"/>
-      <source>Start pong</source>
-      <translation type="unfinished">Start pong</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1441"/>
+        <source>connect all instances</source>
+        <translation>povezuje sve instance</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1545"/>
-      <source>First File</source>
-      <translation type="unfinished">First File</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1443"/>
+        <source>&amp;Sync All Actions</source>
+        <translation>&amp;Sinhronizuj sve radnje</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1546"/>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1562"/>
-      <source>Jump to first file</source>
-      <translation type="unfinished">Jump to first file</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1444"/>
+        <source>Transmit All Signals Automatically.</source>
+        <translation>Šalji sve signale automatski.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1549"/>
-      <source>Last File</source>
-      <translation type="unfinished">Last File</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1448"/>
+        <source>&amp;Remote Control</source>
+        <translation>&amp;Daljinski</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1550"/>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1566"/>
-      <source>Jump to the end of the current folder</source>
-      <translation type="unfinished">Jump to the end of the current folder</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1450"/>
+        <source>Automatically Receive Images From Your Remote Instance.</source>
+        <translation>Automatski primaj slike sa udaljene instance.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1553"/>
-      <source>Skip Previous Images</source>
-      <translation type="unfinished">Skip Previous Images</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1453"/>
+        <source>Remote &amp;Display</source>
+        <translation>Udaljeni &amp;ekran</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1554"/>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1570"/>
-      <source>Jumps 10 images before the current image</source>
-      <translation type="unfinished">Jumps 10 images before the current image</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1454"/>
+        <source>Automatically Send Images to a Remote Instance.</source>
+        <translation>Automatski šalji slike na udaljenu instancu.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1557"/>
-      <source>Skip Next Images</source>
-      <translation type="unfinished">Skip Next Images</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1460"/>
+        <source>Start &amp;Server</source>
+        <translation>Pokreni &amp;server</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1558"/>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1574"/>
-      <source>Jumps 10 images after the current image</source>
-      <translation type="unfinished">Jumps 10 images after the current image</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1465"/>
+        <source>Send &amp;Image</source>
+        <translation>Pošalji &amp;sliku</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1561"/>
-      <source>First File Sync</source>
-      <translation type="unfinished">First File Sync</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1468"/>
+        <source>Sends the current image to all clients.</source>
+        <translation>Šalje trenutnu sliku svim klijentima.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1565"/>
-      <source>Last File Sync</source>
-      <translation type="unfinished">Last File Sync</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1472"/>
+        <source>&amp;Plugin Manager</source>
+        <translation>Upravljač &amp;priključaka</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1569"/>
-      <source>Skip Previous Images Sync</source>
-      <translation type="unfinished">Skip Previous Images Sync</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1473"/>
+        <source>manage installed plugins and download new ones</source>
+        <translation>upravljaj instaliranim priključcima i preuzmi nove</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1573"/>
-      <source>Skip Next Images Sync</source>
-      <translation type="unfinished">Skip Next Images Sync</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1478"/>
+        <source>Select &amp;All</source>
+        <translation>Izaberi &amp;sve</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1577"/>
-      <source>Delete File Silent</source>
-      <translation type="unfinished">Delete File Silent</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1485"/>
+        <source>Zoom &amp;Out</source>
+        <translation>Uma&amp;nji</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1578"/>
-      <source>Deletes a file without warning</source>
-      <translation type="unfinished">Deletes a file without warning</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1488"/>
+        <source>Display &amp;Squares</source>
+        <translation>Prikaz &amp;kvadrata</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="407"/>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="888"/>
-      <source>&lt;data too large to display&gt;</source>
-      <translation>&lt;podaci preveliki za prikaz&gt;</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1492"/>
+        <source>Show &amp;Filename</source>
+        <translation>Prikaži &amp;ime fajla</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="797"/>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="522"/>
-      <source>Filename</source>
-      <translation>Ime fajla</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1508"/>
+        <source>&amp;Rename</source>
+        <translation>&amp;Preimenuj</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="798"/>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="525"/>
-      <source>Path</source>
-      <translation>Putanja</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1511"/>
+        <source>&amp;Batch Process</source>
+        <translation>&amp;Grupna obrada</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="529"/>
-      <source>Target</source>
-      <translation>Meta</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1512"/>
+        <source>Adds selected files to batch processing.</source>
+        <translation>Dodaje izabrane fajlove za grupnu obradu.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="799"/>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="533"/>
-      <source>Size</source>
-      <translation>Veličina</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1527"/>
+        <source>Start pong</source>
+        <translation>Pokreni pong</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="537"/>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="540"/>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="543"/>
-      <source>Date</source>
-      <translation>Datum</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1530"/>
+        <source>First File</source>
+        <translation>Prvi fajl</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="537"/>
-      <source>Created</source>
-      <translation>Kreirano</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1531"/>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1547"/>
+        <source>Jump to first file</source>
+        <translation>Skoči na posljedni fajl</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="540"/>
-      <source>Last Modified</source>
-      <translation>Posljednja izmjena</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1534"/>
+        <source>Last File</source>
+        <translation>Posljedni fajl</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="543"/>
-      <source>Last Read</source>
-      <translation>Posljednje pregledano</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1535"/>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1551"/>
+        <source>Jump to the end of the current folder</source>
+        <translation>Skoči na kraj trenutne fascikle</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="547"/>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="560"/>
-      <source>Owner</source>
-      <translation>Vlasnik</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1538"/>
+        <source>Skip Previous Images</source>
+        <translation>Preskoči prethodne slike</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="551"/>
-      <source>OwnerID</source>
-      <translation>Vlasnički ID</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1539"/>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1555"/>
+        <source>Jumps 10 images before the current image</source>
+        <translation>Preskače 10 slika prije trenutne slike</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="555"/>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="574"/>
-      <source>Group</source>
-      <translation>Grupa</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1542"/>
+        <source>Skip Next Images</source>
+        <translation>Preskoči sljedeće slike</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="560"/>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="567"/>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="574"/>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="581"/>
-      <source>Permissions</source>
-      <translation>Dozvole</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1543"/>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1559"/>
+        <source>Jumps 10 images after the current image</source>
+        <translation>Preskače 10 slika poslje trenutne slike</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="567"/>
-      <source>User</source>
-      <translation>Korisnik</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1546"/>
+        <source>First File Sync</source>
+        <translation>Prva sinhronizacija fajla</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="581"/>
-      <source>Other</source>
-      <translation>Drugo</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1550"/>
+        <source>Last File Sync</source>
+        <translation>Posljednja sinhronizacija fajla</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="591"/>
-      <source>File</source>
-      <translation>Fajl</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1554"/>
+        <source>Skip Previous Images Sync</source>
+        <translation>Preskoči sinhronizaciju pretnodne slike</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1485"/>
-      <source>not defined</source>
-      <translation>nije definisano</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1558"/>
+        <source>Skip Next Images Sync</source>
+        <translation>Preskoči sinhronizaciju sljedeće slike</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1486"/>
-      <source>manual</source>
-      <translation>ručno</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1562"/>
+        <source>Delete File Silent</source>
+        <translation>Izbriši tiho fajl</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1487"/>
-      <source>normal</source>
-      <translation>normalno</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1563"/>
+        <source>Deletes a file without warning</source>
+        <translation>Briše fajl bez upozorenja</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1488"/>
-      <source>aperture priority</source>
-      <translation>prioritet otvora</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="403"/>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="882"/>
+        <source>&lt;data too large to display&gt;</source>
+        <translation>&lt;podaci preveliki za prikaz&gt;</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1489"/>
-      <source>shutter priority</source>
-      <translation>prioritet zatvarača</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="518"/>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="798"/>
+        <source>Filename</source>
+        <translation>Ime fajla</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1490"/>
-      <source>program creative</source>
-      <translation>kreativni program</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="521"/>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="799"/>
+        <source>Path</source>
+        <translation>Putanja</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1491"/>
-      <source>high-speed program</source>
-      <translation>program za visoku brzinu</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="525"/>
+        <source>Target</source>
+        <translation>Meta</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1492"/>
-      <source>portrait mode</source>
-      <translation>portret</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="529"/>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="800"/>
+        <source>Size</source>
+        <translation>Veličina</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1493"/>
-      <source>landscape mode</source>
-      <translation>pejzaž</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="533"/>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="536"/>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="539"/>
+        <source>Date</source>
+        <translation>Datum</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1496"/>
-      <source>No Flash</source>
-      <translation>Bez blica</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="533"/>
+        <source>Created</source>
+        <translation>Kreirano</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1497"/>
-      <source>Fired</source>
-      <translation>Aktivirano</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="536"/>
+        <source>Last Modified</source>
+        <translation>Posljednja izmjena</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1498"/>
-      <source>Fired, Return not detected</source>
-      <translation>Aktivirano, povratak nije detektovan</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="539"/>
+        <source>Last Read</source>
+        <translation>Posljednje pregledano</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1499"/>
-      <source>Fired, Return detected</source>
-      <translation>Aktivirano, povratak detektovan</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="543"/>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="556"/>
+        <source>Owner</source>
+        <translation>Vlasnik</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1500"/>
-      <source>On, Did not fire</source>
-      <translation>Uključeno, nije aktivirano</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="547"/>
+        <source>OwnerID</source>
+        <translation>Vlasnički ID</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1501"/>
-      <source>On, Fired</source>
-      <translation>Uključeno, aktivirano</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="551"/>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="570"/>
+        <source>Group</source>
+        <translation>Grupa</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1502"/>
-      <source>On, Return not detected</source>
-      <translation>Uključeno, povratak nije detektovan</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="556"/>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="563"/>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="570"/>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="577"/>
+        <source>Permissions</source>
+        <translation>Dozvole</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1503"/>
-      <source>On, Return detected</source>
-      <translation>Uključeno, povratak detektovan</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="563"/>
+        <source>User</source>
+        <translation>Korisnik</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1504"/>
-      <source>Off, Did not fire</source>
-      <translation>Isključeno, nije aktivirano</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="577"/>
+        <source>Other</source>
+        <translation>Drugo</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1505"/>
-      <source>Off, Did not fire, Return not detected</source>
-      <translation>Isključeno, nije aktivirano, povratak nije detektovan</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="587"/>
+        <source>File</source>
+        <translation>Fajl</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1506"/>
-      <source>Auto, Did not fire</source>
-      <translation>Automatski, nije aktivirano</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1472"/>
+        <source>not defined</source>
+        <translation>nije definisano</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1507"/>
-      <source>Auto, Fired</source>
-      <translation>Automatski, aktivirano</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1473"/>
+        <source>manual</source>
+        <translation>ručno</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1508"/>
-      <source>Auto, Fired, Return not detected</source>
-      <translation>Automatski, aktivirano, povratak nije detektovan</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1474"/>
+        <source>normal</source>
+        <translation>normalno</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1509"/>
-      <source>Auto, Fired, Return detected</source>
-      <translation>Automatski, aktivirano, povratak detektovan</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1475"/>
+        <source>aperture priority</source>
+        <translation>prioritet otvora</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1510"/>
-      <source>No flash function</source>
-      <translation>Blic isključen</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1476"/>
+        <source>shutter priority</source>
+        <translation>prioritet zatvarača</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1511"/>
-      <source>Off, No flash function</source>
-      <translation>Isključeno, bez blica</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1477"/>
+        <source>program creative</source>
+        <translation>kreativni program</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1512"/>
-      <source>Fired, Red-eye reduction</source>
-      <translation>Aktivirano, redukcija crvenih očiju</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1478"/>
+        <source>high-speed program</source>
+        <translation>program za visoku brzinu</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1513"/>
-      <source>Fired, Red-eye reduction, Return not detected</source>
-      <translation>Aktivirano, redukcija crvenih očiju, povratak nije detektovan</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1479"/>
+        <source>portrait mode</source>
+        <translation>portret</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1514"/>
-      <source>Fired, Red-eye reduction, Return detected</source>
-      <translation>Aktivirano, redukcija crvenih očiju, povratak detektovan</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1480"/>
+        <source>landscape mode</source>
+        <translation>pejzaž</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1515"/>
-      <source>On, Red-eye reduction</source>
-      <translation>Uključeno, redukcija crvenih očiju</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1483"/>
+        <source>No Flash</source>
+        <translation>Bez blica</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1516"/>
-      <source>On, Red-eye reduction, Return not detected</source>
-      <translation>Uključeno, redukcija crvenih očiju, povratak nije detektovan</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1484"/>
+        <source>Fired</source>
+        <translation>Aktivirano</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1517"/>
-      <source>On, Red-eye reduction, Return detected</source>
-      <translation>Uključeno, redukcija crvenih očiju, povratak detektovan</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1485"/>
+        <source>Fired, Return not detected</source>
+        <translation>Aktivirano, povratak nije detektovan</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1518"/>
-      <source>Off, Red-eye reduction</source>
-      <translation>Isključeno, redukcija crvenih očiju</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1486"/>
+        <source>Fired, Return detected</source>
+        <translation>Aktivirano, povratak detektovan</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1519"/>
-      <source>Auto, Did not fire, Red-eye reduction</source>
-      <translation>Automatski, nije aktivirano, redukcija crvenih očiju</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1487"/>
+        <source>On, Did not fire</source>
+        <translation>Uključeno, nije aktivirano</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1520"/>
-      <source>Auto, Fired, Red-eye reduction</source>
-      <translation>Automatski, aktivirano, redukcija crvenih očiju</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1488"/>
+        <source>On, Fired</source>
+        <translation>Uključeno, aktivirano</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1521"/>
-      <source>Auto, Fired, Red-eye reduction, Return not detected</source>
-      <translation>Automatski, aktivirano, redukcija crvenih očiju, povratak nije detektovan</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1489"/>
+        <source>On, Return not detected</source>
+        <translation>Uključeno, povratak nije detektovan</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1522"/>
-      <source>Auto, Fired, Red-eye reduction, Return detected</source>
-      <translation>Automatski, aktivirano, redukcija crvenih očiju, povratak detektovan</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1490"/>
+        <source>On, Return detected</source>
+        <translation>Uključeno, povratak detektovan</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkCentralWidget.cpp" line="201"/>
-      <source>New Tab</source>
-      <translation>Nova kartica</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1491"/>
+        <source>Off, Did not fire</source>
+        <translation>Isključeno, nije aktivirano</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkCentralWidget.cpp" line="204"/>
-      <source>Thumbnail Preview</source>
-      <translation>Pregled sličica</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1492"/>
+        <source>Off, Did not fire, Return not detected</source>
+        <translation>Isključeno, nije aktivirano, povratak nije detektovan</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkCentralWidget.cpp" line="206"/>
-      <source>Settings</source>
-      <translation type="unfinished">Settings</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1493"/>
+        <source>Auto, Did not fire</source>
+        <translation>Automatski, nije aktivirano</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkCentralWidget.cpp" line="208"/>
-      <source>Batch</source>
-      <translation type="unfinished">Batch</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1494"/>
+        <source>Auto, Fired</source>
+        <translation>Automatski, aktivirano</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="90"/>
-      <source>[Resize Batch]</source>
-      <translation>[Grupna promjena veličine]</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1495"/>
+        <source>Auto, Fired, Return not detected</source>
+        <translation>Automatski, aktivirano, povratak nije detektovan</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="116"/>
-      <source>%1 scale factor is 1 -&gt; ignoring</source>
-      <translation>%1 faktor skaliranja je 1 -&gt; ignorisano</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1496"/>
+        <source>Auto, Fired, Return detected</source>
+        <translation>Automatski, aktivirano, povratak detektovan</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="127"/>
-      <source>%1 no need for resizing.</source>
-      <translation>%1 nema potrebe za promjenom veličine.</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1497"/>
+        <source>No flash function</source>
+        <translation>Blic isključen</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="132"/>
-      <source>%1 could not resize image.</source>
-      <translation>%1 ne mogu promijeniti veličinu slike.</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1498"/>
+        <source>Off, No flash function</source>
+        <translation>Isključeno, bez blica</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="137"/>
-      <source>%1 image resized, scale factor: %2%</source>
-      <translation>%1 promijenjena veličina slike, faktor skaliranja: %2%</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1499"/>
+        <source>Fired, Red-eye reduction</source>
+        <translation>Aktivirano, redukcija crvenih očiju</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="139"/>
-      <source>%1 image resized, new side: %2 px</source>
-      <translation>%1 promijenjena veličina slike, nova veličina %2 px</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1500"/>
+        <source>Fired, Red-eye reduction, Return not detected</source>
+        <translation>Aktivirano, redukcija crvenih očiju, povratak nije detektovan</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="172"/>
-      <source>%1 I need to increase the image, but the option is set to decrease only -&gt; skipping.</source>
-      <translation>%1 Trebam povećati sliku, ali dozvoljeno je samo smanjivanje prema postavkama-&gt; preskočeno.</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1501"/>
+        <source>Fired, Red-eye reduction, Return detected</source>
+        <translation>Aktivirano, redukcija crvenih očiju, povratak detektovan</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="176"/>
-      <source>%1 I need to decrease the image, but the option is set to increase only -&gt; skipping.</source>
-      <translation>%1 Trebam smanjiti sliku, ali dozvoljeno je samo uvećavanje prema postavkama -&gt; preskočeno.</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1502"/>
+        <source>On, Red-eye reduction</source>
+        <translation>Uključeno, redukcija crvenih očiju</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="180"/>
-      <source>%1 image size matches scale factor -&gt; skipping.</source>
-      <translation>%1 veličina slike odgovara faktoru skaliranja -&gt; preskočeno.</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1503"/>
+        <source>On, Red-eye reduction, Return not detected</source>
+        <translation>Uključeno, redukcija crvenih očiju, povratak nije detektovan</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="198"/>
-      <source>[Transform Batch]</source>
-      <translation>[Grupna transformacija]</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1504"/>
+        <source>On, Red-eye reduction, Return detected</source>
+        <translation>Uključeno, redukcija crvenih očiju, povratak detektovan</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="218"/>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="295"/>
-      <source>%1 inactive -&gt; skipping</source>
-      <translation>%1 neaktivan -&gt; preskočeno</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1505"/>
+        <source>Off, Red-eye reduction</source>
+        <translation>Isključeno, redukcija crvenih očiju</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="242"/>
-      <source>%1 image transformed.</source>
-      <translation>%1 slike transformisane.</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1506"/>
+        <source>Auto, Did not fire, Red-eye reduction</source>
+        <translation>Automatski, nije aktivirano, redukcija crvenih očiju</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="248"/>
-      <source>%1 error, could not transform image.</source>
-      <translation>%1 greška, ne mogu transformisati sliku.</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1507"/>
+        <source>Auto, Fired, Red-eye reduction</source>
+        <translation>Automatski, aktivirano, redukcija crvenih očiju</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="334"/>
-      <source>%1 Cannot apply %2.</source>
-      <translation>%1 ne mogu primjeniti %2.</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1508"/>
+        <source>Auto, Fired, Red-eye reduction, Return not detected</source>
+        <translation>Automatski, aktivirano, redukcija crvenih očiju, povratak nije detektovan</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="77"/>
-      <source>Batch Action</source>
-      <translation type="unfinished">Batch Action</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1509"/>
+        <source>Auto, Fired, Red-eye reduction, Return detected</source>
+        <translation>Automatski, aktivirano, redukcija crvenih očiju, povratak detektovan</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="244"/>
-      <source>%1 image transformed and cropped.</source>
-      <translation type="unfinished">%1 image transformed and cropped.</translation>
+        <location filename="../src/DkGui/DkCentralWidget.cpp" line="221"/>
+        <source>New Tab</source>
+        <translation>Nova kartica</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="326"/>
-      <source>%1 Cannot cast batch plugin %2.</source>
-      <translation type="unfinished">%1 Cannot cast batch plugin %2.</translation>
+        <location filename="../src/DkGui/DkCentralWidget.cpp" line="224"/>
+        <source>Thumbnail Preview</source>
+        <translation>Pregled sličica</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="337"/>
-      <source>%1 illegal plugin interface: %2</source>
-      <translation>%1 nedozvoljeno sučelje za priključak: %2</translation>
+        <location filename="../src/DkGui/DkCentralWidget.cpp" line="226"/>
+        <source>Settings</source>
+        <translation>Postavke</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="340"/>
-      <source>%1 Cannot apply plugin because it is NULL.</source>
-      <translation type="unfinished">%1 Cannot apply plugin because it is NULL.</translation>
+        <location filename="../src/DkGui/DkCentralWidget.cpp" line="228"/>
+        <source>Batch</source>
+        <translation>Grupna obrada</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="344"/>
-      <source>%1 error, could not apply plugins.</source>
-      <translation>%1 greška, ne mogu primjeniti priključke.</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="268"/>
+        <source>%1 image resized, scale factor: %2%</source>
+        <translation>%1 promijenjena veličina slike, faktor skaliranja: %2%</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="348"/>
-      <source>%1 plugins applied.</source>
-      <translation>%1 priključaka primjenjeno.</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="270"/>
+        <source>%1 image resized, new side: %2 px</source>
+        <translation>%1 promijenjena veličina slike, nova veličina %2 px</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="354"/>
-      <source>[Plugin Batch]</source>
-      <translation>[Grupni dodaci]</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="310"/>
+        <source>%1 I need to increase the image, but the option is set to decrease only -&gt; skipping.</source>
+        <translation>%1 Trebam povećati sliku, ali dozvoljeno je samo smanjivanje prema postavkama-&gt; preskočeno.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="471"/>
-      <source>%1 already exists -&gt; skipping (check 'overwrite' if you want to overwrite the file)</source>
-      <translation>%1 već postoji -&gt; preskočeno (označite 'pisati preko' ako želite da pišete preko fajla)</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="314"/>
+        <source>%1 I need to decrease the image, but the option is set to increase only -&gt; skipping.</source>
+        <translation>%1 Trebam smanjiti sliku, ali dozvoljeno je samo uvećavanje prema postavkama -&gt; preskočeno.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="476"/>
-      <source>Error: input file does not exist</source>
-      <translation>Greška: ulazni fajl ne postoji</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="318"/>
+        <source>%1 image size matches scale factor -&gt; skipping.</source>
+        <translation>%1 veličina slike odgovara faktoru skaliranja -&gt; preskočeno.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="477"/>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="594"/>
-      <source>Input: %1</source>
-      <translation>Ulaz: %1</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="126"/>
+        <source>[Transform Batch]</source>
+        <translation>[Grupna transformacija]</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="482"/>
-      <source>Skipping: nothing to do here.</source>
-      <translation>Preskočeno: bez posla ovdje.</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="226"/>
+        <location filename="../src/DkCore/DkProcess.cpp" line="359"/>
+        <location filename="../src/DkCore/DkProcess.cpp" line="488"/>
+        <source>%1 inactive -&gt; skipping</source>
+        <translation>%1 neaktivan -&gt; preskočeno</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="514"/>
-      <source>processing %1</source>
-      <translation>obrađujem %1</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="265"/>
+        <source>%1 image transformed.</source>
+        <translation>%1 slike transformisane.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="519"/>
-      <source>Error while loading...</source>
-      <translation>Greška pri učitavanju...</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="277"/>
+        <source>%1 error, could not transform image.</source>
+        <translation>%1 greška, ne mogu transformisati sliku.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="527"/>
-      <source>Error: cannot process a NULL function.</source>
-      <translation>Greška: ne mogu obraditi NULL funkciju.</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="373"/>
+        <location filename="../src/DkCore/DkProcess.cpp" line="527"/>
+        <source>%1 Cannot apply %2.</source>
+        <translation>%1 ne mogu primjeniti %2.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="533"/>
-      <source>%1 failed</source>
-      <translation>%1 neuspijelo</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="80"/>
+        <source>Batch Action</source>
+        <translation>Grupne radnje</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="547"/>
-      <source>%1 saved...</source>
-      <translation>%1 sačuvano...</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="262"/>
+        <source>transformed</source>
+        <translation>transformisano</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="550"/>
-      <source>Could not save: %1</source>
-      <translation>Nije moguće sačuvati: %1</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="273"/>
+        <source>%1 image transformed and cropped.</source>
+        <translation>%1 slika transformisana i izrezana.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="565"/>
-      <source>Error: could not rename file, the target file exists already.</source>
-      <translation>Greška: ne mogu preimenovati fajl, željeni fajl već postoji.</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="370"/>
+        <source>%1 %2 applied.</source>
+        <translation>%1 %2 primijenjeno.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="573"/>
-      <source>Error: could not rename file</source>
-      <translation>Greška: ne mogu preimenovati fajl</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="379"/>
+        <source>%1 error, could not apply image adjustments.</source>
+        <translation>%1 greška, nemoguće primijeniti podešavanja slike.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="578"/>
-      <source>Renaming: %1 -&gt; %2</source>
-      <translation>Preimenovanje: %1 -&gt; %2</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="387"/>
+        <source>[Adjustment Batch]</source>
+        <translation>[Grupna podešavanja]</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="593"/>
-      <source>Error: could not copy file</source>
-      <translation>Greška: ne mogu kopirati fajl</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="519"/>
+        <source>%1 Cannot cast batch plugin %2.</source>
+        <translation>%1 ne mogu odraditi grupni priključak %2.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="595"/>
-      <source>Output: %1</source>
-      <translation>Izlaz: %1</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="530"/>
+        <source>%1 illegal plugin interface: %2</source>
+        <translation>%1 nedozvoljeno sučelje za priključak: %2</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="600"/>
-      <source>Copying: %1 -&gt; %2</source>
-      <translation>Kopiram: %1 -&gt; %2</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="533"/>
+        <source>%1 Cannot apply plugin because it is NULL.</source>
+        <translation>%1 ne mogu prihvatiti priključaka jer je NULL.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="615"/>
-      <source>Error: back-up (%1) file already exists</source>
-      <translation>Greška: rezervna kopija (%1)  fajla već postoji</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="537"/>
+        <source>%1 error, could not apply plugins.</source>
+        <translation>%1 greška, ne mogu primjeniti priključke.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="622"/>
-      <source>Error: could not rename existing file to %1</source>
-      <translation>Greška: ne mogu preimenovati postojeći fajl u %1</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="541"/>
+        <source>%1 plugins applied.</source>
+        <translation>%1 priključaka primjenjeno.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="640"/>
-      <source>Error: could not delete existing file</source>
-      <translation>Greška: ne mogu izbrisati postojeći fajl</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="547"/>
+        <source>[Plugin Batch]</source>
+        <translation>[Grupni dodaci]</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="651"/>
-      <source>Ui - a lot of things went wrong sorry, your original file can be found here: %1</source>
-      <translation>Uj - izvinjavamo se za više grešaka koje su se dogodile, vaš originalni fajl možete naći ovdje: %1</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="660"/>
+        <source>%1 already exists -&gt; skipping (check &apos;overwrite&apos; if you want to overwrite the file)</source>
+        <translation>%1 već postoji -&gt; preskočeno (označite &apos;pisati preko&apos; ako želite da pišete preko fajla)</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="656"/>
-      <source>I could not save to %1 so I restored the original file.</source>
-      <translation>Nije moguće sačuvati na %1 pa je originalni fajl vraćen.</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="665"/>
+        <source>Error: input file does not exist</source>
+        <translation>Greška: ulazni fajl ne postoji</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="672"/>
-      <source>%1 deleted.</source>
-      <translation>%1 izbrisan.</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="666"/>
+        <location filename="../src/DkCore/DkProcess.cpp" line="798"/>
+        <source>Input: %1</source>
+        <translation>Ulaz: %1</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="675"/>
-      <source>I could not delete %1</source>
-      <translation>Nije moguće izbrisati %1</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="671"/>
+        <source>Skipping: nothing to do here.</source>
+        <translation>Preskočeno: bez posla ovdje.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="680"/>
-      <source>I did not delete the original because I detected %1 failure(s).</source>
-      <translation>Nije izbrisan origininal jer je otkrivena %1 greška(e).</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="707"/>
+        <source>processing %1</source>
+        <translation>obrađujem %1</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="932"/>
-      <source>nomacs - Image Lounge is a lightweight image viewer.</source>
-      <translation>nomacs - Salon slika je lagani pregledač slika.</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="712"/>
+        <source>Error while loading...</source>
+        <translation>Greška pri učitavanju...</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPong.h" line="88"/>
-      <source>Player 1</source>
-      <translation type="unfinished">Player 1</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="720"/>
+        <source>Error: cannot process a NULL function.</source>
+        <translation>Greška: ne mogu obraditi NULL funkciju.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPong.h" line="89"/>
-      <source>Player 2</source>
-      <translation type="unfinished">Player 2</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="726"/>
+        <source>%1 failed</source>
+        <translation>%1 neuspijelo</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPong.h" line="99"/>
-      <source>Anonymous</source>
-      <translation type="unfinished">Anonymous</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="741"/>
+        <source>%1 not saved - option &apos;Do not Save&apos; is checked...</source>
+        <translation>%1 nije sačuvan - opcija &apos;Nemoj sačuvati&apos; je uključena...</translation>
     </message>
     <message>
-      <location filename="../src/main.cpp" line="121"/>
-      <source>An input image.</source>
-      <translation type="unfinished">An input image.</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="746"/>
+        <source>%1 saved...</source>
+        <translation>%1 sačuvano...</translation>
     </message>
     <message>
-      <location filename="../src/main.cpp" line="124"/>
-      <source>Start in fullscreen.</source>
-      <translation type="unfinished">Start in fullscreen.</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="749"/>
+        <source>Could not save: %1</source>
+        <translation>Nije moguće sačuvati: %1</translation>
     </message>
     <message>
-      <location filename="../src/main.cpp" line="127"/>
-      <source>Start Pong.</source>
-      <translation type="unfinished">Start Pong.</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="764"/>
+        <source>Error: could not rename file, the target file exists already.</source>
+        <translation>Greška: ne mogu preimenovati fajl, željeni fajl već postoji.</translation>
     </message>
     <message>
-      <location filename="../src/main.cpp" line="130"/>
-      <source>Start in private mode.</source>
-      <translation type="unfinished">Start in private mode.</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="772"/>
+        <source>Error: could not rename file</source>
+        <translation>Greška: ne mogu preimenovati fajl</translation>
     </message>
     <message>
-      <location filename="../src/main.cpp" line="134"/>
-      <source>Set the viewing mode &lt;mode&gt;.</source>
-      <translation type="unfinished">Set the viewing mode &lt;mode&gt;.</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="777"/>
+        <source>Renaming: %1 -&gt; %2</source>
+        <translation>Preimenovanje: %1 -&gt; %2</translation>
     </message>
     <message>
-      <location filename="../src/main.cpp" line="135"/>
-      <source>default | frameless | pseudocolor</source>
-      <translation type="unfinished">default | frameless | pseudocolor</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="787"/>
+        <source>I should copy the file, but &apos;Do not Save&apos; is checked - so I will do nothing...</source>
+        <translation>Zahtijevano kopiranje, ali &apos;Nemoj sačuvati&apos; je uključeno - ignorišem...</translation>
     </message>
     <message>
-      <location filename="../src/main.cpp" line="139"/>
-      <source>Load all files of a &lt;directory&gt;.</source>
-      <translation type="unfinished">Load all files of a &lt;directory&gt;.</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="797"/>
+        <source>Error: could not copy file</source>
+        <translation>Greška: ne mogu kopirati fajl</translation>
     </message>
     <message>
-      <location filename="../src/main.cpp" line="140"/>
-      <source>directory</source>
-      <translation type="unfinished">directory</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="799"/>
+        <source>Output: %1</source>
+        <translation>Izlaz: %1</translation>
     </message>
     <message>
-      <location filename="../src/main.cpp" line="144"/>
-      <source>Load &lt;images&gt; to tabs.</source>
-      <translation type="unfinished">Load &lt;images&gt; to tabs.</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="804"/>
+        <source>Copying: %1 -&gt; %2</source>
+        <translation>Kopiram: %1 -&gt; %2</translation>
     </message>
     <message>
-      <location filename="../src/main.cpp" line="145"/>
-      <source>images</source>
-      <translation type="unfinished">images</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="817"/>
+        <source>Error: back-up (%1) file already exists</source>
+        <translation>Greška: rezervna kopija (%1)  fajla već postoji</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUtils.cpp" line="636"/>
-      <source>Binary</source>
-      <translation type="unfinished">Binary</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="825"/>
+        <source>Error: could not rename existing file to %1</source>
+        <translation>Greška: ne mogu preimenovati postojeći fajl u %1</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUtils.cpp" line="637"/>
-      <source>Indexed 8-bit</source>
-      <translation type="unfinished">Indexed 8-bit</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="843"/>
+        <source>Error: could not delete existing file</source>
+        <translation>Greška: ne mogu izbrisati postojeći fajl</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUtils.cpp" line="643"/>
-      <source>RGB 32-bit</source>
-      <translation type="unfinished">RGB 32-bit</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="854"/>
+        <source>Ui - a lot of things went wrong sorry, your original file can be found here: %1</source>
+        <translation>Uj - izvinjavamo se za više grešaka koje su se dogodile, vaš originalni fajl možete naći ovdje: %1</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUtils.cpp" line="649"/>
-      <source>ARGB 32-bit</source>
-      <translation type="unfinished">ARGB 32-bit</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="859"/>
+        <source>I could not save to %1 so I restored the original file.</source>
+        <translation>Nije moguće sačuvati na %1 pa je originalni fajl vraćen.</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUtils.cpp" line="652"/>
-      <source>RGB 16-bit</source>
-      <translation type="unfinished">RGB 16-bit</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="875"/>
+        <source>%1 deleted.</source>
+        <translation>%1 izbrisan.</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUtils.cpp" line="655"/>
-      <source>ARGB 24-bit</source>
-      <translation type="unfinished">ARGB 24-bit</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="878"/>
+        <source>I could not delete %1</source>
+        <translation>Nije moguće izbrisati %1</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUtils.cpp" line="657"/>
-      <source>RGB 24-bit</source>
-      <translation type="unfinished">RGB 24-bit</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="883"/>
+        <source>I did not delete the original because I detected %1 failure(s).</source>
+        <translation>Nije izbrisan origininal jer je otkrivena %1 greška(e).</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUtils.cpp" line="658"/>
-      <source>ARGB 16-bit</source>
-      <translation type="unfinished">ARGB 16-bit</translation>
+        <location filename="../src/DkCore/DkSettings.cpp" line="1027"/>
+        <source>nomacs - Image Lounge is a lightweight image viewer.</source>
+        <translation>nomacs - Salon slika je lagani pregledač slika.</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUtils.cpp" line="661"/>
-      <source>BGR 32-bit</source>
-      <translation type="unfinished">BGR 32-bit</translation>
+        <location filename="../src/DkGui/DkPong.h" line="88"/>
+        <source>Player 1</source>
+        <translation>Igrač 1</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUtils.cpp" line="662"/>
-      <source>ABGR 32-bit</source>
-      <translation type="unfinished">ABGR 32-bit</translation>
+        <location filename="../src/DkGui/DkPong.h" line="89"/>
+        <source>Player 2</source>
+        <translation>Igrač 2</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUtils.cpp" line="663"/>
-      <source>Grayscale 8-bit</source>
-      <translation type="unfinished">Grayscale 8-bit</translation>
+        <location filename="../src/DkGui/DkPong.h" line="99"/>
+        <source>Anonymous</source>
+        <translation>Anonimno</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUtils.cpp" line="664"/>
-      <source>Alpha 8-bit</source>
-      <translation type="unfinished">Alpha 8-bit</translation>
+        <location filename="../src/main.cpp" line="118"/>
+        <source>An input image.</source>
+        <translation>Ulazna slika.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageContainer.cpp" line="142"/>
-      <source>Cropped</source>
-      <translation type="unfinished">Cropped</translation>
+        <location filename="../src/main.cpp" line="121"/>
+        <source>Start in fullscreen.</source>
+        <translation>Pokreni preko cijelog ekrana.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkPluginManager.cpp" line="1094"/>
-      <source>Plugin Manager</source>
-      <translation type="unfinished">Plugin Manager</translation>
+        <location filename="../src/main.cpp" line="124"/>
+        <source>Start Pong.</source>
+        <translation>Pokreni Pong.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkPluginManager.cpp" line="1094"/>
-      <source>The dll could not be deleted!
+        <location filename="../src/main.cpp" line="127"/>
+        <source>Start in private mode.</source>
+        <translation>Pokreni u privatnom načinu rada.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="131"/>
+        <source>Set the viewing mode &lt;mode&gt;.</source>
+        <translation>Postavlja način prikaza &lt;mode&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="132"/>
+        <source>default | frameless | pseudocolor</source>
+        <translation>zadani | bez okvira | pseudo boja</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="136"/>
+        <source>Load all files of a &lt;directory&gt;.</source>
+        <translation>Učitaj sve fajlove iz &lt;directory&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="137"/>
+        <source>directory</source>
+        <translation>direktorij</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="141"/>
+        <source>Load &lt;images&gt; to tabs.</source>
+        <translation>Učitaj &lt;images&gt; u kartice.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="142"/>
+        <source>images</source>
+        <translation>slike</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="146"/>
+        <source>Batch processing of &lt;batch-settings.pnm&gt;.</source>
+        <translation>Grupno procesovanje &lt;batch-settings.pnm&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="147"/>
+        <source>batch-settings-path</source>
+        <translation>putanja grupnog podešavanja</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="151"/>
+        <source>Saves batch log to &lt;log-path.txt&gt;.</source>
+        <translation>Sačuva zapis grupnog podešavanja u &lt;log-path.txt&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="152"/>
+        <source>log-path.txt</source>
+        <translation>putanja-zapisa.txt</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="156"/>
+        <source>Imports the settings from &lt;settings-path.nfo&gt; and saves them.</source>
+        <translation>Unosi postavke iz &lt;settings-path.nfo&gt; i sačuva ih.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="157"/>
+        <source>settings-path.nfo</source>
+        <translation>postavke-putanja.nfo</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="299"/>
+        <source>Critical Error</source>
+        <translation>Kritična greška</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="300"/>
+        <source>Sorry, nomacs ran out of memory...</source>
+        <translation>Žao nam je, nomacs je ostao bez memorije...</translation>
+    </message>
+    <message>
+        <location filename="../src/DkCore/DkUtils.cpp" line="772"/>
+        <source>Binary</source>
+        <translation>Binarni</translation>
+    </message>
+    <message>
+        <location filename="../src/DkCore/DkUtils.cpp" line="773"/>
+        <source>Indexed 8-bit</source>
+        <translation>Indeksirani 8-bit</translation>
+    </message>
+    <message>
+        <location filename="../src/DkCore/DkUtils.cpp" line="779"/>
+        <source>RGB 32-bit</source>
+        <translation>RGB 32-bita</translation>
+    </message>
+    <message>
+        <location filename="../src/DkCore/DkUtils.cpp" line="785"/>
+        <source>ARGB 32-bit</source>
+        <translation>ARGB 32-bita</translation>
+    </message>
+    <message>
+        <location filename="../src/DkCore/DkUtils.cpp" line="788"/>
+        <source>RGB 16-bit</source>
+        <translation>RGB 16-bita</translation>
+    </message>
+    <message>
+        <location filename="../src/DkCore/DkUtils.cpp" line="791"/>
+        <source>ARGB 24-bit</source>
+        <translation>ARGB 24-bita</translation>
+    </message>
+    <message>
+        <location filename="../src/DkCore/DkUtils.cpp" line="793"/>
+        <source>RGB 24-bit</source>
+        <translation>RGB 24-bita</translation>
+    </message>
+    <message>
+        <location filename="../src/DkCore/DkUtils.cpp" line="794"/>
+        <source>ARGB 16-bit</source>
+        <translation>ARGB 16-bita</translation>
+    </message>
+    <message>
+        <location filename="../src/DkCore/DkUtils.cpp" line="797"/>
+        <source>BGR 32-bit</source>
+        <translation>BGR 32-bita</translation>
+    </message>
+    <message>
+        <location filename="../src/DkCore/DkUtils.cpp" line="798"/>
+        <source>ABGR 32-bit</source>
+        <translation>ABGR 32-bita</translation>
+    </message>
+    <message>
+        <location filename="../src/DkCore/DkUtils.cpp" line="799"/>
+        <source>Grayscale 8-bit</source>
+        <translation>Crno-bijelo 8-bita</translation>
+    </message>
+    <message>
+        <location filename="../src/DkCore/DkUtils.cpp" line="800"/>
+        <source>Alpha 8-bit</source>
+        <translation>Alfa 8-bita</translation>
+    </message>
+    <message>
+        <location filename="../src/DkCore/DkImageContainer.cpp" line="141"/>
+        <source>Cropped</source>
+        <translation>Izrezano</translation>
+    </message>
+    <message>
+        <location filename="../src/DkCore/DkPluginManager.cpp" line="1101"/>
+        <source>Plugin Manager</source>
+        <translation>Upravljač priključaka</translation>
+    </message>
+    <message>
+        <location filename="../src/DkCore/DkPluginManager.cpp" line="1102"/>
+        <source>The dll could not be deleted!
 Please restart nomacs and try again.</source>
-      <translation type="unfinished">The dll could not be deleted!
-Please restart nomacs and try again.</translation>
+        <translation>Ne mogu izbrisati dll!
+Molim restartujte nomacs i pokušajte ponovo.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkPluginManager.cpp" line="1241"/>
-      <source>Close plugin</source>
-      <translation type="unfinished">Close plugin</translation>
+        <location filename="../src/DkCore/DkPluginManager.cpp" line="1276"/>
+        <source>Close plugin</source>
+        <translation>Ugasi priključak</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkPluginManager.cpp" line="1243"/>
-      <source>Please close the currently opened plugin.</source>
-      <translation type="unfinished">Please close the currently opened plugin.</translation>
+        <location filename="../src/DkCore/DkPluginManager.cpp" line="1278"/>
+        <source>Please close the currently opened plugin.</source>
+        <translation>Molim zatvorite trenutno otvoreni priključak.</translation>
     </message>
-  </context>
-  <context>
+    <message>
+        <location filename="../src/DkCore/DkManipulatorsIpl.cpp" line="54"/>
+        <source>Could not convert to grayscale</source>
+        <translation>Neuspijelo konvertovanje u crno-bijelo</translation>
+    </message>
+    <message>
+        <location filename="../src/DkCore/DkManipulatorsIpl.cpp" line="71"/>
+        <source>Cannot auto adjust</source>
+        <translation>Nemoguće automatsko prilagođavanje</translation>
+    </message>
+    <message>
+        <location filename="../src/DkCore/DkManipulatorsIpl.cpp" line="89"/>
+        <source>The Image is Already Normalized...</source>
+        <translation>Slika je već normalizovana...</translation>
+    </message>
+    <message>
+        <location filename="../src/DkCore/DkManipulatorsIpl.cpp" line="104"/>
+        <source>Cannot invert image</source>
+        <translation>Nemoguće obrnuti sliku</translation>
+    </message>
+    <message>
+        <location filename="../src/DkCore/DkManipulatorsIpl.cpp" line="117"/>
+        <location filename="../src/DkCore/DkManipulatorsIpl.cpp" line="129"/>
+        <source>Cannot flip image</source>
+        <translation>Nemoguće prevrnuti sliku</translation>
+    </message>
+    <message>
+        <location filename="../src/DkCore/DkManipulatorsIpl.cpp" line="151"/>
+        <source>Sorry, I could not create a tiny planet</source>
+        <translation>Žao nam je, ne može se napraviti mala planeta</translation>
+    </message>
+    <message>
+        <location filename="../src/DkCore/DkManipulatorsIpl.cpp" line="205"/>
+        <source>Cannot sharpen image</source>
+        <translation>Nemoguće izoštriti sliku</translation>
+    </message>
+    <message>
+        <location filename="../src/DkCore/DkManipulatorsIpl.cpp" line="243"/>
+        <source>Cannot rotate image</source>
+        <translation>Nemoguće rotirati sliku</translation>
+    </message>
+    <message>
+        <location filename="../src/DkCore/DkManipulatorsIpl.cpp" line="269"/>
+        <source>Cannot threshold image</source>
+        <translation>Nemoguće primjeniti prag na sliku</translation>
+    </message>
+    <message>
+        <location filename="../src/DkCore/DkManipulatorsIpl.cpp" line="307"/>
+        <source>Cannot change Hue/Saturation</source>
+        <translation>Nemoguće promjeniti nijansu/zasićenje</translation>
+    </message>
+    <message>
+        <location filename="../src/DkCore/DkManipulatorsIpl.cpp" line="357"/>
+        <source>Cannot apply exposure</source>
+        <translation>Nemoguće primjeniti ekspoziciju</translation>
+    </message>
+</context>
+<context>
     <name>QObject::QObject</name>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1533"/>
-      <source>Lena</source>
-      <translation>Lena</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1518"/>
+        <source>Lena</source>
+        <translation>Lena</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1534"/>
-      <source>Show test image</source>
-      <translation type="unfinished">Show test image</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1519"/>
+        <source>Show test image</source>
+        <translation>Prikazuje test sliku</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1537"/>
-      <source>All Images</source>
-      <translation>Sve slike</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1522"/>
+        <source>All Images</source>
+        <translation>Sve slike</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1538"/>
-      <source>Generates all images in the world</source>
-      <translation type="unfinished">Generates all images in the world</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1523"/>
+        <source>Generates all images in the world</source>
+        <translation>Generiše sve slike na svijetu</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1541"/>
-      <source>Pong</source>
-      <translation type="unfinished">Pong</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1526"/>
+        <source>Pong</source>
+        <translation>Pong</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkAdvancedPreference</name>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1138"/>
-      <source>Always Load JPG if Embedded</source>
-      <translation type="unfinished">Always Load JPG if Embedded</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1228"/>
+        <source>Always Load JPG if Embedded</source>
+        <translation>Uvijek učitaj JPG ako je umetnut</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1139"/>
-      <source>Load JPG if it Fits the Screen Resolution</source>
-      <translation type="unfinished">Load JPG if it Fits the Screen Resolution</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1229"/>
+        <source>Load JPG if it Fits the Screen Resolution</source>
+        <translation>Učitaj JPG ako odgovara rezoluciji ekrana</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1140"/>
-      <source>Always Load RAW Data</source>
-      <translation type="unfinished">Always Load RAW Data</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1230"/>
+        <source>Always Load RAW Data</source>
+        <translation>Uvijek učitaj RAW podatke</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1151"/>
-      <source>Apply Noise Filtering to RAW Images</source>
-      <translation type="unfinished">Apply Noise Filtering to RAW Images</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1241"/>
+        <source>Apply Noise Filtering to RAW Images</source>
+        <translation>Prihvati filtriranje šuma na RAW slikama</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1153"/>
-      <source>If checked, a noise filter is applied which reduced color noise</source>
-      <translation type="unfinished">If checked, a noise filter is applied which reduced color noise</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1243"/>
+        <source>If checked, a noise filter is applied which reduced color noise</source>
+        <translation>Ako je čekirano, filter šuma smanjuje šum boja</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1156"/>
-      <source>RAW Loader Settings</source>
-      <translation type="unfinished">RAW Loader Settings</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1246"/>
+        <source>RAW Loader Settings</source>
+        <translation>Postavke RAW čitača</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1164"/>
-      <source>Ask to Save Deleted Files</source>
-      <translation type="unfinished">Ask to Save Deleted Files</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1254"/>
+        <source>Ask to Save Deleted Files</source>
+        <translation>Pitaj da spasi obrisane fajlove</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1166"/>
-      <source>If checked, nomacs asked to save files which were deleted by other applications</source>
-      <translation type="unfinished">If checked, nomacs asked to save files which were deleted by other applications</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1256"/>
+        <source>If checked, nomacs asked to save files which were deleted by other applications</source>
+        <translation>Ako je označeno, nomacs pita da spasi fajlove koji su izbrisani od strane drugih aplikacija</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1169"/>
-      <source>Ignore Exif Orientation when Loading</source>
-      <translation type="unfinished">Ignore Exif Orientation when Loading</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1259"/>
+        <source>Ignore Exif Orientation when Loading</source>
+        <translation>Ignoriši Exif orijentaciju prilikom učitavanja</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1171"/>
-      <source>If checked, images are NOT rotated with respect to their Exif orientation</source>
-      <translation type="unfinished">If checked, images are NOT rotated with respect to their Exif orientation</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1261"/>
+        <source>If checked, images are NOT rotated with respect to their Exif orientation</source>
+        <translation>Ako je označeno, slike NEĆE biti rotirane prema Exif orijentaciji</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1174"/>
-      <source>Save Exif Orientation</source>
-      <translation type="unfinished">Save Exif Orientation</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1264"/>
+        <source>Save Exif Orientation</source>
+        <translation>Snimi Exif orijentaciju</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1176"/>
-      <source>If checked, orientation is written to the Exif rather than rotating the image Matrix
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1266"/>
+        <source>If checked, orientation is written to the Exif rather than rotating the image Matrix
 </source>
-      <translation type="unfinished">If checked, orientation is written to the Exif rather than rotating the image Matrix
+        <translation>Ako je označeno, orijentacija se snima u Exif umjesto da se obrće slika
 </translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1177"/>
-      <source>NOTE: this allows for rotating JPGs without losing information.</source>
-      <translation type="unfinished">NOTE: this allows for rotating JPGs without losing information.</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1267"/>
+        <source>NOTE: this allows for rotating JPGs without losing information.</source>
+        <translation>NAPOMENA: ovo omogućava rotaciju JPG slika bez gubitka podataka.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1180"/>
-      <source>File Loading/Saving</source>
-      <translation type="unfinished">File Loading/Saving</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1270"/>
+        <source>File Loading/Saving</source>
+        <translation>Učitavanje/sačuvanje fajla</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1188"/>
-      <source>Choose the number of Threads in the thread pool</source>
-      <translation type="unfinished">Choose the number of Threads in the thread pool</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1278"/>
+        <source>Choose the number of Threads in the thread pool</source>
+        <translation>Izaberi broj dretvi u ukupnom fondu</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1193"/>
-      <source>Number of Threads</source>
-      <translation type="unfinished">Number of Threads</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1283"/>
+        <source>Number of Threads</source>
+        <translation>Broj dretvi</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1197"/>
-      <source>Use Log File</source>
-      <translation type="unfinished">Use Log File</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1287"/>
+        <source>Use Log File</source>
+        <translation>Koristi fajl zapisa</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1199"/>
-      <source>If checked, a log file will be created.</source>
-      <translation type="unfinished">If checked, a log file will be created.</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1289"/>
+        <source>If checked, a log file will be created.</source>
+        <translation>Ako je označeno, fajl sa zapisom će biti kreiran.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1202"/>
-      <source>Open Log</source>
-      <translation type="unfinished">Open Log</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1292"/>
+        <source>Open Log</source>
+        <translation>Otvori tok</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1210"/>
-      <source>Logging</source>
-      <translation type="unfinished">Logging</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1300"/>
+        <source>Logging</source>
+        <translation>Vođenje zapisa</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1256"/>
-      <source>Please Restart nomacs to apply changes</source>
-      <translation type="unfinished">Please Restart nomacs to apply changes</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1346"/>
+        <source>Please Restart nomacs to apply changes</source>
+        <translation>Molimo restartujte nomacs da bi prihvatili promjene</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkAppManagerDialog</name>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="434"/>
-      <source>Manage Applications</source>
-      <translation>Upravljanje aplikacijama</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="464"/>
+        <source>Manage Applications</source>
+        <translation>Upravljanje aplikacijama</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="457"/>
-      <source>&amp;Run</source>
-      <translation>&amp;Pokreni</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="487"/>
+        <source>&amp;Run</source>
+        <translation>&amp;Pokreni</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="460"/>
-      <source>&amp;Add</source>
-      <translation>&amp;Dodaj</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="490"/>
+        <source>&amp;Add</source>
+        <translation>&amp;Dodaj</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="463"/>
-      <source>&amp;Delete</source>
-      <translation>&amp;Ukloni</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="493"/>
+        <source>&amp;Delete</source>
+        <translation>&amp;Ukloni</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="469"/>
-      <source>&amp;OK</source>
-      <translation>&amp;U redu</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="499"/>
+        <source>&amp;OK</source>
+        <translation>&amp;U redu</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="470"/>
-      <source>&amp;Cancel</source>
-      <translation>&amp;Otkaži</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="500"/>
+        <source>&amp;Cancel</source>
+        <translation>&amp;Otkaži</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="502"/>
-      <source>Executable Files (*.exe);;</source>
-      <translation>Izvršni fajlovi (*.exe);;</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="532"/>
+        <source>Executable Files (*.exe);;</source>
+        <translation>Izvršni fajlovi (*.exe);;</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="510"/>
-      <source>Open Application</source>
-      <translation>Otvori aplikaciju</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="540"/>
+        <source>Open Application</source>
+        <translation>Otvori aplikaciju</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkArchiveExtractionDialog</name>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4275"/>
-      <source>Extract images from an archive</source>
-      <translation>Raspakuj slike iz arhive</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3926"/>
+        <source>Extract images from an archive</source>
+        <translation>Raspakuj slike iz arhive</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4284"/>
-      <source>Archive (%1)</source>
-      <translation>Arhiva (%1)</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3935"/>
+        <source>Archive (%1)</source>
+        <translation>Arhiva (%1)</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4291"/>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4300"/>
-      <source>&amp;Browse</source>
-      <translation>&amp;Pregledaj</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3942"/>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3951"/>
+        <source>&amp;Browse</source>
+        <translation>&amp;Pregledaj</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4295"/>
-      <source>Extract to</source>
-      <translation>Raspakuj u</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3946"/>
+        <source>Extract to</source>
+        <translation>Raspakuj u</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4308"/>
-      <source>Remove Subfolders</source>
-      <translation>Ukloni podfascikle</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3959"/>
+        <source>Remove Subfolders</source>
+        <translation>Ukloni podfascikle</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4314"/>
-      <source>&amp;Extract</source>
-      <translation>&amp;Raspakuj</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3965"/>
+        <source>&amp;Extract</source>
+        <translation>&amp;Raspakuj</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4316"/>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4537"/>
-      <source>&amp;Cancel</source>
-      <translation>&amp;Otkaži</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3967"/>
+        <location filename="../src/DkGui/DkDialog.cpp" line="4188"/>
+        <source>&amp;Cancel</source>
+        <translation>&amp;Otkaži</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4395"/>
-      <source>Open Archive</source>
-      <translation>Otvori arhivu</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="4046"/>
+        <source>Open Archive</source>
+        <translation>Otvori arhivu</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4396"/>
-      <source>Archives (%1)</source>
-      <translation>Arhive (%1)</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="4047"/>
+        <source>Archives (%1)</source>
+        <translation>Arhive (%1)</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4407"/>
-      <source>Open Directory</source>
-      <translation>Otvori fasciklu</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="4058"/>
+        <source>Open Directory</source>
+        <translation>Otvori fasciklu</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4441"/>
-      <source>Not a valid archive.</source>
-      <translation>Neispravna arhiva.</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="4092"/>
+        <source>Not a valid archive.</source>
+        <translation>Neispravna arhiva.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4470"/>
-      <source>Number of images: </source>
-      <translation>Broj slika:</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="4121"/>
+        <source>Number of images: </source>
+        <translation>Broj slika: </translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4472"/>
-      <source>The archive does not contain any images.</source>
-      <translation>Arhiva ne sadrži nijednu sliku.</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="4123"/>
+        <source>The archive does not contain any images.</source>
+        <translation>Arhiva ne sadrži nijednu sliku.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4497"/>
-      <source>The images could not be extracted!</source>
-      <translation>Slike nije moguće raspakovati!</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="4148"/>
+        <source>The images could not be extracted!</source>
+        <translation>Slike nije moguće raspakovati!</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4539"/>
-      <source>Extracting files...</source>
-      <translation>Raspakivam fajlove...</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="4190"/>
+        <source>Extracting files...</source>
+        <translation>Raspakivam fajlove...</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4548"/>
-      <source>Extracting file %1 of %2</source>
-      <translation>Raspakivam fajl %1 od %2</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="4199"/>
+        <source>Extracting file %1 of %2</source>
+        <translation>Raspakivam fajl %1 od %2</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkBasicLoader</name>
     <message>
-      <location filename="../src/DkLoader/DkBasicLoader.cpp" line="312"/>
-      <location filename="../src/DkLoader/DkBasicLoader.cpp" line="1044"/>
-      <source>Original Image</source>
-      <translation type="unfinished">Original Image</translation>
+        <location filename="../src/DkCore/DkBasicLoader.cpp" line="301"/>
+        <location filename="../src/DkCore/DkBasicLoader.cpp" line="678"/>
+        <source>Original Image</source>
+        <translation>Originalna slika</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkBasicLoader.cpp" line="1176"/>
-      <source>Sorry, I could not save: %1</source>
-      <translation>Izvini, nije moguće sačuvati: %1</translation>
+        <location filename="../src/DkCore/DkBasicLoader.cpp" line="824"/>
+        <source>Sorry, I could not save: %1</source>
+        <translation>Izvini, nije moguće sačuvati: %1</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
+    <name>nmc::DkBatchButtonsWidget</name>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2196"/>
+        <source>Start/Cancel Batch Processing (%1)</source>
+        <translation>Počni/otkaži grupnu obradu (%1)</translation>
+    </message>
+</context>
+<context>
+    <name>nmc::DkBatchInput</name>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="339"/>
+        <source>File Explorer</source>
+        <translation>Pregledač fajlova</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="351"/>
+        <source>Thumbnails</source>
+        <translation>Sličice</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="352"/>
+        <source>File List</source>
+        <translation>Fajl lista</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="402"/>
+        <source>Open an Image Directory</source>
+        <translation>Otvori fasciklu sa slikama</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="466"/>
+        <source>No Files Selected</source>
+        <translation>Bez odabranih fajlova</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="468"/>
+        <source>%1 File Selected</source>
+        <translation>%1 fajl odabran</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="470"/>
+        <source>%1 Files Selected</source>
+        <translation>%1 fajlova odabrano</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="491"/>
+        <location filename="../src/DkGui/DkBatch.cpp" line="505"/>
+        <source>Results</source>
+        <translation>Rezultati</translation>
+    </message>
+</context>
+<context>
+    <name>nmc::DkBatchManipulatorWidget</name>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1727"/>
+        <source>Select Image Adjustments</source>
+        <translation>Izaberi podešavanja slike</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1942"/>
+        <source>inactive</source>
+        <translation>neaktivno</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1944"/>
+        <source>%1 manipulators selected</source>
+        <translation>%1 manipulator odabran</translation>
+    </message>
+</context>
+<context>
     <name>nmc::DkBatchOutput</name>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="685"/>
-      <source>Output Directory</source>
-      <translation>Izlazna fascikla</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="733"/>
+        <source>Output Directory</source>
+        <translation>Izlazna fascikla</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="687"/>
-      <source>Browse</source>
-      <translation>Pregledaj</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="736"/>
+        <source>Browse</source>
+        <translation>Pregledaj</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="689"/>
-      <source>Select a Directory</source>
-      <translation>Izaberi fasciklu</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="738"/>
+        <source>Select a Directory</source>
+        <translation>Izaberi fasciklu</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="694"/>
-      <source>Overwrite Existing Files</source>
-      <translation>Piši preko postojećih fajlova</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="743"/>
+        <source>Overwrite Existing Files</source>
+        <translation>Piši preko postojećih fajlova</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="695"/>
-      <source>If checked, existing files are overwritten.
+        <location filename="../src/DkGui/DkBatch.cpp" line="744"/>
+        <source>If checked, existing files are overwritten.
 This option might destroy your images - so be careful!</source>
-      <translation>Ako je označeno, piše preko postojećih fajlova.
+        <translation>Ako je označeno, piše preko postojećih fajlova.
 Ova postavka može uništiti vaše slike - budite pažljivi!</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="699"/>
-      <source>Use Input Folder</source>
-      <translation>Koristi ulaznu fasciklu</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="748"/>
+        <source>Do not Save Output Images</source>
+        <translation>Nemoj sačuvati izlazne slike</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="700"/>
-      <source>If checked, the batch is applied to the input folder - so be careful!</source>
-      <translation>Ako je označeno, izmjene se pišu u ulaznu fasciklu - budite oprezni!</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="749"/>
+        <source>If checked, output images are not saved at all.
+This option is only useful if plugins save sidecar files - so be careful!</source>
+        <translation>Ako je uključeno, izlazne slike neće biti nikako sačuvane.
+Ova opcija je jedino korisna ako dodaci sačuvaju sporedne fajlove - budite oprezni!</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="704"/>
-      <source>Delete Input Files</source>
-      <translation>Izbriši ulazne fajlove</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="753"/>
+        <source>Use Input Folder</source>
+        <translation>Koristi ulaznu fasciklu</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="705"/>
-      <source>If checked, the original file will be deleted if the conversion was successful.
+        <location filename="../src/DkGui/DkBatch.cpp" line="754"/>
+        <source>If checked, the batch is applied to the input folder - so be careful!</source>
+        <translation>Ako je označeno, izmjene se pišu u ulaznu fasciklu - budite oprezni!</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="758"/>
+        <source>Delete Input Files</source>
+        <translation>Izbriši ulazne fajlove</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="759"/>
+        <source>If checked, the original file will be deleted if the conversion was successful.
  So be careful!</source>
-      <translation>Ako je označeno, originalni fajl će biti izbrisan ako je koonverzija uspešna.
+        <translation>Ako je označeno, originalni fajl će biti izbrisan ako je koonverzija uspešna.
 Budite oprezni!</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="723"/>
-      <source>Filename</source>
-      <translation>Ime fajla</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="777"/>
+        <source>Filename</source>
+        <translation>Ime fajla</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="740"/>
-      <source>Keep Extension</source>
-      <translation>Zadrži ekstenziju</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="798"/>
+        <source>Keep Extension</source>
+        <translation>Zadrži ekstenziju</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="741"/>
-      <source>Convert To</source>
-      <translation>Konvertuj u</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="799"/>
+        <source>Convert To</source>
+        <translation>Konvertuj u</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="749"/>
-      <source>Compression</source>
-      <translation type="unfinished">Compression</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="808"/>
+        <source>Quality</source>
+        <translation>Kvalitet</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="764"/>
-      <source>Old: </source>
-      <translation>Staro: </translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="822"/>
+        <source>Preview</source>
+        <translation>Pregled</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="767"/>
-      <source>New: </source>
-      <translation>Novo: </translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="825"/>
+        <source>Old Filename: </source>
+        <translation>Staro ime fajla: </translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="772"/>
-      <source>Filename Preview</source>
-      <translation>Pregled imena fajla</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="830"/>
+        <source>New Filename: </source>
+        <translation>Novo ime fajla: </translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="796"/>
-      <source>Open an Image Directory</source>
-      <translation>Otvori fasciklu sa slikama</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="863"/>
+        <source>Open an Image Directory</source>
+        <translation>Otvori fasciklu sa slikama</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkBatchPluginWidget</name>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1081"/>
-      <source>Sorry, no Plugins found.</source>
-      <translation>Извини, прикључци нису пронађени.</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1466"/>
+        <source>Select Plugins</source>
+        <translation>Izaberi priključke</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1085"/>
-      <source>Drag Plugin Actions here.</source>
-      <translation>Prenesi akcije priključka ovdje.</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1636"/>
+        <source> Settings</source>
+        <translation> Postavke</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1118"/>
-      <source>inactive</source>
-      <translation>neaktivno</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1711"/>
+        <source>inactive</source>
+        <translation>neaktivno</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1120"/>
-      <source>%1 plugins selected</source>
-      <translation>%1 priključaka izabrano</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1713"/>
+        <source>%1 plugins selected</source>
+        <translation>%1 priključaka izabrano</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkBatchProcessing</name>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="863"/>
-      <source>[OK]</source>
-      <translation>[U REDU]</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="1149"/>
+        <source>[OK]</source>
+        <translation>[U REDU]</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="865"/>
-      <source>[FAIL]</source>
-      <translation>[GREŠKA]</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="1151"/>
+        <source>[FAIL]</source>
+        <translation>[GREŠKA]</translation>
     </message>
-  </context>
-  <context>
-    <name>nmc::DkBatchResizeWidget</name>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="969"/>
-      <source>Percent</source>
-      <translation>Postotak</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="969"/>
-      <source>Long Side</source>
-      <translation>Duga strana</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="969"/>
-      <source>Short Side</source>
-      <translation>Kratka strana</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="969"/>
-      <source>Width</source>
-      <translation>Širina</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="969"/>
-      <source>Height</source>
-      <translation>Visina</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="974"/>
-      <source>Transform All</source>
-      <translation>Transformiši sve</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="974"/>
-      <source>Shrink Only</source>
-      <translation>Samo umanji</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="974"/>
-      <source>Enlarge Only</source>
-      <translation>Samo povećaj</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="978"/>
-      <source>%</source>
-      <translation type="unfinished">%</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="984"/>
-      <source> px</source>
-      <translation> px</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1022"/>
-      <source>inactive</source>
-      <translation>neaktivno</translation>
-    </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkBatchTransformWidget</name>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1134"/>
-      <source>Do &amp;Not Rotate</source>
-      <translation>Ne &amp;rotiraj</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1958"/>
+        <source>Resize</source>
+        <translation>Promijeni veličinu</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1136"/>
-      <source>90%1 Counter Clockwise</source>
-      <translation type="unfinished">90%1 Counter Clockwise</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1963"/>
+        <source>Percent</source>
+        <translation>Postotak</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1137"/>
-      <source>90%1 Clockwise</source>
-      <translation type="unfinished">90%1 Clockwise</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1963"/>
+        <source>Long Side</source>
+        <translation>Duga strana</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1138"/>
-      <source>180%1</source>
-      <translation type="unfinished">180%1</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1963"/>
+        <source>Short Side</source>
+        <translation>Kratka strana</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1147"/>
-      <source>Flip &amp;Horizontal</source>
-      <translation>Prevrni &amp;vodoravno</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1963"/>
+        <source>Width</source>
+        <translation>Širina</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1148"/>
-      <source>Flip &amp;Vertical</source>
-      <translation>Prevrni &amp;uspravno</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1963"/>
+        <source>Height</source>
+        <translation>Visina</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1149"/>
-      <source>&amp;Crop from Metadata</source>
-      <translation type="unfinished">&amp;Crop from Metadata</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1967"/>
+        <source>%</source>
+        <translation>%</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1193"/>
-      <source>inactive</source>
-      <translation>neaktivno</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1972"/>
+        <source> px</source>
+        <translation> px</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1198"/>
-      <source>Rotating by: %1</source>
-      <translation>Rotiraj: %1</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1978"/>
+        <source>Transform All</source>
+        <translation>Transformiši sve</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1202"/>
-      <source>Flipping</source>
-      <translation type="unfinished">Flipping</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1978"/>
+        <source>Shrink Only</source>
+        <translation>Samo umanji</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1207"/>
-      <source>Crop</source>
-      <translation type="unfinished">Crop</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1978"/>
+        <source>Enlarge Only</source>
+        <translation>Samo povećaj</translation>
     </message>
-  </context>
-  <context>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1992"/>
+        <source>Orientation</source>
+        <translation>Orijentacija</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1995"/>
+        <source>Do &amp;Not Rotate</source>
+        <translation>Ne &amp;rotiraj</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1997"/>
+        <source>90%1 Counter Clockwise</source>
+        <translation>90%1 suprotno kazaljci na satu</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1998"/>
+        <source>90%1 Clockwise</source>
+        <translation>90%1 u smjeru kazaljke na satu</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1999"/>
+        <source>180%1</source>
+        <translation>180%1</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2008"/>
+        <source>Transformations</source>
+        <translation>Transformacije</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2011"/>
+        <source>&amp;Crop from Metadata</source>
+        <translation>&amp;Izreži sa meta podataka</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2063"/>
+        <source>inactive</source>
+        <translation>neaktivno</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2069"/>
+        <source>Resize by: %1%</source>
+        <translation>Promjeni veličinu za: %1%</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2073"/>
+        <source>Resize %1 to: %2 px</source>
+        <translation>Promjeni veličinu %1 u %2 px</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2079"/>
+        <source>Rotating by: %1</source>
+        <translation>Rotiraj: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2085"/>
+        <source>Crop</source>
+        <translation>Izreži</translation>
+    </message>
+</context>
+<context>
     <name>nmc::DkBatchWidget</name>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1241"/>
-      <source>Batch Conversion</source>
-      <translation type="unfinished">Batch Conversion</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2288"/>
+        <source>next</source>
+        <translation>sljedeće</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1250"/>
-      <source>next</source>
-      <translation type="unfinished">next</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2293"/>
+        <source>previous</source>
+        <translation>prethodno</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1255"/>
-      <source>previous</source>
-      <translation type="unfinished">previous</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2314"/>
+        <source>no files selected</source>
+        <translation>nijedan fajl odabran</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1277"/>
-      <source>Input Directory</source>
-      <translation type="unfinished">Input Directory</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2319"/>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2322"/>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2326"/>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2334"/>
+        <source>inactive</source>
+        <translation>neaktivno</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1277"/>
-      <source>no files selected</source>
-      <translation type="unfinished">no files selected</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2319"/>
+        <source>Adjustments</source>
+        <translation>Podešavanja</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1283"/>
-      <source>Resize</source>
-      <translation type="unfinished">Resize</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2322"/>
+        <source>Transform</source>
+        <translation>Transformisati</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1283"/>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1287"/>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1292"/>
-      <source>inactive</source>
-      <translation>neaktivno</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2326"/>
+        <source>Plugins</source>
+        <translation>Priključci</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1287"/>
-      <source>Transform</source>
-      <translation type="unfinished">Transform</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2330"/>
+        <source>Output</source>
+        <translation>Izlaz</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1292"/>
-      <source>Plugins</source>
-      <translation type="unfinished">Plugins</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2330"/>
+        <source>not set</source>
+        <translation>nije postavljeno</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1297"/>
-      <source>Output</source>
-      <translation type="unfinished">Output</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2515"/>
+        <source>Please select files for processing.</source>
+        <translation>Molimo izaberite fajlove za obradu.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1297"/>
-      <source>not set</source>
-      <translation type="unfinished">not set</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2522"/>
+        <source>I am missing a widget.</source>
+        <translation>Nedostaje vidžet.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1310"/>
-      <source>Show &amp;Log</source>
-      <translation type="unfinished">Show &amp;Log</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2536"/>
+        <source>Please check &apos;Overwrite Existing Files&apos; or choose a different output directory.</source>
+        <translation>Molimo označite &apos;pisati preko postojećih fajlova&apos; ili izaberite drugu izlaznu fasciklu.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1311"/>
-      <source>Shows detailed status messages.</source>
-      <translation type="unfinished">Shows detailed status messages.</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2557"/>
+        <source>Create Output Directory</source>
+        <translation>Kreiraj izlaznu fasciklu</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1317"/>
-      <source>&amp;OK</source>
-      <translation>&amp;U redu</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1383"/>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1401"/>
-      <source>Wrong Configuration</source>
-      <translation type="unfinished">Wrong Configuration</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1383"/>
-      <source>Please select files for processing.</source>
-      <translation type="unfinished">Please select files for processing.</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1391"/>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1452"/>
-      <source>Fatal Error</source>
-      <translation type="unfinished">Fatal Error</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1391"/>
-      <source>I am missing a widget.</source>
-      <translation type="unfinished">I am missing a widget.</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1401"/>
-      <source>Please check 'Overwrite Existing Files' or choose a different output directory.</source>
-      <translation type="unfinished">Please check 'Overwrite Existing Files' or choose a different output directory.</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1414"/>
-      <source>Create Output Directory</source>
-      <translation type="unfinished">Create Output Directory</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1415"/>
-      <source>Should I create:
+        <location filename="../src/DkGui/DkBatch.cpp" line="2558"/>
+        <source>Should I create:
 %1</source>
-      <translation type="unfinished">Should I create:
+        <translation>Da li da kreiram:
 %1</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1431"/>
-      <source>Info</source>
-      <translation type="unfinished">Info</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2575"/>
+        <source>Please select an output directory.</source>
+        <translation>Molimo izaberite izlaznu fasciklu.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1431"/>
-      <source>Please select an output directory.</source>
-      <translation type="unfinished">Please select an output directory.</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2722"/>
+        <source>Batch Log</source>
+        <translation>Zapis grupnog podešavanja</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1435"/>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1439"/>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1443"/>
-      <source>Error</source>
-      <translation>Greška</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2787"/>
+        <source>Save Profile</source>
+        <translation>Sačuvaj profil</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1435"/>
-      <source>Sorry, I cannot create %1.</source>
-      <translation type="unfinished">Sorry, I cannot create %1.</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2787"/>
+        <source>Cannot save empty profile.</source>
+        <translation>Nemoguće sačuvati prazan profil.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1439"/>
-      <source>Sorry, I cannot find files to process.</source>
-      <translation type="unfinished">Sorry, I cannot find files to process.</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2792"/>
+        <source>Error</source>
+        <translation>Greška</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1443"/>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1452"/>
-      <source>Sorry, the file pattern is empty.</source>
-      <translation type="unfinished">Sorry, the file pattern is empty.</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2580"/>
+        <source>Sorry, I cannot create %1.</source>
+        <translation>Žao nam je, ne mogu kreirati %1.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1559"/>
-      <source>%1/%2 files processed... %3 failed.</source>
-      <translation type="unfinished">%1/%2 files processed... %3 failed.</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2314"/>
+        <source>Input</source>
+        <translation>Ulaz</translation>
     </message>
-  </context>
-  <context>
-    <name>nmc::DkBrightness</name>
     <message>
-      <location filename="../src/DkGui/DkManipulationWidgets.cpp" line="875"/>
-      <source>Brightness</source>
-      <translation>Svjetlina</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2334"/>
+        <source>Profiles</source>
+        <translation>Profili</translation>
     </message>
-  </context>
-  <context>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2585"/>
+        <source>Sorry, I cannot find files to process.</source>
+        <translation>Žao nam je, ne mogu pronaći fajlove za obradu.</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2590"/>
+        <source>Sorry, the file pattern is empty.</source>
+        <translation>Žao nam je, mustra za fajlove je prazna.</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2600"/>
+        <source>Sorry, I cannot start processing - please check the configuration.</source>
+        <translation>Žao nam je, nemoguće početi procesiranje - molimo provjerite konfiguraciju.</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2642"/>
+        <source>Canceling...</source>
+        <translation>Otkazujem...</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2696"/>
+        <source>%1/%2 files processed... %3 failed.</source>
+        <translation>%1/%2 fajlova obrađeno... %3 nije uspijelo.</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2792"/>
+        <source>Sorry, I cannot save the settings...</source>
+        <translation>Žao nam je, nemoguće sačuvati ove postavke...</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2808"/>
+        <source>Error Loading Profile</source>
+        <translation>Greška pri učitavanju profila</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2809"/>
+        <source>Sorry, I cannot load batch settings from: 
+%1</source>
+        <translation>Žao nam je, nemoguće učitati grupne postavke iz:
+%1</translation>
+    </message>
+</context>
+<context>
     <name>nmc::DkCentralWidget</name>
     <message>
-      <location filename="../src/DkGui/DkCentralWidget.cpp" line="485"/>
-      <source>General</source>
-      <translation type="unfinished">General</translation>
+        <location filename="../src/DkGui/DkCentralWidget.cpp" line="275"/>
+        <source>Go to Tab</source>
+        <translation>Idi na karticu</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkCentralWidget.cpp" line="491"/>
-      <source>Display</source>
-      <translation type="unfinished">Display</translation>
+        <location filename="../src/DkGui/DkCentralWidget.cpp" line="275"/>
+        <source>Go to tab number: </source>
+        <translation>Idi na kraticu broj: </translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkCentralWidget.cpp" line="497"/>
-      <source>File</source>
-      <translation>Fajl</translation>
+        <location filename="../src/DkGui/DkCentralWidget.cpp" line="532"/>
+        <source>General</source>
+        <translation>Opšte</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkCentralWidget.cpp" line="503"/>
-      <source>File Associations</source>
-      <translation type="unfinished">File Associations</translation>
+        <location filename="../src/DkGui/DkCentralWidget.cpp" line="538"/>
+        <source>Display</source>
+        <translation>Ekran</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkCentralWidget.cpp" line="510"/>
-      <source>Advanced</source>
-      <translation type="unfinished">Advanced</translation>
+        <location filename="../src/DkGui/DkCentralWidget.cpp" line="544"/>
+        <source>File</source>
+        <translation>Fajl</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkCentralWidget.cpp" line="1083"/>
-      <source>Sorry, I could not drop the content.</source>
-      <translation>Izvini, ne mogu odbaciti sadržaj.</translation>
+        <location filename="../src/DkGui/DkCentralWidget.cpp" line="550"/>
+        <source>File Associations</source>
+        <translation>Fajl asocijacije</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkCentralWidget.cpp" line="1115"/>
-      <source>Save File</source>
-      <translation>Sačuvaj fajl</translation>
+        <location filename="../src/DkGui/DkCentralWidget.cpp" line="556"/>
+        <source>Advanced</source>
+        <translation>Napredno</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkCentralWidget.cpp" line="1123"/>
-      <source>%1 vec files merged</source>
-      <translation>%1 fajlova je spojeno</translation>
+        <location filename="../src/DkGui/DkCentralWidget.cpp" line="562"/>
+        <source>Editor</source>
+        <translation>Uređivač</translation>
     </message>
-  </context>
-  <context>
+    <message>
+        <location filename="../src/DkGui/DkCentralWidget.cpp" line="1100"/>
+        <source>I could not load &quot;%1&quot;</source>
+        <translation>Nemoguće učitati &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkCentralWidget.cpp" line="1132"/>
+        <source>Unable to load file &quot;%1&quot;</source>
+        <translation>Nemoguće učitati fajl &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkCentralWidget.cpp" line="1140"/>
+        <source>&quot;%1&quot; cannot be loaded</source>
+        <translation>&quot;%1&quot; nemoguće učitati</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkCentralWidget.cpp" line="1146"/>
+        <source>downloading &quot;%1&quot;</source>
+        <translation>preuzimam &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkCentralWidget.cpp" line="1160"/>
+        <source>Too many urls to load. Loading only the first %1</source>
+        <translation>Previše URLova za učitati. Učitavam samo prvih %1</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkCentralWidget.cpp" line="1219"/>
+        <source>Sorry, I could not drop the content.</source>
+        <translation>Izvini, ne mogu odbaciti sadržaj.</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkCentralWidget.cpp" line="1303"/>
+        <source>Save File</source>
+        <translation>Sačuvaj fajl</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkCentralWidget.cpp" line="1311"/>
+        <source>%1 vec files merged</source>
+        <translation>%1 fajlova je spojeno</translation>
+    </message>
+</context>
+<context>
     <name>nmc::DkColorChooser</name>
     <message>
-      <location filename="../src/DkLoader/DkBasicWidgets.cpp" line="167"/>
-      <source>Reset</source>
-      <translation>Resetuj</translation>
+        <location filename="../src/DkCore/DkBasicWidgets.cpp" line="283"/>
+        <source>Reset</source>
+        <translation>Resetuj</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkColorSlider</name>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="114"/>
-      <source>Drag the slider downwards for elimination</source>
-      <translation>Povuci klizač nadole za eliminaciju</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="112"/>
+        <source>Drag the slider downwards for elimination</source>
+        <translation>Povuci klizač nadole za eliminaciju</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkCommentTextEdit</name>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="1143"/>
-      <source>Click here to add notes</source>
-      <translation>Klikni ovdje za dodavanje napomena</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="1144"/>
+        <source>Click here to add notes</source>
+        <translation>Klikni ovdje za dodavanje napomena</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkCommentWidget</name>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="1162"/>
-      <source>NOTES</source>
-      <translation>NAPOMENE</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="1163"/>
+        <source>NOTES</source>
+        <translation>NAPOMENE</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="1176"/>
-      <source>Enter your notes here. They will be saved to the image metadata.</source>
-      <translation>Unesi napomene ovdje. Biti će snimljene među podatke slike.</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="1177"/>
+        <source>Enter your notes here. They will be saved to the image metadata.</source>
+        <translation>Unesi napomene ovdje. Biti će snimljene među podatke slike.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="1182"/>
-      <source>Save Note (CTRL + ENTER)</source>
-      <translation>Sačuvaj napomenu (CTRL + ENTER)</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="1183"/>
+        <source>Save Note (CTRL + ENTER)</source>
+        <translation>Sačuvaj napomenu (CTRL + ENTER)</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="1189"/>
-      <source>Discard Changes (ESC)</source>
-      <translation>Odbaci promjene (ESC)</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="1190"/>
+        <source>Discard Changes (ESC)</source>
+        <translation>Odbaci promjene (ESC)</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="1230"/>
-      <source>Sorry, I cannot save comments for this image format.</source>
-      <translation>Izvini, ne mogu sačuvati komentare za ovaj format slike.</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="1231"/>
+        <source>Sorry, I cannot save comments for this image format.</source>
+        <translation>Izvini, ne mogu sačuvati komentare za ovaj format slike.</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkCompressDialog</name>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="178"/>
-      <source>Original</source>
-      <translation>Originalna</translation>
+        <location filename="../src/DkCore/DkSaveDialog.cpp" line="180"/>
+        <source>Original</source>
+        <translation>Originalna</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="180"/>
-      <source>New</source>
-      <translation>Nova</translation>
+        <location filename="../src/DkCore/DkSaveDialog.cpp" line="182"/>
+        <source>New</source>
+        <translation>Nova</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="206"/>
-      <source>Medium (1024 x 786)</source>
-      <translation>Srednja (1024 × 768)</translation>
+        <location filename="../src/DkCore/DkSaveDialog.cpp" line="208"/>
+        <source>Medium (1024 x 786)</source>
+        <translation>Srednja (1024 × 768)</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="212"/>
-      <source>Image Quality</source>
-      <translation>Kvalitet slike</translation>
+        <location filename="../src/DkCore/DkSaveDialog.cpp" line="214"/>
+        <source>Image Quality</source>
+        <translation>Kvalitet slike</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="218"/>
-      <source>Lossless Compression</source>
-      <translation>Kompresija bez gubitka</translation>
+        <location filename="../src/DkCore/DkSaveDialog.cpp" line="220"/>
+        <source>Lossless Compression</source>
+        <translation>Kompresija bez gubitka</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="225"/>
-      <source>Background Color</source>
-      <translation>Boja pozadine</translation>
+        <location filename="../src/DkCore/DkSaveDialog.cpp" line="227"/>
+        <source>Background Color</source>
+        <translation>Boja pozadine</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="257"/>
-      <source>&amp;OK</source>
-      <translation>&amp;U redu</translation>
+        <location filename="../src/DkCore/DkSaveDialog.cpp" line="259"/>
+        <source>&amp;OK</source>
+        <translation>&amp;U redu</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="254"/>
-      <source>&amp;Cancel</source>
-      <translation>&amp;Otkaži</translation>
+        <location filename="../src/DkCore/DkSaveDialog.cpp" line="256"/>
+        <source>&amp;Cancel</source>
+        <translation>&amp;Otkaži</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="140"/>
-      <source>JPG Settings</source>
-      <translation>JPG postavke</translation>
+        <location filename="../src/DkCore/DkSaveDialog.cpp" line="142"/>
+        <source>JPG Settings</source>
+        <translation>JPG postavke</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="142"/>
-      <source>J2K Settings</source>
-      <translation>J2k postavke</translation>
+        <location filename="../src/DkCore/DkSaveDialog.cpp" line="144"/>
+        <source>J2K Settings</source>
+        <translation>J2k postavke</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="151"/>
-      <source>WebP Settings</source>
-      <translation>WebP postavke</translation>
+        <location filename="../src/DkCore/DkSaveDialog.cpp" line="153"/>
+        <source>WebP Settings</source>
+        <translation>WebP postavke</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="164"/>
-      <source>Save for Web</source>
-      <translation>Snimi za web</translation>
+        <location filename="../src/DkCore/DkSaveDialog.cpp" line="166"/>
+        <source>Save for Web</source>
+        <translation>Snimi za web</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="205"/>
-      <source>Small  (800 x 600)</source>
-      <translation>Mala  (800 × 600)</translation>
+        <location filename="../src/DkCore/DkSaveDialog.cpp" line="207"/>
+        <source>Small  (800 x 600)</source>
+        <translation>Mala  (800 × 600)</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="207"/>
-      <source>Large  (1920 x 1080)</source>
-      <translation>Velika  (1920 × 1080)</translation>
+        <location filename="../src/DkCore/DkSaveDialog.cpp" line="209"/>
+        <source>Large  (1920 x 1080)</source>
+        <translation>Velika  (1920 × 1080)</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="208"/>
-      <source>Original Size</source>
-      <translation>Originalna veličina</translation>
+        <location filename="../src/DkCore/DkSaveDialog.cpp" line="210"/>
+        <source>Original Size</source>
+        <translation>Originalna veličina</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="375"/>
-      <source>File Size: --</source>
-      <translation>Veličina fajla: --</translation>
+        <location filename="../src/DkCore/DkSaveDialog.cpp" line="377"/>
+        <source>File Size: --</source>
+        <translation>Veličina fajla: --</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="392"/>
-      <source>File Size: ~%1</source>
-      <translation>Veličina fajla: ~%1</translation>
+        <location filename="../src/DkCore/DkSaveDialog.cpp" line="394"/>
+        <source>File Size: ~%1</source>
+        <translation>Veličina fajla: ~%1</translation>
     </message>
-  </context>
-  <context>
-    <name>nmc::DkContrast</name>
-    <message>
-      <location filename="../src/DkGui/DkManipulationWidgets.cpp" line="969"/>
-      <source>Contrast</source>
-      <translation>Kontrast</translation>
-    </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkControlWidget</name>
     <message>
-      <location filename="../src/DkGui/DkControlWidget.cpp" line="579"/>
-      <source>Closing Plugin</source>
-      <translation type="unfinished">Closing Plugin</translation>
+        <location filename="../src/DkGui/DkControlWidget.cpp" line="558"/>
+        <source>Closing Plugin</source>
+        <translation>Zatvaram priključak</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkControlWidget.cpp" line="580"/>
-      <source>Apply plugin changes?</source>
-      <translation type="unfinished">Apply plugin changes?</translation>
+        <location filename="../src/DkGui/DkControlWidget.cpp" line="559"/>
+        <source>Apply plugin changes?</source>
+        <translation>Prihvati promjena priključka?</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkCropToolBar</name>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="959"/>
-      <source>Crop (ENTER)</source>
-      <translation>Isjeci (ENTER)</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="938"/>
+        <source>Crop (ENTER)</source>
+        <translation>Isjeci (ENTER)</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="963"/>
-      <source>Cancel (ESC)</source>
-      <translation>Otkaži (ESC)</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="942"/>
+        <source>Cancel (ESC)</source>
+        <translation>Otkaži (ESC)</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="967"/>
-      <source>Pan</source>
-      <translation>Švenk</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="946"/>
+        <source>Pan</source>
+        <translation>Švenk</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="975"/>
-      <source>User Defined</source>
-      <translation>Korisnički definisano</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="954"/>
+        <source>User Defined</source>
+        <translation>Korisnički definisano</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="976"/>
-      <source>No Aspect Ratio</source>
-      <translation>Bez razmjera</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="955"/>
+        <source>No Aspect Ratio</source>
+        <translation>Bez razmjera</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="984"/>
-      <source>Horizontal Constraint</source>
-      <translation>Horizontalno ograničenje</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="963"/>
+        <source>Horizontal Constraint</source>
+        <translation>Horizontalno ograničenje</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="987"/>
-      <source>Swap</source>
-      <translation>Razmjena</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="966"/>
+        <source>Swap</source>
+        <translation>Razmjena</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="989"/>
-      <source>Swap Dimensions</source>
-      <translation>Dimenzije razmjene</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="968"/>
+        <source>Swap Dimensions</source>
+        <translation>Dimenzije razmjene</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="995"/>
-      <source>Vertical Constraint</source>
-      <translation>Vertikalno ograničenje</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="974"/>
+        <source>Vertical Constraint</source>
+        <translation>Vertikalno ograničenje</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="1009"/>
-      <source>Background Color</source>
-      <translation>Boja pozadine</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="988"/>
+        <source>Background Color</source>
+        <translation>Boja pozadine</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="1018"/>
-      <source>Guides</source>
-      <translation>Vodiči</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="997"/>
+        <source>Guides</source>
+        <translation>Vodiči</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="1018"/>
-      <source>Rule of Thirds</source>
-      <translation>Pravilo trećine</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="997"/>
+        <source>Rule of Thirds</source>
+        <translation>Pravilo trećine</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="1018"/>
-      <source>Grid</source>
-      <translation>Mreža</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="997"/>
+        <source>Grid</source>
+        <translation>Mreža</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="1022"/>
-      <source>Show Guides in the Preview</source>
-      <translation>Prikaži vodiče u pregledu</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="1001"/>
+        <source>Show Guides in the Preview</source>
+        <translation>Prikaži vodiče u pregledu</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="1026"/>
-      <source>Invert Crop Tool Color</source>
-      <translation>Obrni boju alata za isjecanje</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="1005"/>
+        <source>Invert Crop Tool Color</source>
+        <translation>Obrni boju alata za isjecanje</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="1031"/>
-      <source>Show Info</source>
-      <translation>Prikaži informacije</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="1010"/>
+        <source>Show Info</source>
+        <translation>Prikaži informacije</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="1036"/>
-      <source>Crop to Metadata</source>
-      <translation type="unfinished">Crop to Metadata</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="1015"/>
+        <source>Crop to Metadata</source>
+        <translation>Izreži do metapodataka</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkCropWidget</name>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="2003"/>
-      <source>Crop Toolbar</source>
-      <translation>Alatna traka za isjecanje</translation>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="2010"/>
+        <source>Crop Toolbar</source>
+        <translation>Alatna traka za isjecanje</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkDescriptionEdit</name>
     <message>
-      <location filename="../src/DkLoader/DkPluginManager.cpp" line="956"/>
-      <source>No metadata available!</source>
-      <translation type="unfinished">No metadata available!</translation>
+        <location filename="../src/DkCore/DkPluginManager.cpp" line="994"/>
+        <source>No metadata available!</source>
+        <translation>Metapodaci nedostupni!</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkDialogManager</name>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4597"/>
-      <source>Preview</source>
-      <translation type="unfinished">Preview</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="4249"/>
+        <source>Preview</source>
+        <translation>Pregled</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4612"/>
-      <source>Shortcuts</source>
-      <translation type="unfinished">Shortcuts</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="4264"/>
+        <source>Shortcuts</source>
+        <translation>Prečice</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkDirectoryChooser</name>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="2733"/>
-      <source>...</source>
-      <translation type="unfinished">...</translation>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="2845"/>
+        <source>...</source>
+        <translation>...</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="2747"/>
-      <source>Open an Image Directory</source>
-      <translation>Otvori fasciklu sa slikama</translation>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="2859"/>
+        <source>Open an Image Directory</source>
+        <translation>Otvori fasciklu sa slikama</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkDisplayPreference</name>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="597"/>
-      <source>Invert mouse wheel behaviour for zooming</source>
-      <translation type="unfinished">Invert mouse wheel behaviour for zooming</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="685"/>
+        <source>Invert mouse wheel behaviour for zooming</source>
+        <translation>Obrni ponašanje kolutića miša kod zumiranja</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="599"/>
-      <source>If checked, the mouse wheel behaviour is inverted while zooming.</source>
-      <translation type="unfinished">If checked, the mouse wheel behaviour is inverted while zooming.</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="687"/>
+        <source>If checked, the mouse wheel behaviour is inverted while zooming.</source>
+        <translation>Ako je označeno, kolutić miša se ponaša obrnuto tokom zumiranja.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="602"/>
-      <source>Show pixels if zoom level is above</source>
-      <translation type="unfinished">Show pixels if zoom level is above</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="690"/>
+        <source>Show pixels if zoom level is above</source>
+        <translation>Prikaži piksele ako je nivo zuma iznad</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="606"/>
-      <source>nomacs will not interpolate images if the zoom level is larger.</source>
-      <translation type="unfinished">nomacs will not interpolate images if the zoom level is larger.</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="694"/>
+        <source>nomacs will not interpolate images if the zoom level is larger.</source>
+        <translation>nomacs neće interpolirati slike ako je nivo zuma veći.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="612"/>
-      <source>Zoom</source>
-      <translation type="unfinished">Zoom</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="700"/>
+        <source>Zoom</source>
+        <translation>Zum</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="620"/>
-      <source>Always keep zoom</source>
-      <translation type="unfinished">Always keep zoom</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="708"/>
+        <source>Always keep zoom</source>
+        <translation>Uvijek zadrži zum</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="621"/>
-      <source>Keep zoom if the size is the same</source>
-      <translation type="unfinished">Keep zoom if the size is the same</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="709"/>
+        <source>Keep zoom if the size is the same</source>
+        <translation>Zadrži zum ako je veličina ista</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="622"/>
-      <source>If checked, the zoom level is only kept, if the image loaded has the same level as the previous.</source>
-      <translation type="unfinished">If checked, the zoom level is only kept, if the image loaded has the same level as the previous.</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="710"/>
+        <source>If checked, the zoom level is only kept, if the image loaded has the same level as the previous.</source>
+        <translation>Ako je označeno, nivo zuma se jedino zadrži ako učitana slika ima istu veličinu kao i prethodna.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="623"/>
-      <source>Never keep zoom</source>
-      <translation type="unfinished">Never keep zoom</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="711"/>
+        <source>Never keep zoom</source>
+        <translation>Nikada ne zadržavaj zum</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="625"/>
-      <source>Always zoom to fit</source>
-      <translation type="unfinished">Always zoom to fit</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="713"/>
+        <source>Always zoom to fit</source>
+        <translation>Uvijek zumiraj da slika stane</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="638"/>
-      <source>When Displaying New Images</source>
-      <translation type="unfinished">When Displaying New Images</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="726"/>
+        <source>When Displaying New Images</source>
+        <translation>Prilikom prikazivanja nove slike</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="647"/>
-      <source>Define the icon size in pixel.</source>
-      <translation type="unfinished">Define the icon size in pixel.</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="735"/>
+        <source>Define the icon size in pixel.</source>
+        <translation>Definiši veličinu ikona u pikselima.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="653"/>
-      <source>Icon Size</source>
-      <translation type="unfinished">Icon Size</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="741"/>
+        <source>Icon Size</source>
+        <translation>Veličina ikona</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="657"/>
-      <source>Image Transition</source>
-      <translation type="unfinished">Image Transition</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="745"/>
+        <source>Image Transition</source>
+        <translation>Prelaz između slika</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="661"/>
-      <source>Choose a transition when loading a new image</source>
-      <translation type="unfinished">Choose a transition when loading a new image</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="749"/>
+        <source>Choose a transition when loading a new image</source>
+        <translation>Izaberi prelaz pri učitavanju slika</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="665"/>
-      <source>Unknown Transition</source>
-      <translation type="unfinished">Unknown Transition</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="753"/>
+        <source>Unknown Transition</source>
+        <translation>Nepoznat prelaz</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="668"/>
-      <source>Appear</source>
-      <translation type="unfinished">Appear</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="756"/>
+        <source>Appear</source>
+        <translation>Izgled</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="669"/>
-      <source>Swipe</source>
-      <translation type="unfinished">Swipe</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="757"/>
+        <source>Swipe</source>
+        <translation>Potegnuti</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="670"/>
-      <source>Fade</source>
-      <translation type="unfinished">Fade</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="758"/>
+        <source>Fade</source>
+        <translation>Isčezni</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="679"/>
-      <source>Define the image transition speed.</source>
-      <translation type="unfinished">Define the image transition speed.</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="767"/>
+        <source>Define the image transition speed.</source>
+        <translation>Definiši brzinu prelaza slika.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="686"/>
-      <source>Always Animate Image Loading</source>
-      <translation type="unfinished">Always Animate Image Loading</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="774"/>
+        <source>Always Animate Image Loading</source>
+        <translation>Uvijek animiraj učitavanje slika</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="688"/>
-      <source>If unchecked, loading is only animated if nomacs is fullscreen</source>
-      <translation type="unfinished">If unchecked, loading is only animated if nomacs is fullscreen</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="776"/>
+        <source>If unchecked, loading is only animated if nomacs is fullscreen</source>
+        <translation>Ako nije označeno, učitavanje je jedino animirano ako je nomacs preko cijelog ekrana</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="691"/>
-      <source>Display Time</source>
-      <translation type="unfinished">Display Time</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="779"/>
+        <source>Display Time</source>
+        <translation>Vrijeme prikaza</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="695"/>
-      <source>Define the time an image is displayed.</source>
-      <translation type="unfinished">Define the time an image is displayed.</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="783"/>
+        <source>Define the time an image is displayed.</source>
+        <translation>Definiše vrijeme koliko se slika prikazuje.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="702"/>
-      <source>Slideshow</source>
-      <translation type="unfinished">Slideshow</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="790"/>
+        <source>Slideshow</source>
+        <translation>Slajdšou</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="711"/>
-      <source>Show crop rectangle</source>
-      <translation type="unfinished">Show crop rectangle</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="799"/>
+        <source>Show crop rectangle</source>
+        <translation>Prikaži kvadrat za rezanje</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="715"/>
-      <source>Show Metadata Cropping</source>
-      <translation type="unfinished">Show Metadata Cropping</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="803"/>
+        <source>Show Metadata Cropping</source>
+        <translation>Prikaži rezanje metapodataka</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="765"/>
-      <source>Please Restart nomacs to apply changes</source>
-      <translation type="unfinished">Please Restart nomacs to apply changes</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="853"/>
+        <source>Please Restart nomacs to apply changes</source>
+        <translation>Molimo restartujte nomacs da bi prihvatili promjene</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkExplorer</name>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="479"/>
-      <source>Editable</source>
-      <translation>Moguće izmjeniti</translation>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="484"/>
+        <source>Editable</source>
+        <translation>Moguće izmjeniti</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="485"/>
-      <source>Open Selected Image</source>
-      <translation type="unfinished">Open Selected Image</translation>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="490"/>
+        <source>Open Selected Image</source>
+        <translation>Otvori odabranu sliku</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="495"/>
-      <source>Adjust Columns</source>
-      <translation type="unfinished">Adjust Columns</translation>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="500"/>
+        <source>Adjust Columns</source>
+        <translation>Namjesti kolumne</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkExportTiffDialog</name>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2523"/>
-      <source>Export Multi-Page TIFF</source>
-      <translation>Eksportuj višestrani TIFF</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2552"/>
+        <source>Export Multi-Page TIFF</source>
+        <translation>Eksportuj višestrani TIFF</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2569"/>
-      <source>Multi-Page TIFF:</source>
-      <translation>Višestrani TIFF:</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2598"/>
+        <source>Multi-Page TIFF:</source>
+        <translation>Višestrani TIFF:</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2572"/>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2581"/>
-      <source>&amp;Browse</source>
-      <translation>&amp;Pregledaj</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2601"/>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2610"/>
+        <source>&amp;Browse</source>
+        <translation>&amp;Pregledaj</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2575"/>
-      <source>No Multi-Page TIFF loaded</source>
-      <translation>Bez učitanog višestranog TIFF</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2604"/>
+        <source>No Multi-Page TIFF loaded</source>
+        <translation>Bez učitanog višestranog TIFF</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2578"/>
-      <source>Save Folder:</source>
-      <translation>Sačuvaj u fasciklu:</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2607"/>
+        <source>Save Folder:</source>
+        <translation>Sačuvaj u fasciklu:</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2584"/>
-      <source>Specify a Save Folder</source>
-      <translation>Odredi fasciklu za sačuvanje</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2613"/>
+        <source>Specify a Save Folder</source>
+        <translation>Odredi fasciklu za sačuvanje</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2587"/>
-      <source>Filename:</source>
-      <translation>Ime fajla:</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2616"/>
+        <source>Filename:</source>
+        <translation>Ime fajla:</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2598"/>
-      <source>Export Pages</source>
-      <translation>Eksportuj stranice</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2627"/>
+        <source>Export Pages</source>
+        <translation>Eksportuj stranice</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2605"/>
-      <source>Overwrite</source>
-      <translation>Piši preko</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2634"/>
+        <source>Overwrite</source>
+        <translation>Piši preko</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2637"/>
-      <source>&amp;Export</source>
-      <translation>&amp;Eksportuj</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2666"/>
+        <source>&amp;Export</source>
+        <translation>&amp;Eksportuj</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2638"/>
-      <source>&amp;Cancel</source>
-      <translation>&amp;Otkaži</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2667"/>
+        <source>&amp;Cancel</source>
+        <translation>&amp;Otkaži</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2655"/>
-      <source>Open TIFF</source>
-      <translation>Otvori TIFF</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2684"/>
+        <source>Open TIFF</source>
+        <translation>Otvori TIFF</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2666"/>
-      <source>Open an Image Directory</source>
-      <translation>Otvori fasciklu sa slikama</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2695"/>
+        <source>Open an Image Directory</source>
+        <translation>Otvori fasciklu sa slikama</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2753"/>
-      <source>%1 exists, skipping...</source>
-      <translation>%1 postoji, preskočeno...</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2782"/>
+        <source>%1 exists, skipping...</source>
+        <translation>%1 postoji, preskočeno...</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2766"/>
-      <source>Sorry, I could not save: %1</source>
-      <translation>Izvini, nije moguće sačuvati: %1</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2795"/>
+        <source>Sorry, I could not save: %1</source>
+        <translation>Izvini, nije moguće sačuvati: %1</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2758"/>
-      <source>Sorry, I could not load page: %1</source>
-      <translation>Izvini, ne mogu učitati stranicu: %1</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2787"/>
+        <source>Sorry, I could not load page: %1</source>
+        <translation>Izvini, ne mogu učitati stranicu: %1</translation>
     </message>
-  </context>
-  <context>
-    <name>nmc::DkExposure</name>
+</context>
+<context>
+    <name>nmc::DkExposureWidget</name>
     <message>
-      <location filename="../src/DkGui/DkManipulationWidgets.cpp" line="1368"/>
-      <source>Exposure</source>
-      <translation>Ekspozicija</translation>
+        <location filename="../src/DkGui/DkManipulatorWidgets.cpp" line="457"/>
+        <source>Exposure</source>
+        <translation>Ekspozicija</translation>
     </message>
-  </context>
-  <context>
+    <message>
+        <location filename="../src/DkGui/DkManipulatorWidgets.cpp" line="464"/>
+        <source>Offset</source>
+        <translation>Istup</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkManipulatorWidgets.cpp" line="471"/>
+        <source>Gamma</source>
+        <translation>Gama</translation>
+    </message>
+</context>
+<context>
     <name>nmc::DkFileAssociationsPreference</name>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="997"/>
-      <source>Filter</source>
-      <translation type="unfinished">Filter</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1087"/>
+        <source>Filter</source>
+        <translation>Filter</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="998"/>
-      <source>Browse</source>
-      <translation>Pregledaj</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1088"/>
+        <source>Browse</source>
+        <translation>Pregledaj</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="999"/>
-      <source>Register</source>
-      <translation type="unfinished">Register</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1089"/>
+        <source>Register</source>
+        <translation>Registruj</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1011"/>
-      <source>Set as Default Viewer</source>
-      <translation type="unfinished">Set as Default Viewer</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1101"/>
+        <source>Set as Default Viewer</source>
+        <translation>Postavi kao podrazumijevani pregledač slika</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1029"/>
-      <source>Please Restart nomacs to apply changes</source>
-      <translation type="unfinished">Please Restart nomacs to apply changes</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1119"/>
+        <source>Please Restart nomacs to apply changes</source>
+        <translation>Molimo restartujte nomacs da bi prihvatili promjene</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1102"/>
-      <source>Image</source>
-      <translation>Slika</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1192"/>
+        <source>Image</source>
+        <translation>Slika</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkFileInfoLabel</name>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="1147"/>
-      <source>Info Box</source>
-      <translation>Info kutija</translation>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="1152"/>
+        <source>Info Box</source>
+        <translation>Info kutija</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="1148"/>
-      <source>All information fields are currently hidden.
+        <location filename="../src/DkGui/DkWidgets.cpp" line="1153"/>
+        <source>All information fields are currently hidden.
 Do you want to show them again?</source>
-      <translation>Sva polja su trenutno skrivena.
+        <translation>Sva polja su trenutno skrivena.
 Da li ih želite povratiti?</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkFilePreference</name>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="835"/>
-      <source>Screenshots are automatically saved to this folder</source>
-      <translation type="unfinished">Screenshots are automatically saved to this folder</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="922"/>
+        <source>Screenshots are automatically saved to this folder</source>
+        <translation>Snimke ekrana se automatski snimaju u ovaj direktorij</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="837"/>
-      <source>Use Temporary Folder</source>
-      <translation type="unfinished">Use Temporary Folder</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="924"/>
+        <source>Use Temporary Folder</source>
+        <translation>Koristi privremeni direktorij</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="852"/>
-      <source>We recommend to set a moderate cache value around 100 MB</source>
-      <translation type="unfinished">We recommend to set a moderate cache value around 100 MB</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="942"/>
+        <source>Maximal Cache Size</source>
+        <translation>Maksimalna veličina keša</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="854"/>
-      <source>Maximal Cache Size</source>
-      <translation type="unfinished">Maximal Cache Size</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="939"/>
+        <source>We recommend to set a moderate cache value around 100 MB. [%1-%2 MB]</source>
+        <translation>Predlažemo da se postavi umjerena vrijednost keša oko 100MB. [%1-%2 MB]</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="868"/>
-      <source>We recommend to set a moderate edit history value around 100 MB</source>
-      <translation type="unfinished">We recommend to set a moderate edit history value around 100 MB</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="956"/>
+        <source>We recommend to set a moderate edit history value around 100 MB. [%1-%2 MB]</source>
+        <translation>Predlažemo da se postavi umjerena vrijednost povijesti uređivanja oko 100MB. [%1-%2 MB]</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="870"/>
-      <source>History Size</source>
-      <translation type="unfinished">History Size</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="959"/>
+        <source>History Size</source>
+        <translation>Veličina povijesti</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="877"/>
-      <source>Skip Images</source>
-      <translation type="unfinished">Skip Images</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="966"/>
+        <source>Skip Images</source>
+        <translation>Preskoči slike</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="878"/>
-      <source>Images are skipped until the Next key is released</source>
-      <translation type="unfinished">Images are skipped until the Next key is released</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="967"/>
+        <source>Images are skipped until the Next key is released</source>
+        <translation>Slike su preskočene dok se ne pusti Next dugme</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="879"/>
-      <source>Wait for Images to be Loaded</source>
-      <translation type="unfinished">Wait for Images to be Loaded</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="968"/>
+        <source>Wait for Images to be Loaded</source>
+        <translation>Sačekaj da slike budu učitane</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="880"/>
-      <source>The next image is loaded after the current image is shown.</source>
-      <translation type="unfinished">The next image is loaded after the current image is shown.</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="969"/>
+        <source>The next image is loaded after the current image is shown.</source>
+        <translation>Sljedeća slika se učita nakon što se prikaže trenutna.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="891"/>
-      <source>Image Loading Policy</source>
-      <translation type="unfinished">Image Loading Policy</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="980"/>
+        <source>Image Loading Policy</source>
+        <translation>Postavke učitavanja slika</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="903"/>
-      <source>Number of Skipped Images on PgUp/PgDown</source>
-      <translation type="unfinished">Number of Skipped Images on PgUp/PgDown</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="992"/>
+        <source>Number of Skipped Images on PgUp/PgDown</source>
+        <translation>Broj preskočenih slika na PgUp/PgDown</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkFilePreview</name>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="191"/>
-      <source>Show Left</source>
-      <translation>Prikaži lijevo</translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="191"/>
+        <source>Show Left</source>
+        <translation>Prikaži lijevo</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="192"/>
-      <source>Shows the Thumbnail Bar on the Left</source>
-      <translation>Prikazuje traku sličica lijevo</translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="192"/>
+        <source>Shows the Thumbnail Bar on the Left</source>
+        <translation>Prikazuje traku sličica lijevo</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="195"/>
-      <source>Show Top</source>
-      <translation>Prikaži gore</translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="195"/>
+        <source>Show Top</source>
+        <translation>Prikaži gore</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="196"/>
-      <source>Shows the Thumbnail Bar at the Top</source>
-      <translation>Prikazuje traku sličica na vrhu</translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="196"/>
+        <source>Shows the Thumbnail Bar at the Top</source>
+        <translation>Prikazuje traku sličica na vrhu</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="199"/>
-      <source>Show Right</source>
-      <translation>Prikaži desno</translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="199"/>
+        <source>Show Right</source>
+        <translation>Prikaži desno</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="200"/>
-      <source>Shows the Thumbnail Bar on the Right</source>
-      <translation>Prikazuje traku sličica desno</translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="200"/>
+        <source>Shows the Thumbnail Bar on the Right</source>
+        <translation>Prikazuje traku sličica desno</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="203"/>
-      <source>Show Bottom</source>
-      <translation>Prikaži dole</translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="203"/>
+        <source>Show Bottom</source>
+        <translation>Prikaži dole</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="204"/>
-      <source>Shows the Thumbnail Bar at the Bottom</source>
-      <translation>Prikazuje traku sličica na dnu</translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="204"/>
+        <source>Shows the Thumbnail Bar at the Bottom</source>
+        <translation>Prikazuje traku sličica na dnu</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="207"/>
-      <source>Undock</source>
-      <translation>Odvoji</translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="207"/>
+        <source>Undock</source>
+        <translation>Odvoji</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="208"/>
-      <source>Undock the thumbnails</source>
-      <translation>Odvoji sličice</translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="208"/>
+        <source>Undock the thumbnails</source>
+        <translation>Odvoji sličice</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="211"/>
-      <source>File Preview Menu</source>
-      <translation>Meni pregleda fajla</translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="211"/>
+        <source>File Preview Menu</source>
+        <translation>Meni pregleda fajla</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="578"/>
-      <source>Name: </source>
-      <translation>Ime: </translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="585"/>
+        <source>Name: </source>
+        <translation>Ime: </translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="579"/>
-      <source>Size: </source>
-      <translation>Veličina: </translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="586"/>
+        <source>Size: </source>
+        <translation>Veličina: </translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="580"/>
-      <source>Created: </source>
-      <translation>Kreirano:</translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="587"/>
+        <source>Created: </source>
+        <translation>Kreirano: </translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="597"/>
-      <source>CTRL+Zoom resizes the thumbnails</source>
-      <translation>CTRL + zum mijenja veličinu sličica</translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="604"/>
+        <source>CTRL+Zoom resizes the thumbnails</source>
+        <translation>CTRL + zum mijenja veličinu sličica</translation>
     </message>
-  </context>
-  <context>
-    <name>nmc::DkFileSelection</name>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="446"/>
-      <source>No Files Selected</source>
-      <translation>Bez odabranih fajlova</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="325"/>
-      <source>File Explorer</source>
-      <translation>Pregledač fajlova</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="337"/>
-      <source>Thumbnails</source>
-      <translation>Sličice</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="338"/>
-      <source>File List</source>
-      <translation>Fajl lista</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="382"/>
-      <source>Open an Image Directory</source>
-      <translation>Otvori fasciklu sa slikama</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="448"/>
-      <source>%1 File Selected</source>
-      <translation>%1 fajl odabran</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="450"/>
-      <source>%1 Files Selected</source>
-      <translation>%1 fajlova odabrano</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="471"/>
-      <location filename="../src/DkGui/DkBatch.cpp" line="485"/>
-      <source>Results</source>
-      <translation>Rezultati</translation>
-    </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkFilenameWidget</name>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="514"/>
-      <source>Current Filename</source>
-      <translation>Trenutno ime fajla</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="534"/>
+        <source>Current Filename</source>
+        <translation>Trenutno ime fajla</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="515"/>
-      <source>Text</source>
-      <translation>Tekst</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="535"/>
+        <source>Text</source>
+        <translation>Tekst</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="516"/>
-      <source>Number</source>
-      <translation>Broj</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="536"/>
+        <source>Number</source>
+        <translation>Broj</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="522"/>
-      <source>Keep Case</source>
-      <translation>Zadrži velika i mala slova</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="542"/>
+        <source>Keep Case</source>
+        <translation>Zadrži velika i mala slova</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="523"/>
-      <source>To lowercase</source>
-      <translation>U mala slova</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="543"/>
+        <source>To lowercase</source>
+        <translation>U mala slova</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="524"/>
-      <source>To UPPERCASE</source>
-      <translation>U VELIKA SLOVA</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="544"/>
+        <source>To UPPERCASE</source>
+        <translation>U VELIKA SLOVA</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="535"/>
-      <source>1 digit</source>
-      <translation>1 cifra</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="555"/>
+        <source>1 digit</source>
+        <translation>1 cifra</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="536"/>
-      <source>2 digits</source>
-      <translation>2 cifre</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="556"/>
+        <source>2 digits</source>
+        <translation>2 cifre</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="537"/>
-      <source>3 digits</source>
-      <translation>3 cifre</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="557"/>
+        <source>3 digits</source>
+        <translation>3 cifre</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="538"/>
-      <source>4 digits</source>
-      <translation>4 cifre</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="558"/>
+        <source>4 digits</source>
+        <translation>4 cifre</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="539"/>
-      <source>5 digits</source>
-      <translation>5 cifara</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="559"/>
+        <source>5 digits</source>
+        <translation>5 cifara</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkForceThumbDialog</name>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4159"/>
-      <source>Overwrite Existing Thumbnails</source>
-      <translation>Piši preko postojećih sličica</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3810"/>
+        <source>Overwrite Existing Thumbnails</source>
+        <translation>Piši preko postojećih sličica</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4164"/>
-      <source>&amp;OK</source>
-      <translation>&amp;U redu</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3815"/>
+        <source>&amp;OK</source>
+        <translation>&amp;U redu</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4165"/>
-      <source>&amp;Cancel</source>
-      <translation>&amp;Otkaži</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3816"/>
+        <source>&amp;Cancel</source>
+        <translation>&amp;Otkaži</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4182"/>
-      <source>Compute thumbnails for all images in:
+        <location filename="../src/DkGui/DkDialog.cpp" line="3833"/>
+        <source>Compute thumbnails for all images in:
  %1
 </source>
-      <translation>Izračunaj sličice za sve slike u:
- %1</translation>
+        <translation>Izračunaj sličice za sve slike u:
+ %1
+</translation>
     </message>
-  </context>
-  <context>
-    <name>nmc::DkGamma</name>
-    <message>
-      <location filename="../src/DkGui/DkManipulationWidgets.cpp" line="1270"/>
-      <source>Gamma</source>
-      <translation>Gama</translation>
-    </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkGeneralPreference</name>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="306"/>
-      <source>Highlight Color</source>
-      <translation type="unfinished">Highlight Color</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="298"/>
+        <source>Highlight Color</source>
+        <translation>Istaknuta boja</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="311"/>
-      <source>Icon Color</source>
-      <translation type="unfinished">Icon Color</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="303"/>
+        <source>Icon Color</source>
+        <translation>Boja ikona</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="316"/>
-      <source>Background Color</source>
-      <translation>Boja pozadine</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="308"/>
+        <source>Background Color</source>
+        <translation>Boja pozadine</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="321"/>
-      <source>Fullscreen Color</source>
-      <translation type="unfinished">Fullscreen Color</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="313"/>
+        <source>Fullscreen Color</source>
+        <translation>Boja celog ekrana</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="326"/>
-      <source>HUD Foreground Color</source>
-      <translation type="unfinished">HUD Foreground Color</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="318"/>
+        <source>HUD Foreground Color</source>
+        <translation>Prednja boja HUD-a</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="331"/>
-      <source>HUD Background Color</source>
-      <translation type="unfinished">HUD Background Color</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="323"/>
+        <source>HUD Background Color</source>
+        <translation>Pozadinska boja HUD-a</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="337"/>
-      <source>Color Settings</source>
-      <translation type="unfinished">Color Settings</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="329"/>
+        <source>Color Settings</source>
+        <translation>Postavke boja</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="346"/>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="554"/>
-      <source>Reset All Settings</source>
-      <translation type="unfinished">Reset All Settings</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="339"/>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="607"/>
+        <source>Reset All Settings</source>
+        <translation>Povrati sve postavke</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="350"/>
-      <source>Default Settings</source>
-      <translation type="unfinished">Default Settings</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="343"/>
+        <source>&amp;Import Settings</source>
+        <translation>&amp;Importuj postavke</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="363"/>
-      <source>Show Recent Files on Start-Up</source>
-      <translation type="unfinished">Show Recent Files on Start-Up</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="347"/>
+        <source>&amp;Export Settings</source>
+        <translation>&amp;Eksportuj postavke</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="365"/>
-      <source>Show the History Panel on Start-Up</source>
-      <translation type="unfinished">Show the History Panel on Start-Up</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="351"/>
+        <source>Default Settings</source>
+        <translation>Podrazumijevane postavke</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="368"/>
-      <source>Log Recent Files</source>
-      <translation type="unfinished">Log Recent Files</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="366"/>
+        <source>Show Recent Files on Start-Up</source>
+        <translation>Prikaži nedavne fajlove pri pokretanju</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="370"/>
-      <source>If checked, recent files will be saved.</source>
-      <translation type="unfinished">If checked, recent files will be saved.</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="368"/>
+        <source>Show the History Panel on Start-Up</source>
+        <translation>Prikaži panel za povijest pri pokretanju</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="373"/>
-      <source>Loop Images</source>
-      <translation type="unfinished">Loop Images</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="371"/>
+        <source>Log Recent Files</source>
+        <translation>Bilježi nedavne slike</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="375"/>
-      <source>Start with the first image in a folder after showing the last.</source>
-      <translation type="unfinished">Start with the first image in a folder after showing the last.</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="373"/>
+        <source>If checked, recent files will be saved.</source>
+        <translation>Ako je označeno, nedavni fajlovi će biti snimljeni.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="378"/>
-      <source>Mouse Wheel Zooms</source>
-      <translation type="unfinished">Mouse Wheel Zooms</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="376"/>
+        <source>Check for Duplicates on Open</source>
+        <translation>Provjeri da ovjerene duplikate</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="380"/>
-      <source>If checked, the mouse wheel zooms - otherwise it is used to switch between images.</source>
-      <translation type="unfinished">If checked, the mouse wheel zooms - otherwise it is used to switch between images.</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="378"/>
+        <source>If any files are opened which are already open in a tab, don&apos;t open them again.</source>
+        <translation>Ne otvaraj ponovo fajlove koji su već otvoreni u nekoj kartici.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="383"/>
-      <source>Double Click Opens Fullscreen</source>
-      <translation type="unfinished">Double Click Opens Fullscreen</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="381"/>
+        <source>Show extra options related to tabs</source>
+        <translation>Prikaži dodatne postavke u povezanim karticama</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="385"/>
-      <source>If checked, a double click on the canvas opens the fullscreen mode.</source>
-      <translation type="unfinished">If checked, a double click on the canvas opens the fullscreen mode.</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="383"/>
+        <source>Enables the &quot;Go to Tab&quot;, &quot;First Tab&quot;, and &quot;Last Tab&quot; options in the View menu, and the &quot;Open Tabs&quot; and &quot;Save Tabs&quot; options in the File menu.</source>
+        <translation>Prikazuje &quot;Idi na karticu&quot;, &quot;Prva kartica&quot; i &quot;Zadnja kartica&quot; mogućnost u izborniku pogleda, i &quot;Otvori kartice&quot; i &quot;Sačuvaj kartice&quot; mogućnost u izborniku fajlova.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="388"/>
-      <source>Show Background Image</source>
-      <translation type="unfinished">Show Background Image</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="386"/>
+        <source>Loop Images</source>
+        <translation>Prikazuj u petlji</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="390"/>
-      <source>If checked, the nomacs logo is shown in the bottom right corner.</source>
-      <translation type="unfinished">If checked, the nomacs logo is shown in the bottom right corner.</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="388"/>
+        <source>Start with the first image in a folder after showing the last.</source>
+        <translation>Prikaži prvu sliku u direktoriju nakon prikaza posljednje.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="393"/>
-      <source>Switch CTRL with ALT</source>
-      <translation type="unfinished">Switch CTRL with ALT</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="391"/>
+        <source>Mouse Wheel Zooms</source>
+        <translation>Zumiraj točkićem miša</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="395"/>
-      <source>If checked, CTRL + Mouse is switched with ALT + Mouse.</source>
-      <translation type="unfinished">If checked, CTRL + Mouse is switched with ALT + Mouse.</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="393"/>
+        <source>If checked, the mouse wheel zooms - otherwise it is used to switch between images.</source>
+        <translation>Ako je označeno, točkić na mišu zumira. Inače se koristi za promjenu slika.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="398"/>
-      <source>Enable LAN Sync</source>
-      <translation type="unfinished">Enable LAN Sync</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="396"/>
+        <source>Next Image on Horizontal Zoom</source>
+        <translation>Sljedeća slika pri horizontalnom zumiranju</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="400"/>
-      <source>If checked, syncing in your LAN is enabled.</source>
-      <translation type="unfinished">If checked, syncing in your LAN is enabled.</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="398"/>
+        <source>If checked, horizontal wheel events load the next/previous images.</source>
+        <translation>Ako je uključeno, horizontalno kretanje točkića učitava sljedeću/prethodnu sliku.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="403"/>
-      <source>Close on ESC</source>
-      <translation type="unfinished">Close on ESC</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="401"/>
+        <source>Double Click Opens Fullscreen</source>
+        <translation>Dupli klik otvora preko cijelog ekrana</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="405"/>
-      <source>Close nomacs if ESC is pressed.</source>
-      <translation type="unfinished">Close nomacs if ESC is pressed.</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="403"/>
+        <source>If checked, a double click on the canvas opens the fullscreen mode.</source>
+        <translation>Ako je označeno, dupli klik na sliku otvara prikaz preko cijelog ekrana.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="408"/>
-      <source>Check For Updates</source>
-      <translation type="unfinished">Check For Updates</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="406"/>
+        <source>Show Background Image</source>
+        <translation>Prikaži pozadinsku sliku</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="410"/>
-      <source>Check for updates on start-up.</source>
-      <translation type="unfinished">Check for updates on start-up.</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="408"/>
+        <source>If checked, the nomacs logo is shown in the bottom right corner.</source>
+        <translation>Ako je označeno, nomacs logo će biti prikazan u donjem desnom uglu.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="413"/>
-      <source>General</source>
-      <translation type="unfinished">General</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="411"/>
+        <source>Switch CTRL with ALT</source>
+        <translation>Zamjeni CTRL i ALT</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="428"/>
-      <source>Choose your preferred language.</source>
-      <translation type="unfinished">Choose your preferred language.</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="413"/>
+        <source>If checked, CTRL + Mouse is switched with ALT + Mouse.</source>
+        <translation>Ako je označeno, CTRL + miš je zamijenjeno sa ALT + miš.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="433"/>
-      <source>Info on how to translate nomacs.</source>
-      <translation type="unfinished">Info on how to translate nomacs.</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="416"/>
+        <source>Enable LAN Sync</source>
+        <translation>Omogući LAN sinhronizaciju</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="436"/>
-      <source>Language</source>
-      <translation type="unfinished">Language</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="418"/>
+        <source>If checked, syncing in your LAN is enabled.</source>
+        <translation>Ako je označeno, LAN sinhronizacija je omogućena.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="457"/>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="558"/>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="571"/>
-      <source>Please Restart nomacs to apply changes</source>
-      <translation type="unfinished">Please Restart nomacs to apply changes</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="421"/>
+        <source>Close on ESC</source>
+        <translation>Zatvori na ESC</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="554"/>
-      <source>This will reset all personal settings!</source>
-      <translation type="unfinished">This will reset all personal settings!</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="423"/>
+        <source>Close nomacs if ESC is pressed.</source>
+        <translation>Zatvori nomacs pri pritisku ESC dugmeta.</translation>
     </message>
-  </context>
-  <context>
+    <message>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="426"/>
+        <source>Check For Updates</source>
+        <translation>Provjeri ažuriranja</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="428"/>
+        <source>Check for updates on start-up.</source>
+        <translation>Provjerava da li postoje ažuriranja pri pokretanju.</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="431"/>
+        <source>General</source>
+        <translation>Opšte</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="449"/>
+        <source>Choose your preferred language.</source>
+        <translation>Izaberi jezik.</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="454"/>
+        <source>Info on how to translate nomacs.</source>
+        <translation>Informacije za prevod nomacsa.</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="457"/>
+        <source>Language</source>
+        <translation>Jezik</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="478"/>
+        <source>Please Restart nomacs to apply changes</source>
+        <translation>Molimo restartujte nomacs da bi prihvatili promjene</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="607"/>
+        <source>This will reset all personal settings!</source>
+        <translation>Ovo će izbrisati sve lične postavke!</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="621"/>
+        <source>Import Settings</source>
+        <translation>Unesi postavke</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="638"/>
+        <source>Export Settings</source>
+        <translation>Izvezi postavke</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="649"/>
+        <source>Settings exported</source>
+        <translation>Postavke izvedene</translation>
+    </message>
+</context>
+<context>
+    <name>nmc::DkGenericProfileWidget</name>
+    <message>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="3074"/>
+        <source>Set As Default</source>
+        <translation>Postavi kao zadano</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="3132"/>
+        <source>Profile Name</source>
+        <translation>Ime profila</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="3133"/>
+        <source>Profile Name:</source>
+        <translation>Ime profila:</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="3145"/>
+        <source>Profile Already Exists</source>
+        <translation>Profil već postoji</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="3146"/>
+        <source>Do you want to overwrite %1?</source>
+        <translation>Da li želite snimi preko %1?</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="3210"/>
+        <source>No Profiles</source>
+        <translation>Nema profila</translation>
+    </message>
+</context>
+<context>
     <name>nmc::DkGlobalSettingsWidget</name>
     <message>
-      <location filename="../src/DkCore/DkUtils.cpp" line="344"/>
-      <source>English</source>
-      <extracomment>this should be the name of the language in which nomacs is translated to</extracomment>
-      <translation>hrvatski</translation>
+        <location filename="../src/DkCore/DkUtils.cpp" line="409"/>
+        <source>English</source>
+        <extracomment>this should be the name of the language in which nomacs is translated to</extracomment>
+        <translation>hrvatski</translation>
     </message>
-  </context>
-  <context>
-    <name>nmc::DkHue</name>
+</context>
+<context>
+    <name>nmc::DkHistogram</name>
     <message>
-      <location filename="../src/DkGui/DkManipulationWidgets.cpp" line="1166"/>
-      <source>Hue</source>
-      <translation>Nijansa</translation>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="2113"/>
+        <source>Show Statistics</source>
+        <translation>Prikaži statistiku</translation>
     </message>
-  </context>
-  <context>
+    <message>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="2118"/>
+        <source>Histogram Settings</source>
+        <translation>Histogram postavke</translation>
+    </message>
+</context>
+<context>
+    <name>nmc::DkHueWidget</name>
+    <message>
+        <location filename="../src/DkGui/DkManipulatorWidgets.cpp" line="403"/>
+        <source>Hue</source>
+        <translation>Nijansa</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkManipulatorWidgets.cpp" line="410"/>
+        <source>Saturation</source>
+        <translation>Zasićenje</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkManipulatorWidgets.cpp" line="417"/>
+        <source>Brightness</source>
+        <translation>Svjetlina</translation>
+    </message>
+</context>
+<context>
     <name>nmc::DkImageContainerT</name>
     <message>
-      <location filename="../src/DkLoader/DkImageContainer.cpp" line="666"/>
-      <source>Sorry, the file: %1 does not exist... </source>
-      <translation>Izvini, fajl: %1 ne postoji... </translation>
+        <location filename="../src/DkCore/DkImageContainer.cpp" line="671"/>
+        <source>Sorry, the file: %1 does not exist... </source>
+        <translation>Izvini, fajl: %1 ne postoji... </translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageContainer.cpp" line="673"/>
-      <source>Sorry, you are not allowed to read: %1</source>
-      <translation>Izvini, nije vam dozvoljeno da čitanje: %1</translation>
+        <location filename="../src/DkCore/DkImageContainer.cpp" line="678"/>
+        <source>Sorry, you are not allowed to read: %1</source>
+        <translation>Izvini, nije vam dozvoljeno da čitanje: %1</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageContainer.cpp" line="784"/>
-      <source>Sorry, I could not load: %1</source>
-      <translation>Izvini, nije moguće učitati: %1</translation>
+        <location filename="../src/DkCore/DkImageContainer.cpp" line="796"/>
+        <source>updated...</source>
+        <translation>ažurirano...</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageContainer.cpp" line="827"/>
-      <source>Sorry, I could not download:
+        <location filename="../src/DkCore/DkImageContainer.cpp" line="804"/>
+        <source>Sorry, I could not load: %1</source>
+        <translation>Izvini, nije moguće učitati: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/DkCore/DkImageContainer.cpp" line="847"/>
+        <source>Sorry, I could not download:
 %1</source>
-      <translation>Izvini, nije moguće preuzeti:
+        <translation>Izvini, nije moguće preuzeti:
 %1</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageContainer.cpp" line="893"/>
-      <source>I can't save an empty file, sorry...
+        <location filename="../src/DkCore/DkImageContainer.cpp" line="913"/>
+        <source>I can&apos;t save an empty file, sorry...
 </source>
-      <translation>Ne mogu sačuvati prazan fajl, izvini...</translation>
+        <translation>Ne mogu sačuvati prazan fajl, izvini...
+</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageContainer.cpp" line="898"/>
-      <source>Sorry, the directory: %1  does not exist
+        <location filename="../src/DkCore/DkImageContainer.cpp" line="918"/>
+        <source>Sorry, the directory: %1  does not exist
 </source>
-      <translation>Izvini, fascikla: %1  ne postoji</translation>
+        <translation>Izvini, fascikla: %1  ne postoji
+</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageContainer.cpp" line="903"/>
-      <source>Sorry, I can't write to the file: %1</source>
-      <translation>Izvini, ne mogu pisati u fajl: %1</translation>
+        <location filename="../src/DkCore/DkImageContainer.cpp" line="923"/>
+        <source>Sorry, I can&apos;t write to the file: %1</source>
+        <translation>Izvini, ne mogu pisati u fajl: %1</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkImageLoader</name>
     <message>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="852"/>
-      <source>sorry, %1 does not exist anymore...</source>
-      <translation>izvini, %1 ne postoji više...</translation>
+        <location filename="../src/DkCore/DkImageLoader.cpp" line="857"/>
+        <source>sorry, %1 does not exist anymore...</source>
+        <translation>izvini, %1 ne postoji više...</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="561"/>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="623"/>
-      <source>You have reached the beginning</source>
-      <translation>Stigli ste na početak</translation>
+        <location filename="../src/DkCore/DkImageLoader.cpp" line="561"/>
+        <location filename="../src/DkCore/DkImageLoader.cpp" line="623"/>
+        <source>You have reached the beginning</source>
+        <translation>Stigli ste na početak</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="567"/>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="628"/>
-      <source>You have reached the end</source>
-      <translation>Stigli ste na kraj</translation>
+        <location filename="../src/DkCore/DkImageLoader.cpp" line="567"/>
+        <location filename="../src/DkCore/DkImageLoader.cpp" line="628"/>
+        <source>You have reached the end</source>
+        <translation>Stigli ste na kraj</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="736"/>
-      <source>Save Image</source>
-      <translation>Sačuvaj sliku</translation>
+        <location filename="../src/DkCore/DkImageLoader.cpp" line="739"/>
+        <source>Save Image</source>
+        <translation>Sačuvaj sliku</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="736"/>
-      <source>Do you want to save changes to:
+        <location filename="../src/DkCore/DkImageLoader.cpp" line="740"/>
+        <source>Do you want to save changes to:
 %1</source>
-      <translation>Da li želite da sačuvate promjene u:
+        <translation>Da li želite da sačuvate promjene u:
 %1</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="948"/>
-      <source>%1 of %2</source>
-      <translation type="unfinished">%1 of %2</translation>
+        <location filename="../src/DkCore/DkImageLoader.cpp" line="953"/>
+        <source>%1 of %2</source>
+        <translation>%1 od %2</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="1043"/>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="1121"/>
-      <source>Save File %1</source>
-      <translation>Snimi fajl %1</translation>
+        <location filename="../src/DkCore/DkImageLoader.cpp" line="1051"/>
+        <location filename="../src/DkCore/DkImageLoader.cpp" line="1129"/>
+        <source>Save File %1</source>
+        <translation>Snimi fajl %1</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="1108"/>
-      <source>Overwrite File</source>
-      <translation>Piši preko fajla</translation>
+        <location filename="../src/DkCore/DkImageLoader.cpp" line="1116"/>
+        <source>Overwrite File</source>
+        <translation>Piši preko fajla</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="1109"/>
-      <source>Do you want to overwrite:
+        <location filename="../src/DkCore/DkImageLoader.cpp" line="1117"/>
+        <source>Do you want to overwrite:
 %1?</source>
-      <translation>Da li želite pisati preko:
+        <translation>Da li želite pisati preko:
 %1?</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="1237"/>
-      <source>Sorry, I cannot save an empty image...</source>
-      <translation>Izvini, ne mogu snimiti praznu sliku...</translation>
+        <location filename="../src/DkCore/DkImageLoader.cpp" line="1245"/>
+        <source>Sorry, I cannot save an empty image...</source>
+        <translation>Izvini, ne mogu snimiti praznu sliku...</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="1420"/>
-      <source>Rotated</source>
-      <translation type="unfinished">Rotated</translation>
+        <location filename="../src/DkCore/DkImageLoader.cpp" line="1428"/>
+        <source>Rotated</source>
+        <translation>Rotirano</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="1684"/>
-      <source>Error</source>
-      <translation>Greška</translation>
+        <location filename="../src/DkCore/DkImageLoader.cpp" line="1692"/>
+        <source>Error</source>
+        <translation>Greška</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="993"/>
-      <source>Save Directory</source>
-      <translation>Sačuvaj fasciklu</translation>
+        <location filename="../src/DkCore/DkImageLoader.cpp" line="1000"/>
+        <source>Save Directory</source>
+        <translation>Sačuvaj fasciklu</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="1366"/>
-      <source>%1 deleted...</source>
-      <translation>%1 izbrisano...</translation>
+        <location filename="../src/DkCore/DkImageLoader.cpp" line="1374"/>
+        <source>%1 deleted...</source>
+        <translation>%1 izbrisano...</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="1370"/>
-      <source>Sorry, I could not delete: %1</source>
-      <translation>Izvini, ne mogu izbrisati: %1</translation>
+        <location filename="../src/DkCore/DkImageLoader.cpp" line="1378"/>
+        <source>Sorry, I could not delete: %1</source>
+        <translation>Izvini, ne mogu izbrisati: %1</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="196"/>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="232"/>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="268"/>
-      <source>%1 
+        <location filename="../src/DkCore/DkImageLoader.cpp" line="196"/>
+        <location filename="../src/DkCore/DkImageLoader.cpp" line="232"/>
+        <location filename="../src/DkCore/DkImageLoader.cpp" line="268"/>
+        <source>%1 
  does not contain any image</source>
-      <translation>%1 
+        <translation>%1 
  ne sadrži nijednu sliku</translation>
     </message>
-  </context>
-  <context>
-    <name>nmc::DkImageManipulationDialog</name>
-    <message>
-      <location filename="../src/DkGui/DkManipulationWidgets.cpp" line="94"/>
-      <source>Image Manipulation Tools</source>
-      <translation>Alati za manipulaciju slika</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkManipulationWidgets.cpp" line="170"/>
-      <source>&amp;OK</source>
-      <translation>&amp;U redu</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkManipulationWidgets.cpp" line="171"/>
-      <source>&amp;Cancel</source>
-      <translation>&amp;Otkaži</translation>
-    </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkImageStorage</name>
     <message>
-      <location filename="../src/DkLoader/DkImageStorage.cpp" line="1245"/>
-      <source>Anti Aliasing Enabled</source>
-      <translation>Uključen anti-alias</translation>
+        <location filename="../src/DkCore/DkImageStorage.cpp" line="1572"/>
+        <source>Anti Aliasing Enabled</source>
+        <translation>Uključen anti-alias</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageStorage.cpp" line="1245"/>
-      <source>Anti Aliasing Disabled</source>
-      <translation>Isključen anti-alias</translation>
+        <location filename="../src/DkCore/DkImageStorage.cpp" line="1572"/>
+        <source>Anti Aliasing Disabled</source>
+        <translation>Isključen anti-alias</translation>
     </message>
-  </context>
-  <context>
-    <name>nmc::DkInstallUpdater</name>
-    <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="228"/>
-      <source>There are new packages available: </source>
-      <translation type="unfinished">There are new packages available: </translation>
-    </message>
-    <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="235"/>
-      <source>Updates Available</source>
-      <translation type="unfinished">Updates Available</translation>
-    </message>
-    <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="240"/>
-      <source>&amp;Upgrade</source>
-      <translation>&amp;Nadogradnja</translation>
-    </message>
-    <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="241"/>
-      <source>Remind Me &amp;Later</source>
-      <translation type="unfinished">Remind Me &amp;Later</translation>
-    </message>
-    <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="242"/>
-      <source>&amp;Skip this Version</source>
-      <translation type="unfinished">&amp;Skip this Version</translation>
-    </message>
-    <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="258"/>
-      <source>nomacs Updates</source>
-      <translation type="unfinished">nomacs Updates</translation>
-    </message>
-    <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="258"/>
-      <source>nomacs is up-to-date</source>
-      <translation>nomacs je ažuran</translation>
-    </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkInstalledPluginsModel</name>
     <message>
-      <location filename="../src/DkLoader/DkPluginManager.cpp" line="745"/>
-      <source>Uninstall</source>
-      <translation>Deinstaliraj</translation>
+        <location filename="../src/DkCore/DkPluginManager.cpp" line="783"/>
+        <source>Uninstall</source>
+        <translation>Deinstaliraj</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkPluginManager.cpp" line="758"/>
-      <source>Name</source>
-      <translation>Ime</translation>
+        <location filename="../src/DkCore/DkPluginManager.cpp" line="796"/>
+        <source>Name</source>
+        <translation>Ime</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkPluginManager.cpp" line="760"/>
-      <source>Version</source>
-      <translation>Verzija</translation>
+        <location filename="../src/DkCore/DkPluginManager.cpp" line="798"/>
+        <source>Version</source>
+        <translation>Verzija</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkPluginManager.cpp" line="762"/>
-      <source>Uninstall plugin</source>
-      <translation>Deinstaliraj priključak</translation>
+        <location filename="../src/DkCore/DkPluginManager.cpp" line="800"/>
+        <source>Uninstall plugin</source>
+        <translation>Deinstaliraj priključak</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkListWidget</name>
     <message>
-      <location filename="../src/DkGui/DkWidgets.h" line="945"/>
-      <source>Drag Items Here</source>
-      <translation>Prenesi stvari ovdje</translation>
+        <location filename="../src/DkGui/DkWidgets.h" line="969"/>
+        <source>Drag Items Here</source>
+        <translation>Prenesi stvari ovdje</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
+    <name>nmc::DkManipulatorWidget</name>
+    <message>
+        <location filename="../src/DkGui/DkManipulatorWidgets.cpp" line="120"/>
+        <source>Undo</source>
+        <translation>Opozovi</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkManipulatorWidgets.cpp" line="128"/>
+        <source>Redo</source>
+        <translation>Ponovi</translation>
+    </message>
+</context>
+<context>
     <name>nmc::DkMessageBox</name>
     <message>
-      <location filename="../src/DkLoader/DkMessageBox.cpp" line="66"/>
-      <source>Error</source>
-      <translation>Greška</translation>
+        <location filename="../src/DkCore/DkMessageBox.cpp" line="66"/>
+        <source>Error</source>
+        <translation>Greška</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMessageBox.cpp" line="99"/>
-      <source>Remember my choice</source>
-      <translation>Zapamti moj izbor</translation>
+        <location filename="../src/DkCore/DkMessageBox.cpp" line="100"/>
+        <source>Remember my choice</source>
+        <translation>Zapamti moj izbor</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkMetaData</name>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="60"/>
-      <source>Image Size</source>
-      <translation>Veličina slike</translation>
+        <location filename="../src/DkCore/DkSettings.cpp" line="65"/>
+        <source>Image Size</source>
+        <translation>Veličina slike</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="61"/>
-      <source>Orientation</source>
-      <translation>Orijentacija</translation>
+        <location filename="../src/DkCore/DkSettings.cpp" line="66"/>
+        <source>Orientation</source>
+        <translation>Orijentacija</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="62"/>
-      <source>Make</source>
-      <translation>Marka</translation>
+        <location filename="../src/DkCore/DkSettings.cpp" line="67"/>
+        <source>Make</source>
+        <translation>Marka</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="63"/>
-      <source>Model</source>
-      <translation>Model</translation>
+        <location filename="../src/DkCore/DkSettings.cpp" line="68"/>
+        <source>Model</source>
+        <translation>Model</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="64"/>
-      <source>Aperture Value</source>
-      <translation>Otvor blende</translation>
+        <location filename="../src/DkCore/DkSettings.cpp" line="69"/>
+        <source>Aperture Value</source>
+        <translation>Otvor blende</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="65"/>
-      <source>ISO</source>
-      <translation>ISO</translation>
+        <location filename="../src/DkCore/DkSettings.cpp" line="70"/>
+        <source>ISO</source>
+        <translation>ISO</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="66"/>
-      <source>Flash</source>
-      <translation>Blic</translation>
+        <location filename="../src/DkCore/DkSettings.cpp" line="71"/>
+        <source>Flash</source>
+        <translation>Blic</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="67"/>
-      <source>Focal Length</source>
-      <translation>Fokusna dužina</translation>
+        <location filename="../src/DkCore/DkSettings.cpp" line="72"/>
+        <source>Focal Length</source>
+        <translation>Fokusna dužina</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="68"/>
-      <source>Exposure Mode</source>
-      <translation>Režim ekspozicije</translation>
+        <location filename="../src/DkCore/DkSettings.cpp" line="73"/>
+        <source>Exposure Mode</source>
+        <translation>Režim ekspozicije</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="69"/>
-      <source>Exposure Time</source>
-      <translation>Vrijeme ekspozicije</translation>
+        <location filename="../src/DkCore/DkSettings.cpp" line="74"/>
+        <source>Exposure Time</source>
+        <translation>Vrijeme ekspozicije</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="72"/>
-      <source>Rating</source>
-      <translation>Ocjena</translation>
+        <location filename="../src/DkCore/DkSettings.cpp" line="77"/>
+        <source>Rating</source>
+        <translation>Ocjena</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="73"/>
-      <source>User Comment</source>
-      <translation>Korisnički komentar</translation>
+        <location filename="../src/DkCore/DkSettings.cpp" line="78"/>
+        <source>User Comment</source>
+        <translation>Korisnički komentar</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="74"/>
-      <source>Date Time</source>
-      <translation>Datum i vrijeme</translation>
+        <location filename="../src/DkCore/DkSettings.cpp" line="79"/>
+        <source>Date Time</source>
+        <translation>Datum i vrijeme</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="75"/>
-      <source>Date Time Original</source>
-      <translation>Datum i vrijeme originala</translation>
+        <location filename="../src/DkCore/DkSettings.cpp" line="80"/>
+        <source>Date Time Original</source>
+        <translation>Datum i vrijeme originala</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="76"/>
-      <source>Image Description</source>
-      <translation>Opis slike</translation>
+        <location filename="../src/DkCore/DkSettings.cpp" line="81"/>
+        <source>Image Description</source>
+        <translation>Opis slike</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="77"/>
-      <source>Creator</source>
-      <translation>Kreator</translation>
+        <location filename="../src/DkCore/DkSettings.cpp" line="82"/>
+        <source>Creator</source>
+        <translation>Kreator</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="78"/>
-      <source>Creator Title</source>
-      <translation>Naslov kreatora</translation>
+        <location filename="../src/DkCore/DkSettings.cpp" line="83"/>
+        <source>Creator Title</source>
+        <translation>Naslov kreatora</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="79"/>
-      <source>City</source>
-      <translation>Grad</translation>
+        <location filename="../src/DkCore/DkSettings.cpp" line="84"/>
+        <source>City</source>
+        <translation>Grad</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="80"/>
-      <source>Country</source>
-      <translation>Država</translation>
+        <location filename="../src/DkCore/DkSettings.cpp" line="85"/>
+        <source>Country</source>
+        <translation>Država</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="81"/>
-      <source>Headline</source>
-      <translation>Naslov</translation>
+        <location filename="../src/DkCore/DkSettings.cpp" line="86"/>
+        <source>Headline</source>
+        <translation>Naslov</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="82"/>
-      <source>Caption</source>
-      <translation>Natpis</translation>
+        <location filename="../src/DkCore/DkSettings.cpp" line="87"/>
+        <source>Caption</source>
+        <translation>Natpis</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="83"/>
-      <source>Copyright</source>
-      <translation>Autorska prava</translation>
+        <location filename="../src/DkCore/DkSettings.cpp" line="88"/>
+        <source>Copyright</source>
+        <translation>Autorska prava</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="84"/>
-      <source>Keywords</source>
-      <translation>Ključne rječi</translation>
+        <location filename="../src/DkCore/DkSettings.cpp" line="89"/>
+        <source>Keywords</source>
+        <translation>Ključne rječi</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="85"/>
-      <source>Path</source>
-      <translation>Putanja</translation>
+        <location filename="../src/DkCore/DkSettings.cpp" line="90"/>
+        <source>Path</source>
+        <translation>Putanja</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="86"/>
-      <source>File Size</source>
-      <translation>Veličina fajla</translation>
+        <location filename="../src/DkCore/DkSettings.cpp" line="91"/>
+        <source>File Size</source>
+        <translation>Veličina fajla</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkMetaDataDock</name>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="389"/>
-      <source>Thumbnail</source>
-      <translation>Sličica</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="389"/>
+        <source>Thumbnail</source>
+        <translation>Sličica</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkMetaDataHUD</name>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="682"/>
-      <source>Image Information</source>
-      <translation>Informacije o slici</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="683"/>
+        <source>Image Information</source>
+        <translation>Informacije o slici</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="729"/>
-      <source>Change Entries</source>
-      <translation>Izmjeni upise</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="730"/>
+        <source>Change Entries</source>
+        <translation>Izmjeni upise</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="730"/>
-      <source>You can customize the entries displayed here.</source>
-      <translation>Ovdje možete prilagoditi prikazane upise.</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="731"/>
+        <source>You can customize the entries displayed here.</source>
+        <translation>Ovdje možete prilagoditi prikazane upise.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="733"/>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="1113"/>
-      <source>Number of Columns</source>
-      <translation>Broj kolona</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="734"/>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="1114"/>
+        <source>Number of Columns</source>
+        <translation>Broj kolona</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="734"/>
-      <source>Select the desired number of columns.</source>
-      <translation>Izaberite željeni broj kolona.</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="735"/>
+        <source>Select the desired number of columns.</source>
+        <translation>Izaberite željeni broj kolona.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="737"/>
-      <source>Set to Default</source>
-      <translation>Vrati na standardne postavke</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="738"/>
+        <source>Set to Default</source>
+        <translation>Vrati na standardne postavke</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="738"/>
-      <source>Reset the metadata panel.</source>
-      <translation>Resetuj panel o informacijama.</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="739"/>
+        <source>Reset the metadata panel.</source>
+        <translation>Resetuj panel o informacijama.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="742"/>
-      <source>Show Left</source>
-      <translation>Prikaži lijevo</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="743"/>
+        <source>Show Left</source>
+        <translation>Prikaži lijevo</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="743"/>
-      <source>Shows the Metadata on the Left</source>
-      <translation>Prikazuje informacije lijevo</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="744"/>
+        <source>Shows the Metadata on the Left</source>
+        <translation>Prikazuje informacije lijevo</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="746"/>
-      <source>Show Top</source>
-      <translation>Prikaži gore</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="747"/>
+        <source>Show Top</source>
+        <translation>Prikaži gore</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="747"/>
-      <source>Shows the Metadata at the Top</source>
-      <translation>Prikazuje informacije na vrhu</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="748"/>
+        <source>Shows the Metadata at the Top</source>
+        <translation>Prikazuje informacije na vrhu</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="750"/>
-      <source>Show Right</source>
-      <translation>Prikaži desno</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="751"/>
+        <source>Show Right</source>
+        <translation>Prikaži desno</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="751"/>
-      <source>Shows the Metadata on the Right</source>
-      <translation>Prikazuje informacije desno</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="752"/>
+        <source>Shows the Metadata on the Right</source>
+        <translation>Prikazuje informacije desno</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="754"/>
-      <source>Show Bottom</source>
-      <translation>Prikaži dole</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="755"/>
+        <source>Show Bottom</source>
+        <translation>Prikaži dole</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="755"/>
-      <source>Shows the Metadata at the Bottom</source>
-      <translation>Prikazuje informacije na dnu</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="756"/>
+        <source>Shows the Metadata at the Bottom</source>
+        <translation>Prikazuje informacije na dnu</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="1030"/>
-      <source>Metadata Menu</source>
-      <translation>Meni sa informacijama</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="1031"/>
+        <source>Metadata Menu</source>
+        <translation>Meni sa informacijama</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="1092"/>
-      <source>&amp;OK</source>
-      <translation>&amp;U redu</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="1093"/>
+        <source>&amp;OK</source>
+        <translation>&amp;U redu</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="1093"/>
-      <source>&amp;Cancel</source>
-      <translation>&amp;Otkaži</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="1094"/>
+        <source>&amp;Cancel</source>
+        <translation>&amp;Otkaži</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="1113"/>
-      <source>Number of columns (-1 is default)</source>
-      <translation>Broj kolona (obično -1)</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="1114"/>
+        <source>Number of columns (-1 is default)</source>
+        <translation>Broj kolona (obično -1)</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkMetaDataModel</name>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="64"/>
-      <source>Key</source>
-      <translation>Ključ</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="64"/>
+        <source>Key</source>
+        <translation>Ključ</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="64"/>
-      <source>Value</source>
-      <translation>Vrijednost</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="64"/>
+        <source>Value</source>
+        <translation>Vrijednost</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="146"/>
-      <source>Data.</source>
-      <translation>Podaci.</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="145"/>
+        <source>Data.</source>
+        <translation>Podaci.</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkMetaDataSelection</name>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="550"/>
-      <source>Check All</source>
-      <translation>Provjeri sve</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="550"/>
+        <source>Check All</source>
+        <translation>Provjeri sve</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkMosaicDialog</name>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3207"/>
-      <source>Create Mosaic Image</source>
-      <translation>Kreiraj mozaik</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2858"/>
+        <source>Create Mosaic Image</source>
+        <translation>Kreiraj mozaik</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3270"/>
-      <source>Darken</source>
-      <translation>Tamnije</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2921"/>
+        <source>Darken</source>
+        <translation>Tamnije</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3271"/>
-      <source>Lighten</source>
-      <translation>Svijetlije</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2922"/>
+        <source>Lighten</source>
+        <translation>Svijetlije</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3272"/>
-      <source>Saturation</source>
-      <translation>Zasićenje</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2923"/>
+        <source>Saturation</source>
+        <translation>Zasićenje</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3280"/>
-      <source>Mosaic Image:</source>
-      <translation>Mozaik:</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2931"/>
+        <source>Mosaic Image:</source>
+        <translation>Mozaik:</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3283"/>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3293"/>
-      <source>&amp;Browse</source>
-      <translation>&amp;Pregledaj</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2934"/>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2944"/>
+        <source>&amp;Browse</source>
+        <translation>&amp;Pregledaj</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3285"/>
-      <source>Choose which image to mosaic.</source>
-      <translation type="unfinished">Choose which image to mosaic.</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2936"/>
+        <source>Choose which image to mosaic.</source>
+        <translation>Izaberi sliku za stvaranja mozaika.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3287"/>
-      <source>No Image loaded</source>
-      <translation>Slike nisu učitane</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2938"/>
+        <source>No Image loaded</source>
+        <translation>Slike nisu učitane</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3290"/>
-      <source>Image Database:</source>
-      <translation>Baza sa slikama:</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2941"/>
+        <source>Image Database:</source>
+        <translation>Baza sa slikama:</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3295"/>
-      <source>Specify the root folder of the image database.</source>
-      <translation type="unfinished">Specify the root folder of the image database.</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2946"/>
+        <source>Specify the root folder of the image database.</source>
+        <translation>Izaberi izvorni direktorij za bazu slika.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3297"/>
-      <source>Specify an Image Database</source>
-      <translation>Izaberite bazu podataka sa slikama</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2948"/>
+        <source>Specify an Image Database</source>
+        <translation>Izaberite bazu podataka sa slikama</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3300"/>
-      <source>Resolution:</source>
-      <translation>Rezolucija:</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2951"/>
+        <source>Resolution:</source>
+        <translation>Rezolucija:</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3304"/>
-      <source>Pixel Width</source>
-      <translation>Širina piksela</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2955"/>
+        <source>Pixel Width</source>
+        <translation>Širina piksela</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3309"/>
-      <source>Pixel Height</source>
-      <translation>Visina piksela</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2960"/>
+        <source>Pixel Height</source>
+        <translation>Visina piksela</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3316"/>
-      <source>Patches:</source>
-      <translation>Zakrpe:</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2967"/>
+        <source>Patches:</source>
+        <translation>Zakrpe:</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3320"/>
-      <source>Number of Horizontal Patches</source>
-      <translation>Broj horizontalnih zakrpa</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2971"/>
+        <source>Number of Horizontal Patches</source>
+        <translation>Broj horizontalnih zakrpa</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3325"/>
-      <source>Number of Vertical Patches</source>
-      <translation>Broj vertikalnih zakrpa</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2976"/>
+        <source>Number of Vertical Patches</source>
+        <translation>Broj vertikalnih zakrpa</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3330"/>
-      <source>If this label turns red, the computation might be slower.</source>
-      <translation>Ako pocrveni, proračun može biti sporiji.</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2981"/>
+        <source>If this label turns red, the computation might be slower.</source>
+        <translation>Ako pocrveni, proračun može biti sporiji.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3333"/>
-      <source>Filters:</source>
-      <translation>Filteri:</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2984"/>
+        <source>Filters:</source>
+        <translation>Filteri:</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3338"/>
-      <source>You can split multiple ignore words with ;</source>
-      <translation>Možete izabrati više rječi za zanemarivanje pomoću ;</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2989"/>
+        <source>You can split multiple ignore words with ;</source>
+        <translation>Možete izabrati više rječi za zanemarivanje pomoću ;</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3342"/>
-      <source>All Images</source>
-      <translation>Sve slike</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2993"/>
+        <source>All Images</source>
+        <translation>Sve slike</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3391"/>
-      <source>&amp;Save</source>
-      <translation>&amp;Sačuvaj</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3042"/>
+        <source>&amp;Save</source>
+        <translation>&amp;Sačuvaj</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3392"/>
-      <source>&amp;Generate</source>
-      <translation>&amp;Generiši</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3043"/>
+        <source>&amp;Generate</source>
+        <translation>&amp;Generiši</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3393"/>
-      <source>&amp;Cancel</source>
-      <translation>&amp;Otkaži</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3044"/>
+        <source>&amp;Cancel</source>
+        <translation>&amp;Otkaži</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3413"/>
-      <source>Open TIFF</source>
-      <translation>Otvori TIFF</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3064"/>
+        <source>Open TIFF</source>
+        <translation>Otvori TIFF</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3423"/>
-      <source>Open an Image Directory</source>
-      <translation>Otvori fasciklu sa slikama</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3074"/>
+        <source>Open an Image Directory</source>
+        <translation>Otvori fasciklu sa slikama</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3444"/>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3456"/>
-      <source>%1 x %2 cm @150 dpi</source>
-      <translation>%1 × %2 cm @150-dpi</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3095"/>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3107"/>
+        <source>%1 x %2 cm @150 dpi</source>
+        <translation>%1 × %2 cm @150-dpi</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3501"/>
-      <source>Patch Resolution: %1 px</source>
-      <translation>Zakrpi rezoluciju: %1 px</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3152"/>
+        <source>Patch Resolution: %1 px</source>
+        <translation>Zakrpi rezoluciju: %1 px</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3699"/>
-      <source>Filling empty areas...</source>
-      <translation>Popunjava prazna područja...</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3350"/>
+        <source>Filling empty areas...</source>
+        <translation>Popunjava prazna područja...</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3703"/>
-      <source>I need to use some images twice - maybe the database is too small?</source>
-      <translation>Potrebno koristiti neke slike dva puta - da li je baza slika premala?</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3354"/>
+        <source>I need to use some images twice - maybe the database is too small?</source>
+        <translation>Potrebno koristiti neke slike dva puta - da li je baza slika premala?</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3708"/>
-      <source>Sorry, it seems that i cannot create your mosaic with this database.</source>
-      <translation>Izvini, izgleda da ne mogu kreirati Vaš mozaik sa ovom bazom.</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3359"/>
+        <source>Sorry, it seems that i cannot create your mosaic with this database.</source>
+        <translation>Izvini, izgleda da ne mogu kreirati Vaš mozaik sa ovom bazom.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3832"/>
-      <source>Something is seriously wrong, I could not load: %1</source>
-      <translation>Nešto je pošlo po zlu, ne mogu učitati: %1</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3483"/>
+        <source>Something is seriously wrong, I could not load: %1</source>
+        <translation>Nešto je pošlo po zlu, ne mogu učitati: %1</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4079"/>
-      <source>Error</source>
-      <translation>Greška</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3730"/>
+        <source>Error</source>
+        <translation>Greška</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4079"/>
-      <source>Sorry, I could not mix the image...</source>
-      <translation>Izvini, ne mogu spojiti sliku...</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3730"/>
+        <source>Sorry, I could not mix the image...</source>
+        <translation>Izvini, ne mogu spojiti sliku...</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkNoMacs</name>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="248"/>
-      <source>Edit</source>
-      <translation>Uredi</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="328"/>
+        <source>&amp;Sync</source>
+        <translation>&amp;Sinhronizacija</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="361"/>
-      <source>&amp;Sync</source>
-      <translation>&amp;Sinhronizacija</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="287"/>
+        <source>Movie Toolbar</source>
+        <translation>Alatna traka za video</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="295"/>
-      <source>Movie Toolbar</source>
-      <translation>Alatna traka za video</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="239"/>
+        <source>Edit Toolbar</source>
+        <translation>Uredi altanu traku</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="365"/>
-      <source>Pl&amp;ugins</source>
-      <translation>P&amp;riključci</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="332"/>
+        <source>Pl&amp;ugins</source>
+        <translation>P&amp;riključci</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="626"/>
-      <source>Quit nomacs</source>
-      <translation>Napusti nomacs</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="562"/>
+        <source>Quit nomacs</source>
+        <translation>Napusti nomacs</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="627"/>
-      <source>Do you want nomacs to save your tabs?</source>
-      <translation>Da li želite da nomacs sačuva kartice?</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="563"/>
+        <source>Do you want nomacs to save your tabs?</source>
+        <translation>Da li želite da nomacs sačuva kartice?</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="629"/>
-      <source>&amp;Save and Quit</source>
-      <translation>&amp;Sačuvaj i napusti</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="565"/>
+        <source>&amp;Save and Quit</source>
+        <translation>&amp;Sačuvaj i napusti</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="630"/>
-      <source>&amp;Quit</source>
-      <translation>&amp;Napusti</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="566"/>
+        <source>&amp;Quit</source>
+        <translation>&amp;Napusti</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="815"/>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="833"/>
-      <source>Sorry, I cannot Flip the Image...</source>
-      <translation>Izvini, ne mogu prevrnuti sliku...</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="923"/>
+        <source>Recursive Folder Scan is Now Enabled</source>
+        <translation>Rekurzivno skeniranje fascikli je sad uključeno</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="817"/>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="835"/>
-      <source>Flipped</source>
-      <translation type="unfinished">Flipped</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="925"/>
+        <source>Recursive Folder Scan is Now Disabled</source>
+        <translation>Rekurzivno skeniranje fascikli je sad isključeno</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="852"/>
-      <source>Sorry, I cannot Invert the Image...</source>
-      <translation>Izvini, ne mogu obrnuti sliku...</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="934"/>
+        <source>Change Opacity</source>
+        <translation>Promjeni providnost</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="854"/>
-      <source>Inverted</source>
-      <translation type="unfinished">Inverted</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="897"/>
-      <source>Sorry, I cannot convert the Image...</source>
-      <translation>Izvini, ne mogu konvertovati sliku...</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="899"/>
-      <source>Grayscale</source>
-      <translation type="unfinished">Grayscale</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="916"/>
-      <source>The Image is Already Normalized...</source>
-      <translation>Slika je već normalizovana...</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="918"/>
-      <source>Normalized</source>
-      <translation type="unfinished">Normalized</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="935"/>
-      <source>Sorry, I cannot Auto Adjust</source>
-      <translation>Izvini, ne mogu automatski podesiti</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="937"/>
-      <source>Auto Adjust</source>
-      <translation type="unfinished">Auto Adjust</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="949"/>
-      <source>Unsharp Mask</source>
-      <translation type="unfinished">Unsharp Mask</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="969"/>
-      <source>Tiny Planet</source>
-      <translation>Mala planeta</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1136"/>
-      <source>Recursive Folder Scan is Now Enabled</source>
-      <translation>Rekurzivno skeniranje fascikli je sad uključeno</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1138"/>
-      <source>Recursive Folder Scan is Now Disabled</source>
-      <translation>Rekurzivno skeniranje fascikli je sad isključeno</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1147"/>
-      <source>Change Opacity</source>
-      <translation>Promjeni providnost</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1222"/>
-      <source>Window Locked
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1009"/>
+        <source>Window Locked
 To unlock: gain focus (ALT+Tab),
 then press CTRL+SHIFT+ALT+B</source>
-      <translation>Prozor zaključan
+        <translation>Prozor zaključan
 Za otključavanje: pritisnite (Alt+Tab),
 pa onda CTRL+SHIFT+ALT+B</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1225"/>
-      <source>You should first reduce opacity
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1012"/>
+        <source>You should first reduce opacity
  before working through the window.</source>
-      <translation>Prvo treba da smanjite providnost
+        <translation>Prvo treba da smanjite providnost
  prije rada kroz prozor.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1316"/>
-      <source>File Explorer</source>
-      <translation>Pregledač fajlova</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1102"/>
+        <source>File Explorer</source>
+        <translation>Pregledač fajlova</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1344"/>
-      <source>Meta Data Info</source>
-      <translation>Meta podaci</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1130"/>
+        <source>Meta Data Info</source>
+        <translation>Meta podaci</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1362"/>
-      <source>History</source>
-      <translation type="unfinished">History</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1148"/>
+        <source>Edit Image</source>
+        <translation>Uredi sliku</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1400"/>
-      <source>Thumbnails</source>
-      <translation>Sličice</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1166"/>
+        <source>History</source>
+        <translation>Povijest</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1437"/>
-      <source>Open an Image Directory</source>
-      <translation>Otvori fasciklu sa slikama</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1204"/>
+        <source>Thumbnails</source>
+        <translation>Sličice</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1455"/>
-      <source>All Files (*.*)</source>
-      <translation>Svi fajlovi (*.*)</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1241"/>
+        <source>Open an Image Directory</source>
+        <translation>Otvori fasciklu sa slikama</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1458"/>
-      <source>Open Image</source>
-      <translation>Otvori sliku</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1259"/>
+        <source>All Files (*.*)</source>
+        <translation>Svi fajlovi (*.*)</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1522"/>
-      <source>Sorry, the directory: %1  does not exist
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1262"/>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1310"/>
+        <source>Open Image</source>
+        <translation>Otvori sliku</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1293"/>
+        <source>The following duplicates were not added:</source>
+        <translation>Sljedeći duplikati nisu dodani:</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1306"/>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1341"/>
+        <source>Text file (*.txt)</source>
+        <translation>Tekstualni fajl (*.txt)</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1307"/>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1342"/>
+        <source>All files (*.*)</source>
+        <translation>Svi fajlovi (*.*)</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1344"/>
+        <source>Save Tab List</source>
+        <translation>Snimi listu kartica</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1415"/>
+        <source>Sorry, the directory: %1  does not exist
 </source>
-      <translation>Izvini, fascikla: %1  ne postoji</translation>
+        <translation>Izvini, fascikla: %1  ne postoji
+</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1535"/>
-      <source>Rename:</source>
-      <translation>Preimenuj:</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1428"/>
+        <source>Rename:</source>
+        <translation>Preimenuj:</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1550"/>
-      <source>Question</source>
-      <translation>Pitanje</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1443"/>
+        <source>Question</source>
+        <translation>Pitanje</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1565"/>
-      <source>Sorry, I can't delete: %1</source>
-      <translation>Izvini, ne mogu izbrisati: %1</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1458"/>
+        <source>Sorry, I can&apos;t delete: %1</source>
+        <translation>Izvini, ne mogu izbrisati: %1</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1580"/>
-      <source>Sorry, I can't rename: %1</source>
-      <translation>Izvini, ne mogu preimenovati: %1</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1473"/>
+        <source>Sorry, I can&apos;t rename: %1</source>
+        <translation>Izvini, ne mogu preimenovati: %1</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1660"/>
-      <source>Go To Image</source>
-      <translation>Idi na sliku</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1553"/>
+        <source>Go To Image</source>
+        <translation>Idi na sliku</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1660"/>
-      <source>Image Index:</source>
-      <translation>Indeks slike:</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1553"/>
+        <source>Image Index:</source>
+        <translation>Indeks slike:</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1765"/>
-      <source>Resize</source>
-      <translation type="unfinished">Resize</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1636"/>
+        <source>Resize</source>
+        <translation>Promijeni veličinu</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1789"/>
-      <source>Shall I move %1 to trash?</source>
-      <translation type="unfinished">Shall I move %1 to trash?</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1660"/>
+        <source>Shall I move %1 to trash?</source>
+        <translation>Da li da prebacim %1 u otpad?</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1791"/>
-      <source>Do you want to permanently delete %1?</source>
-      <translation type="unfinished">Do you want to permanently delete %1?</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1662"/>
+        <source>Do you want to permanently delete %1?</source>
+        <translation>Da li želite trajno da izbrišete %1?</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1796"/>
-      <source>Delete File</source>
-      <translation type="unfinished">Delete File</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1667"/>
+        <source>Delete File</source>
+        <translation>Izbriši fajl</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1836"/>
-      <source>Mosaic</source>
-      <translation type="unfinished">Mosaic</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1707"/>
+        <source>Mosaic</source>
+        <translation>Mozaik</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1866"/>
-      <source>Adjusted</source>
-      <translation type="unfinished">Adjusted</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1727"/>
+        <source>Sorry, I could not create a wallpaper...</source>
+        <translation>Izvini, ne mogu napraviti pozadinu...</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1886"/>
-      <source>Sorry, I could not create a wallpaper...</source>
-      <translation>Izvini, ne mogu napraviti pozadinu...</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1771"/>
+        <source>Save Thumbnails</source>
+        <translation>Sačuvaj sličice</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1930"/>
-      <source>Save Thumbnails</source>
-      <translation>Sačuvaj sličice</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="2117"/>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="2133"/>
+        <source> [Private Mode]</source>
+        <translation> [Privatni režim]</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="2315"/>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="2331"/>
-      <source> [Private Mode]</source>
-      <translation>[Privatni režim]</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="2219"/>
+        <source>Already downloading update</source>
+        <translation>Već preuzimam ažuriranje</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="2413"/>
-      <source>Already downloading update</source>
-      <translation>Već preuzimam ažuriranje</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="2246"/>
+        <source>Downloading update...</source>
+        <translation>Preuzimam ažuriranje...</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="2440"/>
-      <source>Downloading update...</source>
-      <translation>Preuzimam ažuriranje...</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="2246"/>
+        <source>Cancel Update</source>
+        <translation>Otkaži ažuriranje</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="2440"/>
-      <source>Cancel Update</source>
-      <translation>Otkaži ažuriranje</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="2280"/>
+        <source>Unable to install new version&lt;br&gt;</source>
+        <translation>Nemoguće instalirati novu verziju&lt;br&gt;</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="2474"/>
-      <source>Unable to install new version&lt;br&gt;</source>
-      <translation>Nemoguće instalirati novu verziju&lt;br&gt;</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="2281"/>
+        <source>You can download the new version from our web page</source>
+        <translation>Možete preuzeti novu verziju sa naše internet stranice</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="2475"/>
-      <source>You can download the new version from our web page</source>
-      <translation>Možete preuzeti novu verziju sa naše internet stranice</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1727"/>
+        <source>Error</source>
+        <translation>Greška</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1886"/>
-      <source>Error</source>
-      <translation>Greška</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1419"/>
+        <source>Sorry, I can&apos;t write to the fileInfo: %1</source>
+        <translation>Izvini, ne mogu pisati u fajl: %1</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1526"/>
-      <source>Sorry, I can't write to the fileInfo: %1</source>
-      <translation>Izvini, ne mogu pisati u fajl: %1</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1551"/>
-      <source>The fileInfo: %1  already exists.
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1444"/>
+        <source>The fileInfo: %1  already exists.
  Do you want to replace it?</source>
-      <translation>Fajl: %1 već postoji.
+        <translation>Fajl: %1 već postoji.
  Da li želite da ga zamjenite?</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="2489"/>
-      <source>Downloading new translations...</source>
-      <translation>Preuzimam nove prevode...</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="2295"/>
+        <source>Downloading new translations...</source>
+        <translation>Preuzimam nove prevode...</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="2489"/>
-      <source>Cancel</source>
-      <translation>Otkaži</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="2295"/>
+        <source>Cancel</source>
+        <translation>Otkaži</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkNoMacsSync</name>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="2861"/>
-      <source>Sorry, I could not find any clients.</source>
-      <translation>Izvini, ne mogu pronaći klijente.</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="2546"/>
+        <source>Sorry, I could not find any clients.</source>
+        <translation>Izvini, ne mogu pronaći klijente.</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkOpacityDialog</name>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2502"/>
-      <source>Window Opacity</source>
-      <translation>Providnost prozora</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2531"/>
+        <source>Window Opacity</source>
+        <translation>Providnost prozora</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2507"/>
-      <source>&amp;OK</source>
-      <translation>&amp;U redu</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2536"/>
+        <source>&amp;OK</source>
+        <translation>&amp;U redu</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2508"/>
-      <source>&amp;Cancel</source>
-      <translation>&amp;Otkaži</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2537"/>
+        <source>&amp;Cancel</source>
+        <translation>&amp;Otkaži</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkPlayer</name>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="1256"/>
-      <source>Show previous image</source>
-      <translation type="unfinished">Show previous image</translation>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="1263"/>
+        <source>Show previous image</source>
+        <translation>Prikaži prethodnu sliku</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="1268"/>
-      <source>Play/Pause</source>
-      <translation type="unfinished">Play/Pause</translation>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="1275"/>
+        <source>Play/Pause</source>
+        <translation>Reprodukuj/Pauziraj</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="1280"/>
-      <source>Show next image</source>
-      <translation type="unfinished">Show next image</translation>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="1287"/>
+        <source>Show next image</source>
+        <translation>Prikaži sljedeću sliku</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="1323"/>
-      <source>play</source>
-      <translation>pusti</translation>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="1330"/>
+        <source>play</source>
+        <translation>pusti</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkPluginContainer</name>
     <message>
-      <location filename="../src/DkLoader/DkPluginManager.cpp" line="395"/>
-      <source>Author:</source>
-      <translation type="unfinished">Author:</translation>
+        <location filename="../src/DkCore/DkPluginManager.cpp" line="435"/>
+        <source>Author:</source>
+        <translation>Autor:</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkPluginManager.cpp" line="396"/>
-      <source>Company:</source>
-      <translation type="unfinished">Company:</translation>
+        <location filename="../src/DkCore/DkPluginManager.cpp" line="436"/>
+        <source>Company:</source>
+        <translation>Kompanija:</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkPluginManager.cpp" line="397"/>
-      <source>Created:</source>
-      <translation type="unfinished">Created:</translation>
+        <location filename="../src/DkCore/DkPluginManager.cpp" line="437"/>
+        <source>Created:</source>
+        <translation>Kreirano:</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkPluginManager.cpp" line="398"/>
-      <source>Last Modified:</source>
-      <translation type="unfinished">Last Modified:</translation>
+        <location filename="../src/DkCore/DkPluginManager.cpp" line="438"/>
+        <source>Last Modified:</source>
+        <translation>Posljednja izmjena:</translation>
     </message>
-    <message>
-      <location filename="../src/DkLoader/DkPluginManager.cpp" line="399"/>
-      <source>Dependencies:</source>
-      <translation type="unfinished">Dependencies:</translation>
-    </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkPluginManagerDialog</name>
     <message>
-      <location filename="../src/DkLoader/DkPluginManager.cpp" line="507"/>
-      <source>Plugin Manager</source>
-      <translation type="unfinished">Plugin Manager</translation>
+        <location filename="../src/DkCore/DkPluginManager.cpp" line="547"/>
+        <source>Plugin Manager</source>
+        <translation>Upravljač priključaka</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkPluginManager.cpp" line="519"/>
-      <source>&amp;Close</source>
-      <translation>&amp;Zatvori</translation>
+        <location filename="../src/DkCore/DkPluginManager.cpp" line="559"/>
+        <source>&amp;Close</source>
+        <translation>&amp;Zatvori</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkPluginTableWidget</name>
     <message>
-      <location filename="../src/DkLoader/DkPluginManager.cpp" line="581"/>
-      <source>Search plugins</source>
-      <translation type="unfinished">Search plugins</translation>
+        <location filename="../src/DkCore/DkPluginManager.cpp" line="618"/>
+        <source>Search plugins</source>
+        <translation>Pretraži priključke</translation>
     </message>
-    <message>
-      <location filename="../src/DkLoader/DkPluginManager.cpp" line="584"/>
-      <source>Add or Remove Plugins</source>
-      <translation type="unfinished">Add or Remove Plugins</translation>
-    </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkPongPort</name>
     <message>
-      <location filename="../src/DkGui/DkPong.cpp" line="336"/>
-      <source>PAUSED</source>
-      <translation>PAUZA</translation>
+        <location filename="../src/DkGui/DkPong.cpp" line="336"/>
+        <source>PAUSED</source>
+        <translation>PAUZA</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPong.cpp" line="337"/>
-      <source>Press &lt;SPACE&gt; to start.</source>
-      <translation type="unfinished">Press &lt;SPACE&gt; to start.</translation>
+        <location filename="../src/DkGui/DkPong.cpp" line="337"/>
+        <source>Press &lt;SPACE&gt; to start.</source>
+        <translation>Pritisni &lt;SPACE&gt; za početak.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPong.cpp" line="485"/>
-      <source>%1 won!</source>
-      <translation type="unfinished">%1 won!</translation>
+        <location filename="../src/DkGui/DkPong.cpp" line="485"/>
+        <source>%1 won!</source>
+        <translation>%1 je pobijedio!</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPong.cpp" line="486"/>
-      <source>Hit &lt;SPACE&gt; to start a new Game</source>
-      <translation type="unfinished">Hit &lt;SPACE&gt; to start a new Game</translation>
+        <location filename="../src/DkGui/DkPong.cpp" line="486"/>
+        <source>Hit &lt;SPACE&gt; to start a new Game</source>
+        <translation>Pritisni &lt;SPACE&gt; za novu igru</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkPreferenceWidget</name>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="65"/>
-      <source>next</source>
-      <translation type="unfinished">next</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="70"/>
+        <source>next</source>
+        <translation>sljedeće</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="70"/>
-      <source>previous</source>
-      <translation type="unfinished">previous</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="75"/>
+        <source>previous</source>
+        <translation>prethodno</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="89"/>
-      <source>Restart nomacs</source>
-      <translation type="unfinished">Restart nomacs</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="95"/>
+        <source>Restart nomacs</source>
+        <translation>Ponovo pokreni nomacs</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkPrintPreviewDialog</name>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2186"/>
-      <source>Fit Width</source>
-      <translation type="unfinished">Fit Width</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2215"/>
+        <source>Fit Width</source>
+        <translation>Prilagodi širinu</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2187"/>
-      <source>Fit Page</source>
-      <translation type="unfinished">Fit Page</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2216"/>
+        <source>Fit Page</source>
+        <translation>Prilagodi stranici</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2197"/>
-      <source>Zoom in</source>
-      <translation>Uvećaj</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2226"/>
+        <source>Zoom in</source>
+        <translation>Uvećaj</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2199"/>
-      <source>Zoom out</source>
-      <translation>Smanji</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2228"/>
+        <source>Zoom out</source>
+        <translation>Smanji</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2204"/>
-      <source>Portrait</source>
-      <translation>Portret</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2233"/>
+        <source>Portrait</source>
+        <translation>Portret</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2205"/>
-      <source>Landscape</source>
-      <translation>Pejzaž</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2234"/>
+        <source>Landscape</source>
+        <translation>Pejzaž</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2216"/>
-      <source>Print</source>
-      <translation>Štampaj</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2245"/>
+        <source>Print</source>
+        <translation>Štampaj</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2217"/>
-      <source>Page setup</source>
-      <translation>Podešavanje stranice</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2246"/>
+        <source>Page setup</source>
+        <translation>Podešavanje stranice</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2222"/>
-      <source>Reset dpi</source>
-      <translation>Resetuj dpi</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2251"/>
+        <source>Reset dpi</source>
+        <translation>Resetuj dpi</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2243"/>
-      <source>keep ALT key pressed to zoom with the mouse wheel</source>
-      <translation>držite ALT dugme pritisnuto za uvećavanje pomoću miša</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2272"/>
+        <source>keep ALT key pressed to zoom with the mouse wheel</source>
+        <translation>držite ALT dugme pritisnuto za uvećavanje pomoću miša</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2084"/>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2265"/>
-      <source>Print Preview</source>
-      <translation>Pregled prije štampanja</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2118"/>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2294"/>
+        <source>Print Preview</source>
+        <translation>Pregled prije štampanja</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
+    <name>nmc::DkProfileSummaryWidget</name>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1140"/>
+        <source>Summary: </source>
+        <translation>Sažetak: </translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1141"/>
+        <source>Files</source>
+        <translation>Fajlovi</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1170"/>
+        <source>Input</source>
+        <translation>Ulaz</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1174"/>
+        <source>Output</source>
+        <translation>Izlaz</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1178"/>
+        <source>Functions</source>
+        <translation>Funkcije</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1197"/>
+        <source>Update</source>
+        <translation>Ažuriraj</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1202"/>
+        <source>Delete</source>
+        <translation>Izbriši</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1207"/>
+        <source>Export</source>
+        <translation>Izvezi</translation>
+    </message>
+</context>
+<context>
+    <name>nmc::DkProfileWidget</name>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1238"/>
+        <source>Create New Profile</source>
+        <translation>Napravi novi profil</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1241"/>
+        <source>Apply Default</source>
+        <translation>Prihvati zadano</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1280"/>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1336"/>
+        <source>inactive</source>
+        <translation>neaktivno</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1305"/>
+        <source>Default</source>
+        <translation>Zadano</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1372"/>
+        <source>Deleting Profile</source>
+        <translation>Brišem profil</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1373"/>
+        <source>Sorry, I cannot delete %1</source>
+        <translation>Žao nam je, nemoguće izbrisati %1</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1390"/>
+        <source>Export Batch Profile</source>
+        <translation>Izvezi grupni profil</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1392"/>
+        <source>nomacs Batch Profile (*.%1)</source>
+        <translation>nomacs grupni profil (*.%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1404"/>
+        <source>Profile Name</source>
+        <translation>Ime profila</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1405"/>
+        <source>Profile Name:</source>
+        <translation>Ime profila:</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1416"/>
+        <source>Profile Already Exists</source>
+        <translation>Profil već postoji</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1417"/>
+        <source>Do you want to overwrite %1?</source>
+        <translation>Da li želite da snimite preko %1?</translation>
+    </message>
+</context>
+<context>
     <name>nmc::DkQuickAccessEdit</name>
     <message>
-      <location filename="../src/DkGui/DkQuickAccess.cpp" line="139"/>
-      <source>Quick Launch (%1)</source>
-      <translation type="unfinished">Quick Launch (%1)</translation>
+        <location filename="../src/DkGui/DkQuickAccess.cpp" line="141"/>
+        <source>Quick Launch (%1)</source>
+        <translation>Brzo pokreni (%1)</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkRatingLabel</name>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="1018"/>
-      <source>one star</source>
-      <translation>jedna zvijezda</translation>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="1023"/>
+        <source>one star</source>
+        <translation>jedna zvijezda</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="1022"/>
-      <source>two stars</source>
-      <translation>svije zvijezde</translation>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="1027"/>
+        <source>two stars</source>
+        <translation>svije zvijezde</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="1026"/>
-      <source>three star</source>
-      <translation>tri zvijezde</translation>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="1031"/>
+        <source>three star</source>
+        <translation>tri zvijezde</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="1030"/>
-      <source>four star</source>
-      <translation>četiri zvijezde</translation>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="1035"/>
+        <source>four star</source>
+        <translation>četiri zvijezde</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="1034"/>
-      <source>five star</source>
-      <translation>pet zvijezda</translation>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="1039"/>
+        <source>five star</source>
+        <translation>pet zvijezda</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkRatingLabelBg</name>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="1055"/>
-      <source>no rating</source>
-      <translation>bez ocjene</translation>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="1060"/>
+        <source>no rating</source>
+        <translation>bez ocjene</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="1059"/>
-      <source>one star</source>
-      <translation>jedna zvijezda</translation>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="1064"/>
+        <source>one star</source>
+        <translation>jedna zvijezda</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="1063"/>
-      <source>two stars</source>
-      <translation>svije zvijezde</translation>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="1068"/>
+        <source>two stars</source>
+        <translation>svije zvijezde</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="1067"/>
-      <source>three stars</source>
-      <translation>tri zvijezde</translation>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="1072"/>
+        <source>three stars</source>
+        <translation>tri zvijezde</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="1071"/>
-      <source>four stars</source>
-      <translation>četiri zvijezde</translation>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="1076"/>
+        <source>four stars</source>
+        <translation>četiri zvijezde</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="1075"/>
-      <source>five stars</source>
-      <translation>pet zvijezda</translation>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="1080"/>
+        <source>five stars</source>
+        <translation>pet zvijezda</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkResizeDialog</name>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="850"/>
-      <source>Resize Image</source>
-      <translation>Promjeni veličinu slike</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="884"/>
+        <source>Resize Image</source>
+        <translation>Promjeni veličinu slike</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="869"/>
-      <source>Original</source>
-      <translation>Originalna</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="903"/>
+        <source>Original</source>
+        <translation>Originalna</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="871"/>
-      <source>New</source>
-      <translation>Nova</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="905"/>
+        <source>New</source>
+        <translation>Nova</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="900"/>
-      <location filename="../src/DkGui/DkDialog.cpp" line="937"/>
-      <source>Width: </source>
-      <translation>Širina: </translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="934"/>
+        <location filename="../src/DkGui/DkDialog.cpp" line="971"/>
+        <source>Width: </source>
+        <translation>Širina: </translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="913"/>
-      <location filename="../src/DkGui/DkDialog.cpp" line="952"/>
-      <source>Height: </source>
-      <translation>Visina: </translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="947"/>
+        <location filename="../src/DkGui/DkDialog.cpp" line="986"/>
+        <source>Height: </source>
+        <translation>Visina: </translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="978"/>
-      <source>Resolution: </source>
-      <translation>Rezolucija: </translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="1012"/>
+        <source>Resolution: </source>
+        <translation>Rezolucija: </translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="987"/>
-      <source>pixel/inch</source>
-      <translation>piksel/inč</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="1021"/>
+        <source>pixel/inch</source>
+        <translation>piksel/inč</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="988"/>
-      <source>pixel/cm</source>
-      <translation>piksel/cm</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="1022"/>
+        <source>pixel/cm</source>
+        <translation>piksel/cm</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="999"/>
-      <source>Resample Image:</source>
-      <translation>Izmjeni uzorak:</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="1033"/>
+        <source>Resample Image:</source>
+        <translation>Izmjeni uzorak:</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1006"/>
-      <source>Nearest Neighbor</source>
-      <translation>Najbliži susjed</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="1040"/>
+        <source>Nearest Neighbor</source>
+        <translation>Najbliži susjed</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1007"/>
-      <source>Area (best for downscaling)</source>
-      <translation>Oblast (najbolje za smanjivanje)</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="1041"/>
+        <source>Area (best for downscaling)</source>
+        <translation>Oblast (najbolje za smanjivanje)</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1008"/>
-      <source>Linear</source>
-      <translation>Linearno</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="1042"/>
+        <source>Linear</source>
+        <translation>Linearno</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1009"/>
-      <source>Bicubic (4x4 pixel interpolation)</source>
-      <translation>Bikubično (4×4 pikselna interpolacija)</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="1043"/>
+        <source>Bicubic (4x4 pixel interpolation)</source>
+        <translation>Bikubično (4×4 pikselna interpolacija)</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1010"/>
-      <source>Lanczos (8x8 pixel interpolation)</source>
-      <translation>Lanczos (8×8 pikselna interpolacija)</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="1044"/>
+        <source>Lanczos (8x8 pixel interpolation)</source>
+        <translation>Lanczos (8×8 pikselna interpolacija)</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1019"/>
-      <source>Gamma Correction</source>
-      <translation>Korekcija game</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="1053"/>
+        <source>Gamma Correction</source>
+        <translation>Korekcija game</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1030"/>
-      <source>&amp;OK</source>
-      <translation>&amp;U redu</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="1064"/>
+        <source>&amp;OK</source>
+        <translation>&amp;U redu</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1031"/>
-      <source>&amp;Cancel</source>
-      <translation>&amp;Otkaži</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="1065"/>
+        <source>&amp;Cancel</source>
+        <translation>&amp;Otkaži</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1418"/>
-      <source>Sorry, but the image size %1 x %2 is illegal.</source>
-      <translation>Izvini, ali veličina slike %1 × %2 je nedozvoljena.</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="1452"/>
+        <source>Sorry, but the image size %1 x %2 is illegal.</source>
+        <translation>Izvini, ali veličina slike %1 × %2 je nedozvoljena.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1430"/>
-      <source>Sorry, the image is too large: %1</source>
-      <translation>Izvini, slika je prevelika: %1</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="1464"/>
+        <source>Sorry, the image is too large: %1</source>
+        <translation>Izvini, slika je prevelika: %1</translation>
     </message>
-  </context>
-  <context>
-    <name>nmc::DkSaturation</name>
+</context>
+<context>
+    <name>nmc::DkRotateWidget</name>
     <message>
-      <location filename="../src/DkGui/DkManipulationWidgets.cpp" line="1063"/>
-      <source>Saturation</source>
-      <translation>Zasićenje</translation>
+        <location filename="../src/DkGui/DkManipulatorWidgets.cpp" line="338"/>
+        <source>Angle</source>
+        <translation>Ugao</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkSearchDialog</name>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="592"/>
-      <source>Find &amp; Filter</source>
-      <translation>Pronađi i filtriraj</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="622"/>
+        <source>Find &amp; Filter</source>
+        <translation>Pronađi i filtriraj</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="594"/>
-      <source>Load All</source>
-      <translation>Učitaj sve</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="624"/>
+        <source>Load All</source>
+        <translation>Učitaj sve</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="602"/>
-      <source>Type a search word or a regular expression</source>
-      <translation>Unesite rječ ili regularni izraz</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="648"/>
+        <source>F&amp;ind</source>
+        <translation>Pr&amp;onađi</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="618"/>
-      <source>F&amp;ind</source>
-      <translation>Pr&amp;onađi</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="643"/>
+        <source>&amp;Filter</source>
+        <translation>&amp;Filter</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="613"/>
-      <source>&amp;Filter</source>
-      <translation type="unfinished">&amp;Filter</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="632"/>
+        <source>Type search words or a regular expression</source>
+        <translation>Unesite pojam za pretragu ili regular expression</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="660"/>
-      <source>No Matching Items</source>
-      <translation>Nema stavki koje se poklapaju</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="690"/>
+        <source>No Matching Items</source>
+        <translation>Nema stavki koje se poklapaju</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
+    <name>nmc::DkSettingsModel</name>
+    <message>
+        <location filename="../src/DkGui/DkSettingsWidget.cpp" line="299"/>
+        <source>Settings</source>
+        <translation>Postavke</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkSettingsWidget.cpp" line="299"/>
+        <source>Value</source>
+        <translation>Vrijednost</translation>
+    </message>
+</context>
+<context>
+    <name>nmc::DkSettingsWidget</name>
+    <message>
+        <location filename="../src/DkGui/DkSettingsWidget.cpp" line="131"/>
+        <source>Filter Settings</source>
+        <translation>Postavke filtera</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkSettingsWidget.cpp" line="157"/>
+        <source>Delete</source>
+        <translation>Izbriši</translation>
+    </message>
+</context>
+<context>
     <name>nmc::DkShortcutsDialog</name>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1874"/>
-      <source>Keyboard Shortcuts</source>
-      <translation>Prečice tastature</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="1908"/>
+        <source>Keyboard Shortcuts</source>
+        <translation>Prečice tastature</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1910"/>
-      <source>Set to &amp;Default</source>
-      <translation>&amp;Podesi kao standardne</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="1944"/>
+        <source>Set to &amp;Default</source>
+        <translation>&amp;Podesi kao standardne</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1911"/>
-      <source>Removes All Custom Shortcuts</source>
-      <translation>Uklanja sve prilagođene prečice</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="1945"/>
+        <source>Removes All Custom Shortcuts</source>
+        <translation>Uklanja sve prilagođene prečice</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1924"/>
-      <source>&amp;OK</source>
-      <translation>&amp;U redu</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="1958"/>
+        <source>&amp;OK</source>
+        <translation>&amp;U redu</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1925"/>
-      <source>&amp;Cancel</source>
-      <translation>&amp;Otkaži</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="1959"/>
+        <source>&amp;Cancel</source>
+        <translation>&amp;Otkaži</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkShortcutsModel</name>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1579"/>
-      <source>Name</source>
-      <translation>Ime</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="1613"/>
+        <source>Name</source>
+        <translation>Ime</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1579"/>
-      <source>Shortcut</source>
-      <translation>Prečica</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="1613"/>
+        <source>Shortcut</source>
+        <translation>Prečica</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1785"/>
-      <source>%1 already used by %2 &gt; %3
+        <location filename="../src/DkGui/DkDialog.cpp" line="1819"/>
+        <source>%1 already used by %2 &gt; %3
 Press ESC to undo changes</source>
-      <translation>%1 već koristi %2 &gt; %3
+        <translation>%1 već koristi %2 &gt; %3
 Pritisni ESC za opoziv promijena</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1791"/>
-      <source>%1 already used by %2
+        <location filename="../src/DkGui/DkDialog.cpp" line="1825"/>
+        <source>%1 already used by %2
 Press ESC to undo changes</source>
-      <translation>%1 već koristi %2
+        <translation>%1 već koristi %2
 Pritisni ESC za opoziv promijena</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkSplashScreen</name>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="126"/>
-      <source>CLOSE</source>
-      <translation>ZATVORI</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="126"/>
+        <source>CLOSE</source>
+        <translation>ZATVORI</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="130"/>
-      <source>Close (ESC)</source>
-      <translation>Zatvori (ESC)</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="130"/>
+        <source>Close (ESC)</source>
+        <translation>Zatvori (ESC)</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="184"/>
-      <source>Portable</source>
-      <translation>Prenosivo</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="255"/>
+        <source>Portable</source>
+        <translation>Prenosivo</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkStatusBar</name>
     <message>
-      <location filename="../src/DkLoader/DkStatusBar.cpp" line="56"/>
-      <source>CTRL activates the crosshair cursor</source>
-      <translation type="unfinished">CTRL activates the crosshair cursor</translation>
+        <location filename="../src/DkCore/DkStatusBar.cpp" line="56"/>
+        <source>CTRL activates the crosshair cursor</source>
+        <translation>CTRL aktivira krstić kursor</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkTcpMenu</name>
     <message>
-      <location filename="../src/DkGui/DkMenu.cpp" line="227"/>
-      <source>no clients found</source>
-      <translation>klijenti nisu pronađeni</translation>
+        <location filename="../src/DkGui/DkMenu.cpp" line="227"/>
+        <source>no clients found</source>
+        <translation>klijenti nisu pronađeni</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkTextDialog</name>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1971"/>
-      <source>Text Editor</source>
-      <translation>Tekstualni editor</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2005"/>
+        <source>Text Editor</source>
+        <translation>Tekstualni editor</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1981"/>
-      <source>&amp;Save</source>
-      <translation>&amp;Sačuvaj</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2015"/>
+        <source>&amp;Save</source>
+        <translation>&amp;Sačuvaj</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1982"/>
-      <source>&amp;Close</source>
-      <translation>&amp;Zatvori</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2016"/>
+        <source>&amp;Close</source>
+        <translation>&amp;Zatvori</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2006"/>
-      <source>Text File (*.txt)</source>
-      <translation>Tekstualni fajl (*.txt)</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2040"/>
+        <source>Text File (*.txt)</source>
+        <translation>Tekstualni fajl (*.txt)</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2006"/>
-      <source>All Files (*.*)</source>
-      <translation>Svi fajlovi (*.*)</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2040"/>
+        <source>All Files (*.*)</source>
+        <translation>Svi fajlovi (*.*)</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2009"/>
-      <source>Save Text File</source>
-      <translation>Sačuvaj tekstualni fajl</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2043"/>
+        <source>Save Text File</source>
+        <translation>Sačuvaj tekstualni fajl</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2022"/>
-      <source>Error</source>
-      <translation>Greška</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2056"/>
+        <source>Error</source>
+        <translation>Greška</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2022"/>
-      <source>Could not save: %1
+        <location filename="../src/DkGui/DkDialog.cpp" line="2056"/>
+        <source>Could not save: %1
 %2</source>
-      <translation>Ne mogu sačuvati: %1
+        <translation>Ne mogu sačuvati: %1
 %2</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
+    <name>nmc::DkThresholdWidget</name>
+    <message>
+        <location filename="../src/DkGui/DkManipulatorWidgets.cpp" line="369"/>
+        <source>Threshold</source>
+        <translation>Prag</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkManipulatorWidgets.cpp" line="376"/>
+        <source>Color</source>
+        <translation>Boja</translation>
+    </message>
+</context>
+<context>
     <name>nmc::DkThumbLabel</name>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="900"/>
-      <source>Name: </source>
-      <translation>Ime: </translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="907"/>
+        <source>Name: </source>
+        <translation>Ime: </translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="901"/>
-      <source>Size: </source>
-      <translation>Veličina: </translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="908"/>
+        <source>Size: </source>
+        <translation>Veličina: </translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="902"/>
-      <source>Created: </source>
-      <translation>Kreirano:</translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="909"/>
+        <source>Created: </source>
+        <translation>Kreirano: </translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkThumbScene</name>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1252"/>
-      <source>%1 Images</source>
-      <translation>%1 slika</translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1260"/>
+        <source>%1 selected</source>
+        <translation>%1 izabran</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1394"/>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1443"/>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1482"/>
-      <source>Error</source>
-      <translation>Greška</translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1262"/>
+        <source>%1 images</source>
+        <translation>%1 slika</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1394"/>
-      <source>Sorry, I cannot copy %1 to %2</source>
-      <translation>Izvini, ne mogu kopirati %1 u %2</translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1409"/>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1460"/>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1506"/>
+        <source>Error</source>
+        <translation>Greška</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1415"/>
-      <source>Shall I move %1 file(s) to trash?</source>
-      <translation type="unfinished">Shall I move %1 file(s) to trash?</translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1409"/>
+        <source>Sorry, I cannot copy %1 to %2</source>
+        <translation>Izvini, ne mogu kopirati %1 u %2</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1417"/>
-      <source>Are you sure you want to permanently delete %1 file(s)?</source>
-      <translation>Da li ste sigurni da želite trajno obrisati %1 fajl(a)?</translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1430"/>
+        <source>Shall I move %1 file(s) to trash?</source>
+        <translation>Da li da pomjerim %1 fajl(ova) u otpad?</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1422"/>
-      <source>Delete File</source>
-      <translation type="unfinished">Delete File</translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1432"/>
+        <source>Are you sure you want to permanently delete %1 file(s)?</source>
+        <translation>Da li ste sigurni da želite trajno obrisati %1 fajl(a)?</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1443"/>
-      <source>Sorry, I cannot delete:
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1437"/>
+        <source>Delete File</source>
+        <translation>Izbriši fajl</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1461"/>
+        <source>Sorry, I cannot delete:
 %1</source>
-      <translation>Izvini, ne mogu izbrisati:
+        <translation>Izvini, ne mogu izbrisati:
 %1</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1467"/>
-      <source>Rename File(s)</source>
-      <translation>Preimenuj fajl(ove)</translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1488"/>
+        <source>Rename File(s)</source>
+        <translation>Preimenuj fajl(ove)</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1468"/>
-      <source>New Filename:</source>
-      <translation>Novo ime fajla:</translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1489"/>
+        <source>New Filename:</source>
+        <translation>Novo ime fajla:</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1482"/>
-      <source>Sorry, I cannot rename: %1 to %2</source>
-      <translation>Izvini, ne mogu preimenovati: %1 u %2</translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1507"/>
+        <source>Sorry, I cannot rename: %1 to %2</source>
+        <translation>Izvini, ne mogu preimenovati: %1 u %2</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkThumbScrollWidget</name>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1870"/>
-      <source>&amp;Sort</source>
-      <translation>&amp;Sortiraj</translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1895"/>
+        <source>&amp;Sort</source>
+        <translation>&amp;Sortiraj</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1847"/>
-      <source>Thumb Preview Toolbar</source>
-      <translation>Traka za pregled sličica</translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1872"/>
+        <source>Thumb Preview Toolbar</source>
+        <translation>Traka za pregled sličica</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1890"/>
-      <source>Filter Files (Ctrl + F)</source>
-      <translation>Filtriraj fajlove (Ctrl + F)</translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1915"/>
+        <source>Filter Files (Ctrl + F)</source>
+        <translation>Filtriraj fajlove (Ctrl + F)</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1903"/>
-      <source>Thumb</source>
-      <translation>Sličica</translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1928"/>
+        <source>Thumb</source>
+        <translation>Sličica</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkThumbsSaver</name>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="295"/>
-      <source>Cancel</source>
-      <translation>Otkaži</translation>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="295"/>
+        <source>Cancel</source>
+        <translation>Otkaži</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="295"/>
-      <source>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="294"/>
+        <source>
 Creating thumbnails...
 </source>
-      <translation>
-Kreiram sličice...</translation>
+        <translation>
+Kreiram sličice...
+</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="296"/>
-      <source>Thumbnails</source>
-      <translation>Sličice</translation>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="299"/>
+        <source>Thumbnails</source>
+        <translation>Sličice</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkTifDialog</name>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="65"/>
-      <source>TIF compression</source>
-      <translation>TIF kompresija</translation>
+        <location filename="../src/DkCore/DkSaveDialog.cpp" line="65"/>
+        <source>TIF compression</source>
+        <translation>TIF kompresija</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="68"/>
-      <source>&amp;no compression</source>
-      <translation>&amp;bez kompresije</translation>
+        <location filename="../src/DkCore/DkSaveDialog.cpp" line="68"/>
+        <source>&amp;no compression</source>
+        <translation>&amp;bez kompresije</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="69"/>
-      <source>&amp;LZW compression (lossless)</source>
-      <translation>&amp;LZW kompresija (bez gubitka)</translation>
+        <location filename="../src/DkCore/DkSaveDialog.cpp" line="69"/>
+        <source>&amp;LZW compression (lossless)</source>
+        <translation>&amp;LZW kompresija (bez gubitka)</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="79"/>
-      <source>&amp;OK</source>
-      <translation>&amp;U redu</translation>
+        <location filename="../src/DkCore/DkSaveDialog.cpp" line="79"/>
+        <source>&amp;OK</source>
+        <translation>&amp;U redu</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="80"/>
-      <source>&amp;Cancel</source>
-      <translation>&amp;Otkaži</translation>
+        <location filename="../src/DkCore/DkSaveDialog.cpp" line="80"/>
+        <source>&amp;Cancel</source>
+        <translation>&amp;Otkaži</translation>
     </message>
-  </context>
-  <context>
-    <name>nmc::DkTinyPlanetDialog</name>
+</context>
+<context>
+    <name>nmc::DkTinyPlanetWidget</name>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3006"/>
-      <source>Tiny Planet</source>
-      <translation>Mala planeta</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3040"/>
-      <source>Planet Size</source>
-      <translation>Veličina planete</translation>
+        <location filename="../src/DkGui/DkManipulatorWidgets.cpp" line="248"/>
+        <source>Planet Size</source>
+        <translation>Veličina planete</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3048"/>
-      <source>Angle</source>
-      <translation>Ugao</translation>
+        <location filename="../src/DkGui/DkManipulatorWidgets.cpp" line="254"/>
+        <source>Angle</source>
+        <translation>Ugao</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3054"/>
-      <source>Invert Planet</source>
-      <translation>Obrni planetu</translation>
+        <location filename="../src/DkGui/DkManipulatorWidgets.cpp" line="260"/>
+        <source>Invert Planet</source>
+        <translation>Obrni planetu</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkTrainDialog</name>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="254"/>
-      <source>Add New Image Format</source>
-      <translation>Dodaj novi format slike</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="284"/>
+        <source>Add New Image Format</source>
+        <translation>Dodaj novi format slike</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="263"/>
-      <source>Load New Image Format</source>
-      <translation>Učitaj novi format slike</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="293"/>
+        <source>Load New Image Format</source>
+        <translation>Učitaj novi format slike</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="270"/>
-      <source>&amp;Browse</source>
-      <translation>&amp;Pregledaj</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="300"/>
+        <source>&amp;Browse</source>
+        <translation>&amp;Pregledaj</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="283"/>
-      <source>&amp;Add</source>
-      <translation>&amp;Dodaj</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="313"/>
+        <source>&amp;Add</source>
+        <translation>&amp;Dodaj</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="285"/>
-      <source>&amp;Cancel</source>
-      <translation>&amp;Otkaži</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="315"/>
+        <source>&amp;Cancel</source>
+        <translation>&amp;Otkaži</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="317"/>
-      <source>Open Image</source>
-      <translation>Otvori sliku</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="347"/>
+        <source>Open Image</source>
+        <translation>Otvori sliku</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="318"/>
-      <source>All Files (*.*)</source>
-      <translation>Svi fajlovi (*.*)</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="348"/>
+        <source>All Files (*.*)</source>
+        <translation>Svi fajlovi (*.*)</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="364"/>
-      <source>Sorry, currently we don't support: *.%1 files</source>
-      <translation>Izvini, trenutno ne podržavamo: *.%1 fajlove</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="394"/>
+        <source>Sorry, currently we don&apos;t support: *.%1 files</source>
+        <translation>Izvini, trenutno ne podržavamo: *.%1 fajlove</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="369"/>
-      <source>*.%1 is already supported.</source>
-      <translation>*.%1 je već podržan.</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="399"/>
+        <source>*.%1 is already supported.</source>
+        <translation>*.%1 je već podržan.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="373"/>
-      <source>*.%1 is supported.</source>
-      <translation>*.%1 je podržan.</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="403"/>
+        <source>*.%1 is supported.</source>
+        <translation>*.%1 je podržan.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="390"/>
-      <source>Please name the new format:</source>
-      <translation>Molimo imenujte novi format:</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="420"/>
+        <source>Please name the new format:</source>
+        <translation>Molimo imenujte novi format:</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkTransferToolBar</name>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="538"/>
-      <source>Enable</source>
-      <translation>Uključi</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="527"/>
+        <source>Enable</source>
+        <translation>Uključi</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="622"/>
-      <source>Resets the Pseudo Color function</source>
-      <translation>Resetuj funkciju pseudo-boja</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="602"/>
+        <source>Resets the Pseudo Color function</source>
+        <translation>Resetuj funkciju pseudo-boja</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="796"/>
-      <source>Disables the Pseudo Color function</source>
-      <translation>Isključuje funkciju pseudo-boja</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="776"/>
+        <source>Disables the Pseudo Color function</source>
+        <translation>Isključuje funkciju pseudo-boja</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="548"/>
-      <source>Changes the displayed color channel</source>
-      <translation>Mijenja prikazani kanal boja</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="537"/>
+        <source>Changes the displayed color channel</source>
+        <translation>Mijenja prikazani kanal boja</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="533"/>
-      <source>Pseudo Color Toolbar</source>
-      <translation>Traka za pseudo-boje</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="522"/>
+        <source>Pseudo Color Toolbar</source>
+        <translation>Traka za pseudo-boje</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="553"/>
-      <source>Delete</source>
-      <translation>Izbriši</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="542"/>
+        <source>Delete</source>
+        <translation>Izbriši</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="568"/>
-      <source>Click into the field for a new slider</source>
-      <translation>Klikni u polje za novi klizač</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="557"/>
+        <source>Click into the field for a new slider</source>
+        <translation>Klikni u polje za novi klizač</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="621"/>
-      <source>Reset</source>
-      <translation>Resetuj</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="601"/>
+        <source>Reset</source>
+        <translation>Resetuj</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="627"/>
-      <source>Select Color</source>
-      <translation>Izaberi boju</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="607"/>
+        <source>Select Color</source>
+        <translation>Izaberi boju</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="628"/>
-      <source>Adds a slider at the selected color value</source>
-      <translation>Dodaje slajder za izabranu boju</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="608"/>
+        <source>Adds a slider at the selected color value</source>
+        <translation>Dodaje slajder za izabranu boju</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="633"/>
-      <source>Save Gradient</source>
-      <translation>Sačuvaj prelaz</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="613"/>
+        <source>Save Gradient</source>
+        <translation>Sačuvaj prelaz</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="634"/>
-      <source>Saves the current Gradient</source>
-      <translation>Sačuva trenutni prelaz</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="614"/>
+        <source>Saves the current Gradient</source>
+        <translation>Sačuva trenutni prelaz</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="762"/>
-      <source>Gray</source>
-      <translation>Siva</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="742"/>
+        <source>Gray</source>
+        <translation>Siva</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="765"/>
-      <source>RGB</source>
-      <translation>RGB</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="745"/>
+        <source>RGB</source>
+        <translation>RGB</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="766"/>
-      <source>Red</source>
-      <translation>Crvena</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="746"/>
+        <source>Red</source>
+        <translation>Crvena</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="767"/>
-      <source>Green</source>
-      <translation>Zelena</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="747"/>
+        <source>Green</source>
+        <translation>Zelena</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="768"/>
-      <source>Blue</source>
-      <translation>Plava</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="748"/>
+        <source>Blue</source>
+        <translation>Plava</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="539"/>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="798"/>
-      <source>Enables the Pseudo Color function</source>
-      <translation>Uključuje traku sa funckijom za pseudo-boje</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="528"/>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="778"/>
+        <source>Enables the Pseudo Color function</source>
+        <translation>Uključuje traku sa funckijom za pseudo-boje</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkTranslationUpdater</name>
     <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="557"/>
-      <source>Unable to download translation</source>
-      <translation>Nemoguće preuzimanje prevoda</translation>
+        <location filename="../src/DkCore/DkUpdater.cpp" line="398"/>
+        <source>Unable to download translation</source>
+        <translation>Nemoguće preuzimanje prevoda</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="557"/>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="591"/>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="613"/>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="618"/>
-      <source>update</source>
-      <translation>ažuriranje</translation>
+        <location filename="../src/DkCore/DkUpdater.cpp" line="398"/>
+        <location filename="../src/DkCore/DkUpdater.cpp" line="432"/>
+        <location filename="../src/DkCore/DkUpdater.cpp" line="454"/>
+        <location filename="../src/DkCore/DkUpdater.cpp" line="459"/>
+        <source>update</source>
+        <translation>ažuriranje</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="591"/>
-      <source>Unable to update translation</source>
-      <translation>Nemoguće ažurirati prevod</translation>
+        <location filename="../src/DkCore/DkUpdater.cpp" line="432"/>
+        <source>Unable to update translation</source>
+        <translation>Nemoguće ažurirati prevod</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="613"/>
-      <source>Translation updated</source>
-      <translation>Prevod ažuriran</translation>
+        <location filename="../src/DkCore/DkUpdater.cpp" line="454"/>
+        <source>Translation updated</source>
+        <translation>Prevod ažuriran</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="618"/>
-      <source>No newer translations found</source>
-      <translation>Nisu pronađeni novi prevodi</translation>
+        <location filename="../src/DkCore/DkUpdater.cpp" line="459"/>
+        <source>No newer translations found</source>
+        <translation>Nisu pronađeni novi prevodi</translation>
     </message>
-  </context>
-  <context>
-    <name>nmc::DkUndoRedo</name>
+</context>
+<context>
+    <name>nmc::DkUnsharpMaskWidget</name>
     <message>
-      <location filename="../src/DkGui/DkManipulationWidgets.cpp" line="1471"/>
-      <source>&amp;Undo</source>
-      <translation>&amp;Opozovi</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkManipulationWidgets.cpp" line="1473"/>
-      <source>&amp;Redo</source>
-      <translation>&amp;Ponovi</translation>
-    </message>
-  </context>
-  <context>
-    <name>nmc::DkUnsharpDialog</name>
-    <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2826"/>
-      <source>Sharpen Image</source>
-      <translation>Izoštri sliku</translation>
+        <location filename="../src/DkGui/DkManipulatorWidgets.cpp" line="297"/>
+        <source>Sigma</source>
+        <translation>Sigma</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2860"/>
-      <source>Sigma</source>
-      <translation>Sigma</translation>
+        <location filename="../src/DkGui/DkManipulatorWidgets.cpp" line="302"/>
+        <source>Amount</source>
+        <translation>Iznos</translation>
     </message>
-    <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2865"/>
-      <source>Amount</source>
-      <translation>Iznos</translation>
-    </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkUpdateDialog</name>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2045"/>
-      <source>nomacs updater</source>
-      <translation>nomacs ažuriranje</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2079"/>
+        <source>nomacs updater</source>
+        <translation>nomacs ažuriranje</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2053"/>
-      <source>Install Now</source>
-      <translation>Instaliraj sada</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2087"/>
+        <source>Install Now</source>
+        <translation>Instaliraj sada</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2054"/>
-      <source>Cancel</source>
-      <translation>Otkaži</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2088"/>
+        <source>Cancel</source>
+        <translation>Otkaži</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkUpdater</name>
     <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="395"/>
-      <source>sorry, I could not check for newer versions</source>
-      <translation>izvini, ne mogu provjeriti za nove verzije</translation>
+        <location filename="../src/DkCore/DkUpdater.cpp" line="240"/>
+        <source>sorry, I could not check for newer versions</source>
+        <translation>izvini, ne mogu provjeriti za nove verzije</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="395"/>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="415"/>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="418"/>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="426"/>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="496"/>
-      <source>updates</source>
-      <translation>ažuriranja</translation>
+        <location filename="../src/DkCore/DkUpdater.cpp" line="240"/>
+        <location filename="../src/DkCore/DkUpdater.cpp" line="260"/>
+        <location filename="../src/DkCore/DkUpdater.cpp" line="263"/>
+        <location filename="../src/DkCore/DkUpdater.cpp" line="271"/>
+        <location filename="../src/DkCore/DkUpdater.cpp" line="341"/>
+        <source>updates</source>
+        <translation>ažuriranja</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="407"/>
-      <source>A new version</source>
-      <translation>Nova verzija</translation>
+        <location filename="../src/DkCore/DkUpdater.cpp" line="252"/>
+        <source>A new version</source>
+        <translation>Nova verzija</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="407"/>
-      <source>is available</source>
-      <translation>je dostupna</translation>
+        <location filename="../src/DkCore/DkUpdater.cpp" line="252"/>
+        <source>is available</source>
+        <translation>je dostupna</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="408"/>
-      <source>Do you want to download and install it now?</source>
-      <translation>Da li je želite preuzeti i instalirati?</translation>
+        <location filename="../src/DkCore/DkUpdater.cpp" line="253"/>
+        <source>Do you want to download and install it now?</source>
+        <translation>Da li je želite preuzeti i instalirati?</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="409"/>
-      <source>For more information see </source>
-      <translation>Za više informacija pogledajte</translation>
+        <location filename="../src/DkCore/DkUpdater.cpp" line="254"/>
+        <source>For more information see </source>
+        <translation>Za više informacija pogledajte </translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="426"/>
-      <source>sorry, unable to download the new version</source>
-      <translation>izvini, nemoguće preuzimanje nove verzije</translation>
+        <location filename="../src/DkCore/DkUpdater.cpp" line="271"/>
+        <source>sorry, unable to download the new version</source>
+        <translation>izvini, nemoguće preuzimanje nove verzije</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="496"/>
-      <source>Unable to connect to server ... please try again later</source>
-      <translation>Nemoguće spajanje na server ... molimo pokušajte kasnije</translation>
+        <location filename="../src/DkCore/DkUpdater.cpp" line="341"/>
+        <source>Unable to connect to server ... please try again later</source>
+        <translation>Nemoguće spajanje na server ... molimo pokušajte kasnije</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="418"/>
-      <source>nomacs is up-to-date</source>
-      <translation>nomacs je ažuran</translation>
+        <location filename="../src/DkCore/DkUpdater.cpp" line="263"/>
+        <source>nomacs is up-to-date</source>
+        <translation>nomacs je ažuran</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkViewPort</name>
     <message>
-      <location filename="../src/DkGui/DkViewPort.cpp" line="226"/>
-      <source>Original Image</source>
-      <translation type="unfinished">Original Image</translation>
+        <location filename="../src/DkGui/DkViewPort.cpp" line="238"/>
+        <source>Original Image</source>
+        <translation>Originalna slika</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkViewPort.cpp" line="627"/>
-      <source>connected with: </source>
-      <translation>povezan sa: </translation>
+        <location filename="../src/DkGui/DkViewPort.cpp" line="651"/>
+        <source>connected with: </source>
+        <translation>povezan sa: </translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkViewPort.cpp" line="631"/>
-      <source>disconnected with: </source>
-      <translation>nepovezan sa: </translation>
+        <location filename="../src/DkGui/DkViewPort.cpp" line="655"/>
+        <source>disconnected with: </source>
+        <translation>nepovezan sa: </translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkViewPort.cpp" line="1283"/>
-      <source>Transparency Pattern Enabled</source>
-      <translation>Providnost uključena</translation>
+        <location filename="../src/DkGui/DkViewPort.cpp" line="739"/>
+        <source>Busy</source>
+        <translation>Zauzet</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkViewPort.cpp" line="1283"/>
-      <source>Transparency Pattern Disabled</source>
-      <translation>Providnost isključena</translation>
+        <location filename="../src/DkGui/DkViewPort.cpp" line="1408"/>
+        <source>Transparency Pattern Enabled</source>
+        <translation>Providnost uključena</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkViewPort.cpp" line="1324"/>
-      <source>Lena</source>
-      <translation>Lena</translation>
+        <location filename="../src/DkGui/DkViewPort.cpp" line="1408"/>
+        <source>Transparency Pattern Disabled</source>
+        <translation>Providnost isključena</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkViewPort.cpp" line="1324"/>
-      <source>A remarkable woman</source>
-      <translation>Izuzetna žena</translation>
+        <location filename="../src/DkGui/DkViewPort.cpp" line="1449"/>
+        <source>Lena</source>
+        <translation>Lena</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkViewPort.cpp" line="1334"/>
-      <source>you cannot cancel this</source>
-      <translation>ne možete otkazati ovo</translation>
+        <location filename="../src/DkGui/DkViewPort.cpp" line="1449"/>
+        <source>A remarkable woman</source>
+        <translation>Izuzetna žena</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkViewPort.cpp" line="1342"/>
-      <source>did you understand the brainteaser?</source>
-      <translation>razumijete li slagalicu?</translation>
+        <location filename="../src/DkGui/DkViewPort.cpp" line="1459"/>
+        <source>you cannot cancel this</source>
+        <translation>ne možete otkazati ovo</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkViewPort.cpp" line="1344"/>
-      <source>%1 is wrong...</source>
-      <translation>%1 je pogrešno...</translation>
+        <location filename="../src/DkGui/DkViewPort.cpp" line="1467"/>
+        <source>did you understand the brainteaser?</source>
+        <translation>razumijete li slagalicu?</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkViewPort.cpp" line="1385"/>
-      <location filename="../src/DkGui/DkViewPort.cpp" line="1410"/>
-      <source>Attempted to set NULL image</source>
-      <translation>Pokušaj da se postavi NULL slika</translation>
+        <location filename="../src/DkGui/DkViewPort.cpp" line="1469"/>
+        <source>%1 is wrong...</source>
+        <translation>%1 je pogrešno...</translation>
     </message>
-  </context>
-  <context>
+    <message>
+        <location filename="../src/DkGui/DkViewPort.cpp" line="1510"/>
+        <location filename="../src/DkGui/DkViewPort.cpp" line="1536"/>
+        <source>Attempted to set NULL image</source>
+        <translation>Pokušaj da se postavi NULL slika</translation>
+    </message>
+</context>
+<context>
     <name>nmc::DkViewPortFrameless</name>
     <message>
-      <location filename="../src/DkGui/DkViewPort.cpp" line="1943"/>
-      <source>Press F10 to exit Frameless view</source>
-      <translation>Pritisni F10 za izlaz iz pregleda bez okvira</translation>
+        <location filename="../src/DkGui/DkViewPort.cpp" line="2065"/>
+        <source>Press F10 to exit Frameless view</source>
+        <translation>Pritisni F10 za izlaz iz pregleda bez okvira</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkWelcomeDialog</name>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4188"/>
-      <source>Welcome</source>
-      <translation>Dobrodošli</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3839"/>
+        <source>Welcome</source>
+        <translation>Dobrodošli</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4197"/>
-      <source>Welcome to nomacs, please choose your preferred language below.</source>
-      <translation>Dobrodošli u nomacs, molimo izaberite željeni jezik.</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3848"/>
+        <source>Welcome to nomacs, please choose your preferred language below.</source>
+        <translation>Dobrodošli u nomacs, molimo izaberite željeni jezik.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4202"/>
-      <source>&amp;Register File Associations</source>
-      <translation type="unfinished">&amp;Register File Associations</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3853"/>
+        <source>&amp;Register File Associations</source>
+        <translation>P&amp;rijavi asocijacije za fajlove</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4205"/>
-      <source>Set As &amp;Default Viewer</source>
-      <translation type="unfinished">Set As &amp;Default Viewer</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3856"/>
+        <source>Set As &amp;Default Viewer</source>
+        <translation>Postavi kao po&amp;drazumijevani pregledač slika</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4210"/>
-      <source>&amp;OK</source>
-      <translation>&amp;U redu</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3861"/>
+        <source>&amp;OK</source>
+        <translation>&amp;U redu</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4211"/>
-      <source>&amp;Cancel</source>
-      <translation>&amp;Otkaži</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3862"/>
+        <source>&amp;Cancel</source>
+        <translation>&amp;Otkaži</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4249"/>
-      <source>Image</source>
-      <translation>Slika</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3900"/>
+        <source>Image</source>
+        <translation>Slika</translation>
     </message>
-  </context>
+</context>
 </TS>

--- a/ImageLounge/translations/nomacs_sr.ts
+++ b/ImageLounge/translations/nomacs_sr.ts
@@ -1,5886 +1,6310 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
 <TS version="2.1" language="sr" sourcelanguage="en">
-  <context>
-    <name>DkNoMacsClass</name>
-    <message>
-      <location filename="../src/nomacs.ui" line="16"/>
-      <source>nomacs - image lounge</source>
-      <translation>nomacs - салон слика</translation>
-    </message>
-  </context>
-  <context>
+<context>
     <name>QObject</name>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="175"/>
-      <source>&amp;Photoshop</source>
-      <translation>&amp;Photoshop</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="181"/>
+        <source>&amp;Photoshop</source>
+        <translation>&amp;Photoshop</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="186"/>
-      <source>Pic&amp;asa</source>
-      <translation>Pic&amp;asa</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="192"/>
+        <source>Pic&amp;asa</source>
+        <translation>Pic&amp;asa</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="197"/>
-      <source>Picasa Ph&amp;oto Viewer</source>
-      <translation>Picasa Ph&amp;oto Viewer</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="203"/>
+        <source>Picasa Ph&amp;oto Viewer</source>
+        <translation>Picasa Ph&amp;oto Viewer</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="208"/>
-      <source>&amp;IrfanView</source>
-      <translation>&amp;IrfanView</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="214"/>
+        <source>&amp;IrfanView</source>
+        <translation>&amp;IrfanView</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="218"/>
-      <source>&amp;Explorer</source>
-      <translation>&amp;Explorer</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="224"/>
+        <source>&amp;Explorer</source>
+        <translation>Прегл&amp;едач</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="355"/>
-      <source>&amp;File</source>
-      <translation>&amp;Фајл</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="362"/>
+        <source>&amp;File</source>
+        <translation>&amp;Фајл</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="396"/>
-      <source>&amp;Open With</source>
-      <translation>&amp;Отвори са</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="410"/>
+        <source>&amp;Open With</source>
+        <translation>&amp;Отвори са</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="427"/>
-      <source>S&amp;ort</source>
-      <translation>Р&amp;азврстај</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="441"/>
+        <source>S&amp;ort</source>
+        <translation>Р&amp;азврстај</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="441"/>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="650"/>
-      <source>&amp;View</source>
-      <translation>&amp;Преглед</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="455"/>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="670"/>
+        <source>&amp;View</source>
+        <translation>&amp;Преглед</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="486"/>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="656"/>
-      <source>&amp;Edit</source>
-      <translation>&amp;Измени</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="504"/>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="676"/>
+        <source>&amp;Edit</source>
+        <translation>&amp;Измени</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="527"/>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="635"/>
-      <source>&amp;Panels</source>
-      <translation>&amp;Панели</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="542"/>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="654"/>
+        <source>&amp;Panels</source>
+        <translation>&amp;Панели</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="529"/>
-      <source>Tool&amp;bars</source>
-      <translation>Трака а&amp;лата</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="544"/>
+        <source>Tool&amp;bars</source>
+        <translation>Трака а&amp;лата</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="556"/>
-      <source>&amp;Tools</source>
-      <translation>&amp;Алати</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="574"/>
+        <source>&amp;Tools</source>
+        <translation>&amp;Алати</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="2742"/>
-      <source>&amp;Synchronize</source>
-      <translation>&amp;Синхронизуј</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="2436"/>
+        <source>&amp;Synchronize</source>
+        <translation>&amp;Синхронизуј</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="2748"/>
-      <source>&amp;LAN Synchronize</source>
-      <translation>&amp;ЛАН синхронизација</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="2442"/>
+        <source>&amp;LAN Synchronize</source>
+        <translation>&amp;ЛАН синхронизација</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="604"/>
-      <source>&amp;?</source>
-      <translation>&amp;?</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="618"/>
+        <source>&amp;?</source>
+        <translation>&amp;Помоћ?</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="963"/>
-      <source>&amp;Open</source>
-      <translation>&amp;Отвори</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="969"/>
+        <source>&amp;Open</source>
+        <translation>&amp;Отвори</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="965"/>
-      <source>Open an image</source>
-      <translation>Отвори слику</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="971"/>
+        <source>Open an image</source>
+        <translation>Отвори слику</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="967"/>
-      <source>Open &amp;Directory</source>
-      <translation>Отвори &amp;фасциклу</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="973"/>
+        <source>Open &amp;Directory</source>
+        <translation>Отвори &amp;фасциклу</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="969"/>
-      <source>Open a directory and load its first image</source>
-      <translation>Отвори фасциклу и учитај прву слику</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="975"/>
+        <source>Open a directory and load its first image</source>
+        <translation>Отвори фасциклу и учитај прву слику</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="971"/>
-      <source>&amp;Quick Launch</source>
-      <translation>&amp;Брзо отвори</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="980"/>
+        <source>&amp;Quick Launch</source>
+        <translation>&amp;Брзо отвори</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="978"/>
-      <source>&amp;Manage Applications</source>
-      <translation>&amp;Управљање апликацијама</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="987"/>
+        <source>&amp;Manage Applications</source>
+        <translation>&amp;Управљање апликацијама</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="979"/>
-      <source>Manage Applications which are Automatically Opened</source>
-      <translation>Управљај апликацијама које су аутоматски отворене</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="988"/>
+        <source>Manage Applications which are Automatically Opened</source>
+        <translation>Управљај апликацијама које су аутоматски отворене</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="982"/>
-      <source>Re&amp;name</source>
-      <translation>Пре&amp;именуј</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="991"/>
+        <source>Re&amp;name</source>
+        <translation>Пре&amp;именуј</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="985"/>
-      <source>Rename an image</source>
-      <translation>Преименуј слику</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="994"/>
+        <source>Rename an image</source>
+        <translation>Преименуј слику</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="987"/>
-      <source>&amp;Go To</source>
-      <translation>&amp;Иди на</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="996"/>
+        <source>&amp;Go To</source>
+        <translation>&amp;Иди на</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="989"/>
-      <source>Go To an image</source>
-      <translation>Иди на слику</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="998"/>
+        <source>Go To an image</source>
+        <translation>Иди на слику</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="991"/>
-      <source>&amp;Save</source>
-      <translation>&amp;Сачувај</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1000"/>
+        <source>&amp;Save</source>
+        <translation>&amp;Сачувај</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="993"/>
-      <source>Save an image</source>
-      <translation>Сачувај слику</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1002"/>
+        <source>Save an image</source>
+        <translation>Сачувај слику</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="995"/>
-      <source>&amp;Save As</source>
-      <translation>&amp;Сачувај као</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1004"/>
+        <source>&amp;Save As</source>
+        <translation>&amp;Сачувај као</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="997"/>
-      <source>Save an image as</source>
-      <translation>Сачувај слику као</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1006"/>
+        <source>Save an image as</source>
+        <translation>Сачувај слику као</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="999"/>
-      <source>&amp;Save for Web</source>
-      <translation>&amp;Сачувај за веб</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1011"/>
+        <source>&amp;Save for Web</source>
+        <translation>&amp;Сачувај за веб</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1000"/>
-      <source>Save an Image for Web Applications</source>
-      <translation>Сачувај као слику за веб апликације</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1012"/>
+        <source>Save an Image for Web Applications</source>
+        <translation>Сачувај као слику за веб апликације</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1002"/>
-      <source>&amp;Print</source>
-      <translation>&amp;Штампај</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1014"/>
+        <source>&amp;Print</source>
+        <translation>&amp;Штампај</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1004"/>
-      <source>Print an image</source>
-      <translation>Штампај слику</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1016"/>
+        <source>Print an image</source>
+        <translation>Штампај слику</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1012"/>
-      <source>&amp;Reload File</source>
-      <translation>&amp;Поново учитај фајл</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1024"/>
+        <source>&amp;Reload File</source>
+        <translation>&amp;Поново учитај фајл</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1015"/>
-      <source>Reload File</source>
-      <translation>Поново учитај фајл</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1027"/>
+        <source>Reload File</source>
+        <translation>Поново учитај фајл</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1017"/>
-      <source>Ne&amp;xt File</source>
-      <translation>След&amp;ећи фајл</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1029"/>
+        <source>Ne&amp;xt File</source>
+        <translation>След&amp;ећи фајл</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1020"/>
-      <source>Load next image</source>
-      <translation>Учитај следећу слику</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1032"/>
+        <source>Load next image</source>
+        <translation>Учитај следећу слику</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1022"/>
-      <source>Pre&amp;vious File</source>
-      <translation>Прет&amp;ходни фајл</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1034"/>
+        <source>Pre&amp;vious File</source>
+        <translation>Прет&amp;ходни фајл</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1027"/>
-      <source>Add Image Format</source>
-      <translation>Додај формат слике</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1400"/>
+        <source>Add Image Format</source>
+        <translation>Додај формат слике</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1028"/>
-      <source>Add a new image format to nomacs</source>
-      <translation>Додајте нови формат слике у nomacs</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1401"/>
+        <source>Add a new image format to nomacs</source>
+        <translation>Додајте нови формат слике у nomacs</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1030"/>
-      <source>St&amp;art New Instance</source>
-      <translation>По&amp;чни нови пример</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1039"/>
+        <source>St&amp;art New Instance</source>
+        <translation>По&amp;чни нови пример</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1025"/>
-      <source>Load previous file</source>
-      <translation>Учитај претходни фајл</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1037"/>
+        <source>Load previous file</source>
+        <translation>Учитај претходни фајл</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1006"/>
-      <source>&amp;Recent Files</source>
-      <translation>&amp;Скорашњи фајлови</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1018"/>
+        <source>&amp;Recent Files</source>
+        <translation>&amp;Скорашњи фајлови</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1010"/>
-      <source>Show Recent Files</source>
-      <translation>Прикажи скорашње фајлове</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1022"/>
+        <source>Show Recent Files</source>
+        <translation>Прикажи скорашње фајлове</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1032"/>
-      <source>Open file in new instance</source>
-      <translation>Отвори фајл у новом примеру</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1041"/>
+        <source>Open file in new instance</source>
+        <translation>Отвори фајл у новом примеру</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1034"/>
-      <source>St&amp;art Private Instance</source>
-      <translation>По&amp;чни приватни случај</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1043"/>
+        <source>St&amp;art Private Instance</source>
+        <translation>По&amp;чни приватни случај</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1036"/>
-      <source>Open private instance</source>
-      <translation>Отвори приватни случај</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1045"/>
+        <source>Open private instance</source>
+        <translation>Отвори приватни случај</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1038"/>
-      <source>&amp;Find &amp;&amp; Filter</source>
-      <translation>&amp;Пронађи &amp;&amp; Филтрирај</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1047"/>
+        <source>&amp;Find &amp;&amp; Filter</source>
+        <translation>&amp;Пронађи &amp;&amp; Филтрирај</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1040"/>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1389"/>
-      <source>Find an image</source>
-      <translation>Пронађи слику</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1049"/>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1379"/>
+        <source>Find an image</source>
+        <translation>Пронађи слику</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1042"/>
-      <source>Scan Folder Re&amp;cursive</source>
-      <translation>Скенирај фасциклу по&amp;ново</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1051"/>
+        <source>Scan Folder Re&amp;cursive</source>
+        <translation>Скенирај фасциклу рекурзив&amp;но</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1043"/>
-      <source>Step through Folder and Sub Folders</source>
-      <translation>Корак кроз фасциклу и подфасцикле</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1052"/>
+        <source>Step through Folder and Sub Folders</source>
+        <translation>Пролистај кроз фасциклу и подфасцикле</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1047"/>
-      <source>&amp;Exit</source>
-      <translation>&amp;Напусти</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1056"/>
+        <source>&amp;Exit</source>
+        <translation>&amp;Напусти</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1048"/>
-      <source>Exit</source>
-      <translation>Напусти</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1057"/>
+        <source>Exit</source>
+        <translation>Напусти</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1053"/>
-      <source>by &amp;Filename</source>
-      <translation>по &amp;имену фајла</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1062"/>
+        <source>by &amp;Filename</source>
+        <translation>по &amp;имену фајла</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1055"/>
-      <source>Sort by Filename</source>
-      <translation>Разврстај по имену фајла</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1064"/>
+        <source>Sort by Filename</source>
+        <translation>Разврстај по имену фајла</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1059"/>
-      <source>by Date &amp;Created</source>
-      <translation>по датуму &amp;креирања</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1068"/>
+        <source>by Date &amp;Created</source>
+        <translation>по датуму &amp;креирања</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1061"/>
-      <source>Sort by Date Created</source>
-      <translation>Разврстај по датуму креирања</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1070"/>
+        <source>Sort by Date Created</source>
+        <translation>Разврстај по датуму креирања</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1065"/>
-      <source>by Date Modified</source>
-      <translation>по датуму измене</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1074"/>
+        <source>by Date Modified</source>
+        <translation>по датуму измене</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1067"/>
-      <source>Sort by Date Last Modified</source>
-      <translation>Развстај по датуму измене</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1076"/>
+        <source>Sort by Date Last Modified</source>
+        <translation>Развстај по датуму измене</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1071"/>
-      <source>Random</source>
-      <translation>Случајан</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1080"/>
+        <source>Random</source>
+        <translation>Случајан</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1073"/>
-      <source>Sort in Random Order</source>
-      <translation>Сортирај по случајном избору</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1082"/>
+        <source>Sort in Random Order</source>
+        <translation>Сортирај по случајном избору</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1077"/>
-      <source>&amp;Ascending</source>
-      <translation>&amp;Растући</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1086"/>
+        <source>&amp;Ascending</source>
+        <translation>&amp;Растући</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1079"/>
-      <source>Sort in Ascending Order</source>
-      <translation>Развстај по растућем редоследу</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1088"/>
+        <source>Sort in Ascending Order</source>
+        <translation>Развстај по растућем редоследу</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1083"/>
-      <source>&amp;Descending</source>
-      <translation>&amp;Опадајући</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1092"/>
+        <source>&amp;Descending</source>
+        <translation>&amp;Опадајући</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1085"/>
-      <source>Sort in Descending Order</source>
-      <translation>Разврстај по опадајућем редоследу</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1094"/>
+        <source>Sort in Descending Order</source>
+        <translation>Разврстај по опадајућем редоследу</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1092"/>
-      <source>9&amp;0%1 Clockwise</source>
-      <translation>9&amp;0%1 у смеру казаљке на сату</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1101"/>
+        <source>9&amp;0%1 Clockwise</source>
+        <translation>9&amp;0%1 у смеру казаљке на сату</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1095"/>
-      <source>rotate the image 90%1 clockwise</source>
-      <translation>ротирај слику 90%1 у смеру казаљке на сату</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1104"/>
+        <source>rotate the image 90%1 clockwise</source>
+        <translation>ротирај слику 90%1 у смеру казаљке на сату</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1097"/>
-      <source>&amp;90%1 Counter Clockwise</source>
-      <translation>&amp;90%1 супротно казаљци на сату</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1106"/>
+        <source>&amp;90%1 Counter Clockwise</source>
+        <translation>&amp;90%1 супротно казаљци на сату</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1100"/>
-      <source>rotate the image 90%1 counter clockwise</source>
-      <translation>ротирај слику 90%1 супротно казаљци на сату</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1109"/>
+        <source>rotate the image 90%1 counter clockwise</source>
+        <translation>ротирај слику 90%1 супротно казаљци на сату</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1102"/>
-      <source>180%1</source>
-      <translation>180%1</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1111"/>
+        <source>180%1</source>
+        <translation>180%1</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1103"/>
-      <source>rotate the image by 180%1</source>
-      <translation>ротирај слику 180%1</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1112"/>
+        <source>rotate the image by 180%1</source>
+        <translation>ротирај слику 180%1</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1105"/>
-      <source>&amp;Undo</source>
-      <translation>&amp;Откажи</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1114"/>
+        <source>&amp;Undo</source>
+        <translation>&amp;Откажи</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1108"/>
-      <source>Undo Last Action</source>
-      <translation>Поништи последњу радњу</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1117"/>
+        <source>Undo Last Action</source>
+        <translation>Поништи последњу радњу</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1110"/>
-      <source>&amp;Redo</source>
-      <translation>&amp;Понови</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1119"/>
+        <source>&amp;Redo</source>
+        <translation>&amp;Понови</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1113"/>
-      <source>Redo Last Action</source>
-      <translation>Понови последњу радњу</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1122"/>
+        <source>Redo Last Action</source>
+        <translation>Понови последњу радњу</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1115"/>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1517"/>
-      <source>&amp;Copy</source>
-      <translation>&amp;Копирај</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1124"/>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1502"/>
+        <source>&amp;Copy</source>
+        <translation>&amp;Копирај</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1118"/>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1123"/>
-      <source>copy image</source>
-      <translation>копирај слику</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1127"/>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1132"/>
+        <source>copy image</source>
+        <translation>копирај слику</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1120"/>
-      <source>Copy &amp;Buffer</source>
-      <translation>Копирај &amp;бафер</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1129"/>
+        <source>Copy &amp;Buffer</source>
+        <translation>Копирај &amp;бафер</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1125"/>
-      <source>Copy Co&amp;lor</source>
-      <translation>Копирај бо&amp;ју</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1134"/>
+        <source>Copy Co&amp;lor</source>
+        <translation>Копирај бо&amp;ју</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1128"/>
-      <source>copy pixel color value as HEX</source>
-      <translation>копирај пиксел колор вредности као HEX</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1137"/>
+        <source>copy pixel color value as HEX</source>
+        <translation>копирај пиксел колор вредности као HEX</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1133"/>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1520"/>
-      <source>&amp;Paste</source>
-      <translation>&amp;Налепи</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1142"/>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1505"/>
+        <source>&amp;Paste</source>
+        <translation>&amp;Налепи</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1136"/>
-      <source>paste image</source>
-      <translation>налепи слику</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1145"/>
+        <source>paste image</source>
+        <translation>налепи слику</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1138"/>
-      <source>R&amp;esize Image</source>
-      <translation>Пр&amp;омени величину слике</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1167"/>
+        <source>R&amp;esize Image</source>
+        <translation>Пр&amp;омени величину слике</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1141"/>
-      <source>resize the current image</source>
-      <translation>промени величину тренутне слике</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1170"/>
+        <source>resize the current image</source>
+        <translation>промени величину тренутне слике</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1143"/>
-      <source>Cr&amp;op Image</source>
-      <translation>Оп&amp;сеци слику</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1172"/>
+        <source>Cr&amp;op Image</source>
+        <translation>Оп&amp;сеци слику</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1146"/>
-      <source>cut the current image</source>
-      <translation>опсеци тренутну слику</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1175"/>
+        <source>cut the current image</source>
+        <translation>опсеци тренутну слику</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1150"/>
-      <source>Flip &amp;Horizontal</source>
-      <translation>Окрени &amp;водоравно</translation>
+        <location filename="../src/DkCore/DkManipulators.cpp" line="101"/>
+        <source>Flip &amp;Horizontal</source>
+        <translation>Окрени &amp;водоравно</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1151"/>
-      <source>Flip Image Horizontally</source>
-      <translation>Окрени слику водоравно</translation>
+        <location filename="../src/DkCore/DkManipulators.cpp" line="102"/>
+        <source>Flip Image Horizontally</source>
+        <translation>Окрени слику водоравно</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1153"/>
-      <source>Flip &amp;Vertical</source>
-      <translation>Окрени &amp;усправно</translation>
+        <location filename="../src/DkCore/DkManipulators.cpp" line="106"/>
+        <source>Flip &amp;Vertical</source>
+        <translation>Окрени &amp;усправно</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1154"/>
-      <source>Flip Image Vertically</source>
-      <translation>Окрени слику усправно</translation>
+        <location filename="../src/DkCore/DkManipulators.cpp" line="107"/>
+        <source>Flip Image Vertically</source>
+        <translation>Окрени слику усправно</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1156"/>
-      <source>Nor&amp;malize Image</source>
-      <translation>Норм&amp;ализуј слику</translation>
+        <location filename="../src/DkCore/DkManipulators.cpp" line="95"/>
+        <source>Nor&amp;malize Image</source>
+        <translation>Норм&amp;ализуј слику</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1159"/>
-      <source>Normalize the Image</source>
-      <translation>Нормализуј слику</translation>
+        <location filename="../src/DkCore/DkManipulators.cpp" line="97"/>
+        <source>Normalize the Image</source>
+        <translation>Нормализуј слику</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1161"/>
-      <source>&amp;Auto Adjust</source>
-      <translation>&amp;Аутоматско подешавање</translation>
+        <location filename="../src/DkCore/DkManipulators.cpp" line="89"/>
+        <source>&amp;Auto Adjust</source>
+        <translation>&amp;Аутоматско подешавање</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1164"/>
-      <source>Auto Adjust Image Contrast and Color Balance</source>
-      <translation>Аутоматско подешавање контраста и боје</translation>
+        <location filename="../src/DkCore/DkManipulators.cpp" line="84"/>
+        <source>&amp;Grayscale</source>
+        <translation>&amp;Црно-бело</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1166"/>
-      <source>&amp;Invert Image</source>
-      <translation>&amp;Окрени слику</translation>
+        <location filename="../src/DkCore/DkManipulators.cpp" line="91"/>
+        <source>Auto Adjust Image Contrast and Color Balance</source>
+        <translation>Аутоматско подешавање контраста и боје</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1167"/>
-      <source>Invert the Image</source>
-      <translation>Окрени слику</translation>
+        <location filename="../src/DkCore/DkManipulators.cpp" line="111"/>
+        <source>&amp;Invert Image</source>
+        <translation>&amp;Окрени слику</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1169"/>
-      <source>&amp;Convert to Grayscale</source>
-      <translation>&amp;Конвертуј у црно-бело</translation>
+        <location filename="../src/DkCore/DkManipulators.cpp" line="112"/>
+        <source>Invert the Image</source>
+        <translation>Окрени слику</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1170"/>
-      <source>Convert to Grayscale</source>
-      <translation>Конвертуј у црно-бело</translation>
+        <location filename="../src/DkCore/DkManipulators.cpp" line="117"/>
+        <source>&amp;Tiny Planet...</source>
+        <translation>Мала плане&amp;та...</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1172"/>
-      <source>&amp;Unsharp Mask</source>
-      <translation>&amp;Маска за изоштравање</translation>
+        <location filename="../src/DkCore/DkManipulators.cpp" line="118"/>
+        <source>Create a Tiny Planet</source>
+        <translation>Направи малу планету</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1173"/>
-      <source>Stretches the Local Contrast of an Image</source>
-      <translation>Истегни локални контраст слике</translation>
+        <location filename="../src/DkCore/DkManipulators.cpp" line="122"/>
+        <source>&amp;Sharpen...</source>
+        <translation>Изо&amp;штри...</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1175"/>
-      <source>&amp;Tiny Planet</source>
-      <translation>&amp;Мала планета</translation>
+        <location filename="../src/DkCore/DkManipulators.cpp" line="123"/>
+        <source>Sharpens the image by applying an unsharp mask</source>
+        <translation>Изоштрава слику методом неоштре маске</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1176"/>
-      <source>Computes a tiny planet image</source>
-      <translation>Израчунава слику у облику мале планете</translation>
+        <location filename="../src/DkCore/DkManipulators.cpp" line="127"/>
+        <source>&amp;Rotate...</source>
+        <translation>&amp;Ротирај...</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1178"/>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1514"/>
-      <source>&amp;Delete</source>
-      <translation>&amp;Уклони</translation>
+        <location filename="../src/DkCore/DkManipulators.cpp" line="128"/>
+        <source>Rotate the image</source>
+        <translation>Ротира слику</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1181"/>
-      <source>delete current fileInfo</source>
-      <translation>избриши информације тренутног фајла</translation>
+        <location filename="../src/DkCore/DkManipulators.cpp" line="132"/>
+        <source>&amp;Threshold...</source>
+        <translation>&amp;Праг...</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1183"/>
-      <source>&amp;Wallpaper</source>
-      <translation>&amp;Тапет</translation>
+        <location filename="../src/DkCore/DkManipulators.cpp" line="133"/>
+        <source>Threshold the image</source>
+        <translation>Примењује праг на слику</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1184"/>
-      <source>set the current image as wallpaper</source>
-      <translation>подеси тренутну слику као тапет</translation>
+        <location filename="../src/DkCore/DkManipulators.cpp" line="137"/>
+        <source>&amp;Hue/Saturation...</source>
+        <translation>&amp;Нијанса/Засићење...</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1186"/>
-      <source>&amp;Keyboard Shortcuts</source>
-      <translation>&amp;Пречице тастатуре</translation>
+        <location filename="../src/DkCore/DkManipulators.cpp" line="138"/>
+        <source>Change Hue and Saturation</source>
+        <translation>Измени нијансу и засићење</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1188"/>
-      <source>lets you customize your keyboard shortcuts</source>
-      <translation>омогућава вам да прилагодите ваше пречице тастатуре</translation>
+        <location filename="../src/DkCore/DkManipulators.cpp" line="142"/>
+        <source>&amp;Exposure...</source>
+        <translation>&amp;Експонирање...</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1190"/>
-      <source>&amp;Settings</source>
-      <translation>&amp;Подешавање</translation>
+        <location filename="../src/DkCore/DkManipulators.cpp" line="143"/>
+        <source>Change the Exposure and Gamma</source>
+        <translation>Измени експонирање и гаму</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1192"/>
-      <source>settings</source>
-      <translation>подешавање</translation>
+        <location filename="../src/DkCore/DkManipulators.cpp" line="85"/>
+        <source>Convert to Grayscale</source>
+        <translation>Конвертуј у црно-бело</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1196"/>
-      <source>&amp;Menu</source>
-      <translation>&amp;Мени</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1147"/>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1499"/>
+        <source>&amp;Delete</source>
+        <translation>&amp;Уклони</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1197"/>
-      <source>Hides the Menu and Shows it Again on ALT</source>
-      <translation>Сакриј мени и покажи га поново на ALT</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1150"/>
+        <source>delete current fileInfo</source>
+        <translation>избриши информације тренутног фајла</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1200"/>
-      <source>Tool&amp;bar</source>
-      <translation>Тра&amp;ка алата</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1397"/>
+        <source>&amp;Wallpaper</source>
+        <translation>&amp;Тапет</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1202"/>
-      <source>Show Toolbar</source>
-      <translation>Покажи траку алата</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1398"/>
+        <source>set the current image as wallpaper</source>
+        <translation>подеси тренутну слику као тапет</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1205"/>
-      <source>&amp;Statusbar</source>
-      <translation>&amp;Статусна трака</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1152"/>
+        <source>&amp;Keyboard Shortcuts</source>
+        <translation>&amp;Пречице тастатуре</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1207"/>
-      <source>Show Statusbar</source>
-      <translation>Покажи статусни бар</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="526"/>
+        <source>&amp;Adjustments</source>
+        <translation>&amp;Подешавања</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1210"/>
-      <source>&amp;Pseudocolor Function</source>
-      <translation>&amp;Псеудоколор функција</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="966"/>
+        <source>&amp;Close All Tabs</source>
+        <translation>&amp;Затвори све картице</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1212"/>
-      <source>Show Pseudocolor Function</source>
-      <translation>Покажи функцију псеудо боја</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="967"/>
+        <source>Close all open tabs</source>
+        <translation>Затвори све отворене картице</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1216"/>
-      <source>O&amp;verview</source>
-      <translation>П&amp;реглед</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="977"/>
+        <source>&amp;Open Tabs</source>
+        <translation>&amp;Отвори картице</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1218"/>
-      <source>Shows the Zoom Overview</source>
-      <translation>Покажи зум преглед</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="978"/>
+        <source>Open a texfile containing a list of filepaths, and open tabs for them</source>
+        <translation>Отвори текстуални фајл који садржи листу путања и отвори картице за њих</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1222"/>
-      <source>Pla&amp;yer</source>
-      <translation>Пле&amp;јер</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1008"/>
+        <source>&amp;Save Tabs</source>
+        <translation>&amp;Сачувај картице</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1224"/>
-      <source>Shows the Slide Show Player</source>
-      <translation>Покажи плејер за емитовање слика</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1009"/>
+        <source>Save a newline separated list of the filenames of the open tabs</source>
+        <translation>Сачувај листу имена фајлова отворених картица</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1227"/>
-      <source>File &amp;Explorer</source>
-      <translation>Претраживач &amp;фајлова</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1154"/>
+        <source>lets you customize your keyboard shortcuts</source>
+        <translation>омогућава вам да прилагодите ваше пречице тастатуре</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1229"/>
-      <source>Show File Explorer</source>
-      <translation>Покажи претраживач фајлова</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1156"/>
+        <source>&amp;Settings</source>
+        <translation>&amp;Подешавање</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1232"/>
-      <source>Metadata &amp;Info</source>
-      <translation>Мета &amp;подаци</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1158"/>
+        <source>settings</source>
+        <translation>подешавање</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1234"/>
-      <source>Show Metadata Info</source>
-      <translation>Прикажи мета податке</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1161"/>
+        <source>Image &amp;Adjustments</source>
+        <translation>Подешав&amp;ања слике</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1237"/>
-      <source>&amp;Thumbnails</source>
-      <translation>&amp;Сличице</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1164"/>
+        <source>open image manipulation toolbox</source>
+        <translation>отвори алатке за манипулацију са сликом</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1239"/>
-      <source>Show Thumbnails</source>
-      <translation>Покажи сличице</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1181"/>
+        <source>&amp;Menu</source>
+        <translation>&amp;Мени</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1242"/>
-      <source>&amp;Thumbnail Preview</source>
-      <translation>&amp;Преглед сличица</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1182"/>
+        <source>Hides the Menu and Shows it Again on ALT</source>
+        <translation>Сакриј мени и покажи га поново на ALT</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1244"/>
-      <source>Show Thumbnails Preview</source>
-      <translation>Покажи преглед сличица</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1185"/>
+        <source>Tool&amp;bar</source>
+        <translation>Тра&amp;ка алата</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1247"/>
-      <source>&amp;Folder Scrollbar</source>
-      <translation>&amp;Клизач фасцикле</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1187"/>
+        <source>Show Toolbar</source>
+        <translation>Покажи траку алата</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1249"/>
-      <source>Show Folder Scrollbar</source>
-      <translation>Покажи клизач фасцикле</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1190"/>
+        <source>&amp;Statusbar</source>
+        <translation>&amp;Статусна трака</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1252"/>
-      <source>&amp;Metadata</source>
-      <translation>&amp;Метаподаци</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1192"/>
+        <source>Show Statusbar</source>
+        <translation>Покажи статусни бар</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1254"/>
-      <source>Shows the Metadata Panel</source>
-      <translation>Покажи панел метаподатака</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1195"/>
+        <source>&amp;Pseudocolor Function</source>
+        <translation>&amp;Псеудоколор функција</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1257"/>
-      <source>File &amp;Info</source>
-      <translation>Информације о &amp;фајлу</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1197"/>
+        <source>Show Pseudocolor Function</source>
+        <translation>Покажи функцију псеудо боја</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1259"/>
-      <source>Shows the Info Panel</source>
-      <translation>Покажи панел са информацијама</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1201"/>
+        <source>O&amp;verview</source>
+        <translation>П&amp;реглед</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1262"/>
-      <source>&amp;Histogram</source>
-      <translation>&amp;Хистограм</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1203"/>
+        <source>Shows the Zoom Overview</source>
+        <translation>Покажи зум преглед</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1264"/>
-      <source>Shows the Histogram Panel</source>
-      <translation>Покажи хистограм панел</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1207"/>
+        <source>Pla&amp;yer</source>
+        <translation>Пле&amp;јер</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1267"/>
-      <source>Image &amp;Notes</source>
-      <translation>Напомене &amp;о слици</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1209"/>
+        <source>Shows the Slide Show Player</source>
+        <translation>Покажи плејер за емитовање слика</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1269"/>
-      <source>Shows Image Notes</source>
-      <translation>Прикажи напомене слика</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1212"/>
+        <source>&amp;Hide All Panels</source>
+        <translation>&amp;Сакриј све панеле</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1272"/>
-      <source>Edit &amp;History</source>
-      <translation>Уреди &amp;историју</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1214"/>
+        <source>Hide all panels</source>
+        <translation>Сакриј све панеле</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1273"/>
-      <source>Shows the edit history</source>
-      <translation>Прикажи уређивање историје</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1217"/>
+        <source>File &amp;Explorer</source>
+        <translation>Претраживач &amp;фајлова</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1279"/>
-      <source>&amp;Fit Window</source>
-      <translation>&amp;Уклопи прозор</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1219"/>
+        <source>Show File Explorer</source>
+        <translation>Покажи претраживач фајлова</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1281"/>
-      <source>Fit window to the image</source>
-      <translation>Уклопи прозор слике</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1222"/>
+        <source>Metadata &amp;Info</source>
+        <translation>Мета &amp;подаци</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1286"/>
-      <source>Fu&amp;ll Screen</source>
-      <translation>Це&amp;о екран</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1224"/>
+        <source>Show Metadata Info</source>
+        <translation>Прикажи мета податке</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1288"/>
-      <source>Full Screen</source>
-      <translation>Цео екран</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1227"/>
+        <source>&amp;Thumbnails</source>
+        <translation>&amp;Сличице</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1290"/>
-      <source>&amp;Zoom to Fit</source>
-      <translation>&amp;Зумирај да одговара</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1229"/>
+        <source>Show Thumbnails</source>
+        <translation>Покажи сличице</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1292"/>
-      <source>Shows the initial view (no zooming)</source>
-      <translation>Покажи почетни преглед (без зумирања)</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1232"/>
+        <source>&amp;Thumbnail Preview</source>
+        <translation>&amp;Преглед сличица</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1294"/>
-      <source>Show &amp;100%</source>
-      <translation>Покажи &amp;100%</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1234"/>
+        <source>Show Thumbnails Preview</source>
+        <translation>Покажи преглед сличица</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1296"/>
-      <source>Shows the image at 100%</source>
-      <translation>Покажи слику са 100%</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1237"/>
+        <source>&amp;Folder Scrollbar</source>
+        <translation>&amp;Клизач фасцикле</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1298"/>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1497"/>
-      <source>Zoom &amp;In</source>
-      <translation>Увели&amp;чај</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1238"/>
+        <source>Show Folder Scrollbar</source>
+        <translation>Покажи клизач фасцикле</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1300"/>
-      <source>zoom in</source>
-      <translation>увећај</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1241"/>
+        <source>&amp;Metadata</source>
+        <translation>&amp;Метаподаци</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1302"/>
-      <source>&amp;Zoom Out</source>
-      <translation>&amp;Умањи</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1243"/>
+        <source>Shows the Metadata Panel</source>
+        <translation>Покажи панел метаподатака</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1304"/>
-      <source>zoom out</source>
-      <translation>умањи</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1246"/>
+        <source>File &amp;Info</source>
+        <translation>Информације о &amp;фајлу</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1306"/>
-      <source>&amp;Anti Aliasing</source>
-      <translation>&amp;Омекшавање</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1248"/>
+        <source>Shows the Info Panel</source>
+        <translation>Покажи панел са информацијама</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1308"/>
-      <source>if checked images are smoother</source>
-      <translation>ако су проверене слике равномерније</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1251"/>
+        <source>&amp;Histogram</source>
+        <translation>&amp;Хистограм</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1312"/>
-      <source>&amp;Transparency Pattern</source>
-      <translation>&amp;Узорак провидности</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1253"/>
+        <source>Shows the Histogram Panel</source>
+        <translation>Покажи хистограм панел</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1314"/>
-      <source>if checked, a pattern will be displayed for transparent objects</source>
-      <translation>Ако је означено, узорак је бити приказан за провидне објекте</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1256"/>
+        <source>Image &amp;Notes</source>
+        <translation>Напомене &amp;о слици</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1318"/>
-      <source>&amp;Frameless</source>
-      <translation>&amp;Без оквира</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1258"/>
+        <source>Shows Image Notes</source>
+        <translation>Прикажи напомене слика</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1320"/>
-      <source>shows a frameless window</source>
-      <translation>покажи прозор без оквира</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1261"/>
+        <source>Edit &amp;History</source>
+        <translation>Уреди &amp;историју</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1324"/>
-      <source>New &amp;Tab</source>
-      <translation>Нова &amp;картица</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1262"/>
+        <source>Shows the edit history</source>
+        <translation>Приказује истроију уређивања</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1326"/>
-      <source>Open a new tab</source>
-      <translation>Отвори нову картицу</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1268"/>
+        <source>&amp;Fit Window</source>
+        <translation>&amp;Уклопи прозор</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1328"/>
-      <source>&amp;Close Tab</source>
-      <translation>&amp;Затвори картицу</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1270"/>
+        <source>Fit window to the image</source>
+        <translation>Уклопи прозор слике</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1330"/>
-      <source>Close current tab</source>
-      <translation>Затвори тренутну картицу</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1275"/>
+        <source>Fu&amp;ll Screen</source>
+        <translation>Це&amp;о екран</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1332"/>
-      <source>&amp;Previous Tab</source>
-      <translation>&amp;Претходна картица</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1277"/>
+        <source>Full Screen</source>
+        <translation>Цео екран</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1334"/>
-      <source>Switch to previous tab</source>
-      <translation>Пребаци се на претходну картицу</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1279"/>
+        <source>&amp;Zoom to Fit</source>
+        <translation>&amp;Зумирај да одговара</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1336"/>
-      <source>&amp;Next Tab</source>
-      <translation>&amp;Следећа картица</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1281"/>
+        <source>Shows the initial view (no zooming)</source>
+        <translation>Покажи почетни преглед (без зумирања)</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1338"/>
-      <source>Switch to next tab</source>
-      <translation>Пребаци на следећу картицу</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1283"/>
+        <source>Show &amp;100%</source>
+        <translation>Покажи &amp;100%</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1340"/>
-      <source>&amp;Change Opacity</source>
-      <translation>&amp;Измени провидност</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1285"/>
+        <source>Shows the image at 100%</source>
+        <translation>Покажи слику са 100%</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1342"/>
-      <source>change the window opacity</source>
-      <translation>промени провидност прозора</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1287"/>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1482"/>
+        <source>Zoom &amp;In</source>
+        <translation>Увели&amp;чај</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1344"/>
-      <source>Opacity &amp;Up</source>
-      <translation>Повећај &amp;провидност</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1289"/>
+        <source>zoom in</source>
+        <translation>увећај</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1346"/>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1350"/>
-      <source>changes the window opacity</source>
-      <translation>промени провидност прозора</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1291"/>
+        <source>&amp;Zoom Out</source>
+        <translation>&amp;Умањи</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1348"/>
-      <source>Opacity &amp;Down</source>
-      <translation>Смањи &amp;провидност</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1293"/>
+        <source>zoom out</source>
+        <translation>умањи</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1352"/>
-      <source>To&amp;ggle Opacity</source>
-      <translation>Пре&amp;бацивање провидности</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1295"/>
+        <source>&amp;Anti Aliasing</source>
+        <translation>&amp;Омекшавање</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1354"/>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1441"/>
-      <source>toggle the window opacity</source>
-      <translation>пребацивање провидности прозора</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1297"/>
+        <source>if checked images are smoother</source>
+        <translation>ако су проверене слике равномерније</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1356"/>
-      <source>Lock &amp;Window</source>
-      <translation>Закључај &amp;прозор</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1301"/>
+        <source>&amp;Transparency Pattern</source>
+        <translation>&amp;Узорак провидности</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1358"/>
-      <source>lock the window</source>
-      <translation>закључај прозор</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1303"/>
+        <source>if checked, a pattern will be displayed for transparent objects</source>
+        <translation>Ако је означено, узорак је бити приказан за провидне објекте</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1362"/>
-      <source>&amp;Toggle Slideshow</source>
-      <translation>&amp;Пребаци на слајдове</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1307"/>
+        <source>&amp;Frameless</source>
+        <translation>&amp;Без оквира</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1363"/>
-      <source>Start/Pause the slideshow</source>
-      <translation>Покрени/Паузирај приказ слајдова</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1309"/>
+        <source>shows a frameless window</source>
+        <translation>покажи прозор без оквира</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1366"/>
-      <source>&amp;Pause Movie</source>
-      <translation>&amp;Паузирај видео</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="958"/>
+        <source>New &amp;Tab</source>
+        <translation>Нова &amp;картица</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1367"/>
-      <source>pause the current movie</source>
-      <translation>паузирај тренутни видео</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="960"/>
+        <source>Open a new tab</source>
+        <translation>Отвори нову картицу</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1371"/>
-      <source>P&amp;revious Frame</source>
-      <translation>П&amp;ретходни фрејм</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="962"/>
+        <source>&amp;Close Tab</source>
+        <translation>&amp;Затвори картицу</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1372"/>
-      <source>show previous frame</source>
-      <translation>покажи претходни фрејм</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="964"/>
+        <source>Close current tab</source>
+        <translation>Затвори тренутну картицу</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1374"/>
-      <source>&amp;Next Frame</source>
-      <translation>&amp;Следећи фрејм</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1313"/>
+        <source>F&amp;irst Tab</source>
+        <translation>Прва карт&amp;ица</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1375"/>
-      <source>show next frame</source>
-      <translation>покажи следећи фрејм</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1314"/>
+        <source>Switch to first tab</source>
+        <translation>Пребаци на прву картицу</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1377"/>
-      <source>Show G&amp;PS Coordinates</source>
-      <translation>Покажи Г&amp;ПС координате</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1316"/>
+        <source>&amp;Previous Tab</source>
+        <translation>&amp;Претходна картица</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1378"/>
-      <source>shows the GPS coordinates</source>
-      <translation>покажи ГПС координате</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1318"/>
+        <source>Switch to previous tab</source>
+        <translation>Пребаци се на претходну картицу</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1384"/>
-      <source>Compute &amp;Thumbnails</source>
-      <translation>Стварање &amp;сличица</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1320"/>
+        <source>&amp;Go to Tab</source>
+        <translation>&amp;Иди на картицу</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1385"/>
-      <source>compute all thumbnails of the current folder</source>
-      <translation>стварање свих сличица у тренутној фасцикли</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1321"/>
+        <source>Go to tab by index</source>
+        <translation>Иди на картицу по броју</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1388"/>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1511"/>
-      <source>&amp;Filter</source>
-      <translation>&amp;Филтер</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1323"/>
+        <source>&amp;Next Tab</source>
+        <translation>&amp;Следећа картица</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1393"/>
-      <source>Image &amp;Manipulation</source>
-      <translation>Обрада &amp;слика</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1325"/>
+        <source>Switch to next tab</source>
+        <translation>Пребаци на следећу картицу</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1395"/>
-      <source>modify the current image</source>
-      <translation>измени тренутну слику</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1327"/>
+        <source>La&amp;st Tab</source>
+        <translation>По&amp;следња картица</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1397"/>
-      <source>Export Multipage &amp;TIFF</source>
-      <translation>Извези вишестрани &amp;TIFF</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1328"/>
+        <source>Switch to last tab</source>
+        <translation>Пребаци на последњу картицу</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1398"/>
-      <source>Export TIFF pages to multiple tiff files</source>
-      <translation>Извези TIFF стране у више tiff фајлова</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1330"/>
+        <source>&amp;Change Opacity</source>
+        <translation>&amp;Измени провидност</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1400"/>
-      <source>Extract From Archive</source>
-      <translation>Распакуј из архиве</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1332"/>
+        <source>change the window opacity</source>
+        <translation>промени провидност прозора</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1401"/>
-      <source>Extract images from an archive (%1)</source>
-      <translation>Распакуј слике из архиве (%1)</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1334"/>
+        <source>Opacity &amp;Up</source>
+        <translation>Повећај &amp;провидност</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1404"/>
-      <source>&amp;Mosaic Image</source>
-      <translation>&amp;Мозаик слика</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1336"/>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1340"/>
+        <source>changes the window opacity</source>
+        <translation>промени провидност прозора</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1405"/>
-      <source>Create a Mosaic Image</source>
-      <translation>Креирај мозаик слику</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1338"/>
+        <source>Opacity &amp;Down</source>
+        <translation>Смањи &amp;провидност</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1407"/>
-      <source>Batch Processing</source>
-      <translation>Групно подешавање</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1342"/>
+        <source>To&amp;ggle Opacity</source>
+        <translation>Пре&amp;бацивање провидности</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1408"/>
-      <source>Apply actions to multiple images</source>
-      <translation>Примени радње на више слика</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1344"/>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1430"/>
+        <source>toggle the window opacity</source>
+        <translation>пребацивање провидности прозора</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1413"/>
-      <source>&amp;About Nomacs</source>
-      <translation>&amp;О програму Nomacs</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1346"/>
+        <source>Lock &amp;Window</source>
+        <translation>Закључај &amp;прозор</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1415"/>
-      <source>about</source>
-      <translation>о програму</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1348"/>
+        <source>lock the window</source>
+        <translation>закључај прозор</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1417"/>
-      <source>&amp;Documentation</source>
-      <translation>&amp;Документација</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1352"/>
+        <source>&amp;Toggle Slideshow</source>
+        <translation>&amp;Пребаци на слајдове</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1418"/>
-      <source>Online Documentation</source>
-      <translation>Веб документација</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1353"/>
+        <source>Start/Pause the slideshow</source>
+        <translation>Покрени/Паузирај приказ слајдова</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1420"/>
-      <source>&amp;Report a Bug</source>
-      <translation>&amp;Пријави грешку</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1356"/>
+        <source>&amp;Pause Movie</source>
+        <translation>&amp;Паузирај видео</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1421"/>
-      <source>Report a Bug</source>
-      <translation>Пријави грешку</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1357"/>
+        <source>pause the current movie</source>
+        <translation>паузирај тренутни видео</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1423"/>
-      <source>&amp;Feature Request</source>
-      <translation>&amp;Захтевај могућност</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1361"/>
+        <source>P&amp;revious Frame</source>
+        <translation>П&amp;ретходни фрејм</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1424"/>
-      <source>Feature Request</source>
-      <translation>Захтевај могућност</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1362"/>
+        <source>show previous frame</source>
+        <translation>покажи претходни фрејм</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1426"/>
-      <source>&amp;Check for Updates</source>
-      <translation>&amp;Провери ажурирање</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1364"/>
+        <source>&amp;Next Frame</source>
+        <translation>&amp;Следећи фрејм</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1427"/>
-      <source>check for updates</source>
-      <translation>провери ажурирање</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1365"/>
+        <source>show next frame</source>
+        <translation>покажи следећи фрејм</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1429"/>
-      <source>&amp;Update Translation</source>
-      <translation>&amp;Ажурирај превод</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1367"/>
+        <source>Show G&amp;PS Coordinates</source>
+        <translation>Покажи Г&amp;ПС координате</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1430"/>
-      <source>Checks for a new version of the translations of the current language</source>
-      <translation>Провери за нову верзију превода за тренутни језик</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1368"/>
+        <source>shows the GPS coordinates</source>
+        <translation>покажи ГПС координате</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1434"/>
-      <source>Synchronize &amp;View</source>
-      <translation>Синхронизуј &amp;преглед</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1374"/>
+        <source>Compute &amp;Thumbnails</source>
+        <translation>Стварање &amp;сличица</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1436"/>
-      <source>synchronize the current view</source>
-      <translation>синхронизуј тренутни преглед</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1375"/>
+        <source>compute all thumbnails of the current folder</source>
+        <translation>стварање свих сличица у тренутној фасцикли</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1439"/>
-      <source>&amp;Window Overlay</source>
-      <translation>&amp;Преклапање прозора</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1378"/>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1496"/>
+        <source>&amp;Filter</source>
+        <translation>&amp;Филтер</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1444"/>
-      <source>Arrange Instances</source>
-      <translation>Организуј примере</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1383"/>
+        <source>Export Multipage &amp;TIFF</source>
+        <translation>Извези вишестрани &amp;TIFF</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1446"/>
-      <source>arrange connected instances</source>
-      <translation>организуј повезане примере</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1384"/>
+        <source>Export TIFF pages to multiple tiff files</source>
+        <translation>Извези TIFF стране у више tiff фајлова</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1449"/>
-      <source>Connect &amp;All</source>
-      <translation>Повежи &amp;све</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1386"/>
+        <source>Extract From Archive</source>
+        <translation>Распакуј из архиве</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1452"/>
-      <source>connect all instances</source>
-      <translation>повежи све примере</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1387"/>
+        <source>Extract images from an archive (%1)</source>
+        <translation>Распакуј слике из архиве (%1)</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1454"/>
-      <source>&amp;Sync All Actions</source>
-      <translation>&amp;Синхронизуј све радње</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1390"/>
+        <source>&amp;Mosaic Image</source>
+        <translation>&amp;Мозаик слика</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1455"/>
-      <source>Transmit All Signals Automatically.</source>
-      <translation>Шаљи све сигнале аутоматски.</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1391"/>
+        <source>Create a Mosaic Image</source>
+        <translation>Креирај мозаик слику</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1459"/>
-      <source>&amp;Start Upnp</source>
-      <translation>&amp;Почни Упнп</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1393"/>
+        <source>Batch Processing</source>
+        <translation>Групно подешавање</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1460"/>
-      <source>Starts a Upnp Media Renderer.</source>
-      <translation>Почни Упнп рендер медија.</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1394"/>
+        <source>Apply actions to multiple images</source>
+        <translation>Примени радње на више слика</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1463"/>
-      <source>&amp;Remote Control</source>
-      <translation>&amp;Удаљена контрола</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1405"/>
+        <source>&amp;About Nomacs</source>
+        <translation>&amp;О програму Nomacs</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1465"/>
-      <source>Automatically Receive Images From Your Remote Instance.</source>
-      <translation>Аутоматски прими слике са своје удаљене инстанце.</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1407"/>
+        <source>about</source>
+        <translation>о програму</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1468"/>
-      <source>Remote &amp;Display</source>
-      <translation>Удаљени &amp;екран</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1409"/>
+        <source>&amp;Documentation</source>
+        <translation>&amp;Документација</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1469"/>
-      <source>Automatically Send Images to a Remote Instance.</source>
-      <translation>Аутоматски шаљи слике на удаљену инстанцу.</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1410"/>
+        <source>Online Documentation</source>
+        <translation>Веб документација</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1475"/>
-      <source>Start &amp;Server</source>
-      <translation>Покрени &amp;сервер</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1412"/>
+        <source>&amp;Report a Bug</source>
+        <translation>&amp;Пријави грешку</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1480"/>
-      <source>Send &amp;Image</source>
-      <translation>Пошаљи &amp;слику</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1413"/>
+        <source>Report a Bug</source>
+        <translation>Пријави грешку</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1483"/>
-      <source>Sends the current image to all clients.</source>
-      <translation>Пошаљи тренутну слику за све клијенте.</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1415"/>
+        <source>&amp;Check for Updates</source>
+        <translation>&amp;Провери ажурирање</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1487"/>
-      <source>&amp;Plugin Manager</source>
-      <translation>&amp;Менаџер прикључака</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1416"/>
+        <source>check for updates</source>
+        <translation>провери ажурирање</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1488"/>
-      <source>manage installed plugins and download new ones</source>
-      <translation>управљај инсталираним прикључцима и преузми нови</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1418"/>
+        <source>&amp;Update Translation</source>
+        <translation>&amp;Ажурирај превод</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1493"/>
-      <source>Select &amp;All</source>
-      <translation>Одабери &amp;све</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1419"/>
+        <source>Checks for a new version of the translations of the current language</source>
+        <translation>Провери за нову верзију превода за тренутни језик</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1500"/>
-      <source>Zoom &amp;Out</source>
-      <translation>Ума&amp;њи</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1423"/>
+        <source>Synchronize &amp;View</source>
+        <translation>Синхронизуј &amp;поглед</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1503"/>
-      <source>Display &amp;Squares</source>
-      <translation>Приказ &amp;квадрата</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1425"/>
+        <source>synchronize the current view</source>
+        <translation>синхронизуј тренутни поглед</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1507"/>
-      <source>Show &amp;Filename</source>
-      <translation>Прикажи &amp;име фајла</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1428"/>
+        <source>&amp;Window Overlay</source>
+        <translation>&amp;Преклапање прозора</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1523"/>
-      <source>&amp;Rename</source>
-      <translation>&amp;Преименуј</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1433"/>
+        <source>Arrange Instances</source>
+        <translation>Организуј примере</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1526"/>
-      <source>&amp;Batch Process</source>
-      <translation>&amp;Групна обрада</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1435"/>
+        <source>arrange connected instances</source>
+        <translation>организуј повезане примере</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1527"/>
-      <source>Adds selected files to batch processing.</source>
-      <translation>Додај одабране фајлове у групну обраду.</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1438"/>
+        <source>Connect &amp;All</source>
+        <translation>Повежи &amp;све</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1542"/>
-      <source>Start pong</source>
-      <translation>Покрени понг</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1441"/>
+        <source>connect all instances</source>
+        <translation>повежи све примере</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1545"/>
-      <source>First File</source>
-      <translation>Први фајл</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1443"/>
+        <source>&amp;Sync All Actions</source>
+        <translation>&amp;Синхронизуј све радње</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1546"/>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1562"/>
-      <source>Jump to first file</source>
-      <translation>Пређи на први фајл</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1444"/>
+        <source>Transmit All Signals Automatically.</source>
+        <translation>Шаљи све сигнале аутоматски.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1549"/>
-      <source>Last File</source>
-      <translation>Последњи фајл</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1448"/>
+        <source>&amp;Remote Control</source>
+        <translation>&amp;Удаљена контрола</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1550"/>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1566"/>
-      <source>Jump to the end of the current folder</source>
-      <translation>Пређи на крај ове фасцикле</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1450"/>
+        <source>Automatically Receive Images From Your Remote Instance.</source>
+        <translation>Аутоматски прими слике са своје удаљене инстанце.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1553"/>
-      <source>Skip Previous Images</source>
-      <translation>Прескочи претходне слике</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1453"/>
+        <source>Remote &amp;Display</source>
+        <translation>Удаљени &amp;екран</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1554"/>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1570"/>
-      <source>Jumps 10 images before the current image</source>
-      <translation>Прескочи 10 слика пре тренутне слике</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1454"/>
+        <source>Automatically Send Images to a Remote Instance.</source>
+        <translation>Аутоматски шаљи слике на удаљену инстанцу.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1557"/>
-      <source>Skip Next Images</source>
-      <translation>Прескочи следећу слику</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1460"/>
+        <source>Start &amp;Server</source>
+        <translation>Покрени &amp;сервер</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1558"/>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1574"/>
-      <source>Jumps 10 images after the current image</source>
-      <translation>Прескочи 10 слика после тренутне слике</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1465"/>
+        <source>Send &amp;Image</source>
+        <translation>Пошаљи &amp;слику</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1561"/>
-      <source>First File Sync</source>
-      <translation>Прва синхронизација фајла</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1468"/>
+        <source>Sends the current image to all clients.</source>
+        <translation>Пошаљи тренутну слику за све клијенте.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1565"/>
-      <source>Last File Sync</source>
-      <translation>Последња синхронизација фајла</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1472"/>
+        <source>&amp;Plugin Manager</source>
+        <translation>&amp;Менаџер прикључака</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1569"/>
-      <source>Skip Previous Images Sync</source>
-      <translation>Прескочи претходну синхронизацију</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1473"/>
+        <source>manage installed plugins and download new ones</source>
+        <translation>управљај инсталираним прикључцима и преузми нови</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1573"/>
-      <source>Skip Next Images Sync</source>
-      <translation>Прескочи следећу синхронизацију</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1478"/>
+        <source>Select &amp;All</source>
+        <translation>Одабери &amp;све</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1577"/>
-      <source>Delete File Silent</source>
-      <translation>Уклони фајл без упозорења</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1485"/>
+        <source>Zoom &amp;Out</source>
+        <translation>Ума&amp;њи</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1578"/>
-      <source>Deletes a file without warning</source>
-      <translation>Уклони фајл без упозорења</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1488"/>
+        <source>Display &amp;Squares</source>
+        <translation>Приказ &amp;квадрата</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="407"/>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="888"/>
-      <source>&lt;data too large to display&gt;</source>
-      <translation>&lt;превелики подаци за приказивање&gt;</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1492"/>
+        <source>Show &amp;Filename</source>
+        <translation>Прикажи &amp;име фајла</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="797"/>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="522"/>
-      <source>Filename</source>
-      <translation>Име фајла</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1508"/>
+        <source>&amp;Rename</source>
+        <translation>&amp;Преименуј</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="798"/>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="525"/>
-      <source>Path</source>
-      <translation>Путања</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1511"/>
+        <source>&amp;Batch Process</source>
+        <translation>&amp;Групна обрада</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="529"/>
-      <source>Target</source>
-      <translation>Мета</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1512"/>
+        <source>Adds selected files to batch processing.</source>
+        <translation>Додај одабране фајлове у групну обраду.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="799"/>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="533"/>
-      <source>Size</source>
-      <translation>Величина</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1527"/>
+        <source>Start pong</source>
+        <translation>Покрени понг</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="537"/>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="540"/>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="543"/>
-      <source>Date</source>
-      <translation>Датум</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1530"/>
+        <source>First File</source>
+        <translation>Први фајл</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="537"/>
-      <source>Created</source>
-      <translation>Креирано</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1531"/>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1547"/>
+        <source>Jump to first file</source>
+        <translation>Пређи на први фајл</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="540"/>
-      <source>Last Modified</source>
-      <translation>Последња измена</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1534"/>
+        <source>Last File</source>
+        <translation>Последњи фајл</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="543"/>
-      <source>Last Read</source>
-      <translation>Последње прочитано</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1535"/>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1551"/>
+        <source>Jump to the end of the current folder</source>
+        <translation>Пређи на крај ове фасцикле</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="547"/>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="560"/>
-      <source>Owner</source>
-      <translation>Власник</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1538"/>
+        <source>Skip Previous Images</source>
+        <translation>Прескочи претходне слике</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="551"/>
-      <source>OwnerID</source>
-      <translation>Власнички ИД</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1539"/>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1555"/>
+        <source>Jumps 10 images before the current image</source>
+        <translation>Прескочи 10 слика пре тренутне слике</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="555"/>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="574"/>
-      <source>Group</source>
-      <translation>Група</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1542"/>
+        <source>Skip Next Images</source>
+        <translation>Прескочи следећу слику</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="560"/>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="567"/>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="574"/>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="581"/>
-      <source>Permissions</source>
-      <translation>Дозволе</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1543"/>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1559"/>
+        <source>Jumps 10 images after the current image</source>
+        <translation>Прескочи 10 слика после тренутне слике</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="567"/>
-      <source>User</source>
-      <translation>Корисник</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1546"/>
+        <source>First File Sync</source>
+        <translation>Прва синхронизација фајла</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="581"/>
-      <source>Other</source>
-      <translation>Друго</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1550"/>
+        <source>Last File Sync</source>
+        <translation>Последња синхронизација фајла</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="591"/>
-      <source>File</source>
-      <translation>Фајл</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1554"/>
+        <source>Skip Previous Images Sync</source>
+        <translation>Прескочи претходну синхронизацију</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1485"/>
-      <source>not defined</source>
-      <translation>није одређено</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1558"/>
+        <source>Skip Next Images Sync</source>
+        <translation>Прескочи следећу синхронизацију</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1486"/>
-      <source>manual</source>
-      <translation>ручно</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1562"/>
+        <source>Delete File Silent</source>
+        <translation>Уклони фајл без упозорења</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1487"/>
-      <source>normal</source>
-      <translation>нормално</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1563"/>
+        <source>Deletes a file without warning</source>
+        <translation>Уклони фајл без упозорења</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1488"/>
-      <source>aperture priority</source>
-      <translation>приоритет отвора</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="403"/>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="882"/>
+        <source>&lt;data too large to display&gt;</source>
+        <translation>&lt;превелики подаци за приказивање&gt;</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1489"/>
-      <source>shutter priority</source>
-      <translation>приоритет затварача</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="518"/>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="798"/>
+        <source>Filename</source>
+        <translation>Име фајла</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1490"/>
-      <source>program creative</source>
-      <translation>креативни програм</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="521"/>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="799"/>
+        <source>Path</source>
+        <translation>Путања</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1491"/>
-      <source>high-speed program</source>
-      <translation>брзи програм</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="525"/>
+        <source>Target</source>
+        <translation>Мета</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1492"/>
-      <source>portrait mode</source>
-      <translation>режим портрета</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="529"/>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="800"/>
+        <source>Size</source>
+        <translation>Величина</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1493"/>
-      <source>landscape mode</source>
-      <translation>режим пејзаж</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="533"/>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="536"/>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="539"/>
+        <source>Date</source>
+        <translation>Датум</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1496"/>
-      <source>No Flash</source>
-      <translation>Без блица</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="533"/>
+        <source>Created</source>
+        <translation>Креирано</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1497"/>
-      <source>Fired</source>
-      <translation>Активирано</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="536"/>
+        <source>Last Modified</source>
+        <translation>Последња измена</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1498"/>
-      <source>Fired, Return not detected</source>
-      <translation>Активирано, повратак није детектован</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="539"/>
+        <source>Last Read</source>
+        <translation>Последње прочитано</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1499"/>
-      <source>Fired, Return detected</source>
-      <translation>Активирано, повратак детектован</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="543"/>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="556"/>
+        <source>Owner</source>
+        <translation>Власник</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1500"/>
-      <source>On, Did not fire</source>
-      <translation>Укључено, није активирано</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="547"/>
+        <source>OwnerID</source>
+        <translation>Власнички ИД</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1501"/>
-      <source>On, Fired</source>
-      <translation>Укључено, активирано</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="551"/>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="570"/>
+        <source>Group</source>
+        <translation>Група</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1502"/>
-      <source>On, Return not detected</source>
-      <translation>Укључено, повратак није детектован</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="556"/>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="563"/>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="570"/>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="577"/>
+        <source>Permissions</source>
+        <translation>Дозволе</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1503"/>
-      <source>On, Return detected</source>
-      <translation>Укључено, повратак детектован</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="563"/>
+        <source>User</source>
+        <translation>Корисник</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1504"/>
-      <source>Off, Did not fire</source>
-      <translation>Искључено, није активирано</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="577"/>
+        <source>Other</source>
+        <translation>Друго</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1505"/>
-      <source>Off, Did not fire, Return not detected</source>
-      <translation>Искључено, није активирано, повратак није детектован</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="587"/>
+        <source>File</source>
+        <translation>Фајл</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1506"/>
-      <source>Auto, Did not fire</source>
-      <translation>Ауто, није активирано</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1472"/>
+        <source>not defined</source>
+        <translation>није одређено</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1507"/>
-      <source>Auto, Fired</source>
-      <translation>Ауто, активирано</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1473"/>
+        <source>manual</source>
+        <translation>ручно</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1508"/>
-      <source>Auto, Fired, Return not detected</source>
-      <translation>Ауто, активирано, повратак није детектован</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1474"/>
+        <source>normal</source>
+        <translation>нормално</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1509"/>
-      <source>Auto, Fired, Return detected</source>
-      <translation>Ауто, активирано, повратак детектован</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1475"/>
+        <source>aperture priority</source>
+        <translation>приоритет отвора</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1510"/>
-      <source>No flash function</source>
-      <translation>Блиц искључен</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1476"/>
+        <source>shutter priority</source>
+        <translation>приоритет затварача</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1511"/>
-      <source>Off, No flash function</source>
-      <translation>Искључено, без функције блица</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1477"/>
+        <source>program creative</source>
+        <translation>креативни програм</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1512"/>
-      <source>Fired, Red-eye reduction</source>
-      <translation>Активирано, редукција црвених очију</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1478"/>
+        <source>high-speed program</source>
+        <translation>брзи програм</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1513"/>
-      <source>Fired, Red-eye reduction, Return not detected</source>
-      <translation>Активирано, редукција црвених очију, повратак није детектован</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1479"/>
+        <source>portrait mode</source>
+        <translation>режим портрета</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1514"/>
-      <source>Fired, Red-eye reduction, Return detected</source>
-      <translation>Активирано, редукција црвених очију, повратак детектован</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1480"/>
+        <source>landscape mode</source>
+        <translation>режим пејзаж</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1515"/>
-      <source>On, Red-eye reduction</source>
-      <translation>Укључено, редукција црвених очију</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1483"/>
+        <source>No Flash</source>
+        <translation>Без блица</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1516"/>
-      <source>On, Red-eye reduction, Return not detected</source>
-      <translation>Укључено, редукција црвених очију, повратак није детектован</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1484"/>
+        <source>Fired</source>
+        <translation>Активирано</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1517"/>
-      <source>On, Red-eye reduction, Return detected</source>
-      <translation>Укључено, редукција црвених очију, повратак детектован</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1485"/>
+        <source>Fired, Return not detected</source>
+        <translation>Активирано, повратак није детектован</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1518"/>
-      <source>Off, Red-eye reduction</source>
-      <translation>Искључено, редукција црвених очију</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1486"/>
+        <source>Fired, Return detected</source>
+        <translation>Активирано, повратак детектован</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1519"/>
-      <source>Auto, Did not fire, Red-eye reduction</source>
-      <translation>Ауто, није активирано, редукција црвених очију</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1487"/>
+        <source>On, Did not fire</source>
+        <translation>Укључено, није активирано</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1520"/>
-      <source>Auto, Fired, Red-eye reduction</source>
-      <translation>Ауто, активирано, редукција црвених очију</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1488"/>
+        <source>On, Fired</source>
+        <translation>Укључено, активирано</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1521"/>
-      <source>Auto, Fired, Red-eye reduction, Return not detected</source>
-      <translation>Ауто, активирано, редукција црвених очију, повратак није детектован</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1489"/>
+        <source>On, Return not detected</source>
+        <translation>Укључено, повратак није детектован</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMetaData.cpp" line="1522"/>
-      <source>Auto, Fired, Red-eye reduction, Return detected</source>
-      <translation>Ауто, активирано, редукција црвених очију, повратак детектован</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1490"/>
+        <source>On, Return detected</source>
+        <translation>Укључено, повратак детектован</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkCentralWidget.cpp" line="201"/>
-      <source>New Tab</source>
-      <translation>Нова картица</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1491"/>
+        <source>Off, Did not fire</source>
+        <translation>Искључено, није активирано</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkCentralWidget.cpp" line="204"/>
-      <source>Thumbnail Preview</source>
-      <translation>Преглед сличица</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1492"/>
+        <source>Off, Did not fire, Return not detected</source>
+        <translation>Искључено, није активирано, повратак није детектован</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkCentralWidget.cpp" line="206"/>
-      <source>Settings</source>
-      <translation>Подешавање</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1493"/>
+        <source>Auto, Did not fire</source>
+        <translation>Ауто, није активирано</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkCentralWidget.cpp" line="208"/>
-      <source>Batch</source>
-      <translation>Групна обрада</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1494"/>
+        <source>Auto, Fired</source>
+        <translation>Ауто, активирано</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="90"/>
-      <source>[Resize Batch]</source>
-      <translation>[Групна промена величине]</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1495"/>
+        <source>Auto, Fired, Return not detected</source>
+        <translation>Ауто, активирано, повратак није детектован</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="116"/>
-      <source>%1 scale factor is 1 -&gt; ignoring</source>
-      <translation>%1 фактор скалирања је 1 -&gt; игнорисање</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1496"/>
+        <source>Auto, Fired, Return detected</source>
+        <translation>Ауто, активирано, повратак детектован</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="127"/>
-      <source>%1 no need for resizing.</source>
-      <translation>%1 нема потребе за променом величине.</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1497"/>
+        <source>No flash function</source>
+        <translation>Блиц искључен</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="132"/>
-      <source>%1 could not resize image.</source>
-      <translation>%1 не могу променити величину слике.</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1498"/>
+        <source>Off, No flash function</source>
+        <translation>Искључено, без функције блица</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="137"/>
-      <source>%1 image resized, scale factor: %2%</source>
-      <translation>%1 промењена величина, фактор скалирања: %2%</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1499"/>
+        <source>Fired, Red-eye reduction</source>
+        <translation>Активирано, редукција црвених очију</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="139"/>
-      <source>%1 image resized, new side: %2 px</source>
-      <translation>%1 промењена величина, нова величина: %2 px</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1500"/>
+        <source>Fired, Red-eye reduction, Return not detected</source>
+        <translation>Активирано, редукција црвених очију, повратак није детектован</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="172"/>
-      <source>%1 I need to increase the image, but the option is set to decrease only -&gt; skipping.</source>
-      <translation>%1 Хоћу да повећам слику, али постоји само опција смањивања -&gt; прескочи.</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1501"/>
+        <source>Fired, Red-eye reduction, Return detected</source>
+        <translation>Активирано, редукција црвених очију, повратак детектован</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="176"/>
-      <source>%1 I need to decrease the image, but the option is set to increase only -&gt; skipping.</source>
-      <translation>%1 Хоћу да смањим слику, али постоји само опција повећања -&gt; прескочи.</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1502"/>
+        <source>On, Red-eye reduction</source>
+        <translation>Укључено, редукција црвених очију</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="180"/>
-      <source>%1 image size matches scale factor -&gt; skipping.</source>
-      <translation>%1 величина слике се подудара са фактором скалирања -&gt; прескочи.</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1503"/>
+        <source>On, Red-eye reduction, Return not detected</source>
+        <translation>Укључено, редукција црвених очију, повратак није детектован</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="198"/>
-      <source>[Transform Batch]</source>
-      <translation>[Групна трансформација]</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1504"/>
+        <source>On, Red-eye reduction, Return detected</source>
+        <translation>Укључено, редукција црвених очију, повратак детектован</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="218"/>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="295"/>
-      <source>%1 inactive -&gt; skipping</source>
-      <translation>%1 неактиван -&gt; прескочи</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1505"/>
+        <source>Off, Red-eye reduction</source>
+        <translation>Искључено, редукција црвених очију</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="242"/>
-      <source>%1 image transformed.</source>
-      <translation>%1 слике трансформисане.</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1506"/>
+        <source>Auto, Did not fire, Red-eye reduction</source>
+        <translation>Ауто, није активирано, редукција црвених очију</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="248"/>
-      <source>%1 error, could not transform image.</source>
-      <translation>%1 грешка, не могу трансформисати слику.</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1507"/>
+        <source>Auto, Fired, Red-eye reduction</source>
+        <translation>Ауто, активирано, редукција црвених очију</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="334"/>
-      <source>%1 Cannot apply %2.</source>
-      <translation>%1 не могу прихватити %2.</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1508"/>
+        <source>Auto, Fired, Red-eye reduction, Return not detected</source>
+        <translation>Ауто, активирано, редукција црвених очију, повратак није детектован</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="77"/>
-      <source>Batch Action</source>
-      <translation>Групне радње</translation>
+        <location filename="../src/DkCore/DkMetaData.cpp" line="1509"/>
+        <source>Auto, Fired, Red-eye reduction, Return detected</source>
+        <translation>Ауто, активирано, редукција црвених очију, повратак детектован</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="244"/>
-      <source>%1 image transformed and cropped.</source>
-      <translation>%1 слике је трансформисано и опсечено.</translation>
+        <location filename="../src/DkGui/DkCentralWidget.cpp" line="221"/>
+        <source>New Tab</source>
+        <translation>Нова картица</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="326"/>
-      <source>%1 Cannot cast batch plugin %2.</source>
-      <translation>%1 Не могу да одредим групни прикључак %2.</translation>
+        <location filename="../src/DkGui/DkCentralWidget.cpp" line="224"/>
+        <source>Thumbnail Preview</source>
+        <translation>Преглед сличица</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="337"/>
-      <source>%1 illegal plugin interface: %2</source>
-      <translation>%1 недозвољено сучеље за прикључак: %2</translation>
+        <location filename="../src/DkGui/DkCentralWidget.cpp" line="226"/>
+        <source>Settings</source>
+        <translation>Подешавање</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="340"/>
-      <source>%1 Cannot apply plugin because it is NULL.</source>
-      <translation>%1 Не могу да прихватим прикључак јер је NULL.</translation>
+        <location filename="../src/DkGui/DkCentralWidget.cpp" line="228"/>
+        <source>Batch</source>
+        <translation>Групна обрада</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="344"/>
-      <source>%1 error, could not apply plugins.</source>
-      <translation>%1 грешка, не могу применити прикључке.</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="268"/>
+        <source>%1 image resized, scale factor: %2%</source>
+        <translation>%1 промењена величина, фактор скалирања: %2%</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="348"/>
-      <source>%1 plugins applied.</source>
-      <translation>%1 прикључака примењено.</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="270"/>
+        <source>%1 image resized, new side: %2 px</source>
+        <translation>%1 промењена величина, нова величина: %2 px</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="354"/>
-      <source>[Plugin Batch]</source>
-      <translation>[Групни додаци]</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="310"/>
+        <source>%1 I need to increase the image, but the option is set to decrease only -&gt; skipping.</source>
+        <translation>%1 Хоћу да повећам слику, али постоји само опција смањивања -&gt; прескочи.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="471"/>
-      <source>%1 already exists -&gt; skipping (check 'overwrite' if you want to overwrite the file)</source>
-      <translation>%1 већ постоји -&gt; прескочи (провери 'преписивање' ако желиш да препишеш фајл)</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="314"/>
+        <source>%1 I need to decrease the image, but the option is set to increase only -&gt; skipping.</source>
+        <translation>%1 Хоћу да смањим слику, али постоји само опција повећања -&gt; прескочи.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="476"/>
-      <source>Error: input file does not exist</source>
-      <translation>Грешка: улазни фајл не постоји</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="318"/>
+        <source>%1 image size matches scale factor -&gt; skipping.</source>
+        <translation>%1 величина слике се подудара са фактором скалирања -&gt; прескочи.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="477"/>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="594"/>
-      <source>Input: %1</source>
-      <translation>Улаз: %1</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="126"/>
+        <source>[Transform Batch]</source>
+        <translation>[Групна трансформација]</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="482"/>
-      <source>Skipping: nothing to do here.</source>
-      <translation>Прескочи: нема везе овде.</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="226"/>
+        <location filename="../src/DkCore/DkProcess.cpp" line="359"/>
+        <location filename="../src/DkCore/DkProcess.cpp" line="488"/>
+        <source>%1 inactive -&gt; skipping</source>
+        <translation>%1 неактиван -&gt; прескочи</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="514"/>
-      <source>processing %1</source>
-      <translation>обрађујем %1</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="265"/>
+        <source>%1 image transformed.</source>
+        <translation>%1 слике трансформисане.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="519"/>
-      <source>Error while loading...</source>
-      <translation>Грешка код учитавања...</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="277"/>
+        <source>%1 error, could not transform image.</source>
+        <translation>%1 грешка, не могу трансформисати слику.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="527"/>
-      <source>Error: cannot process a NULL function.</source>
-      <translation>Грешка: не могу обрадити NULL функцију.</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="373"/>
+        <location filename="../src/DkCore/DkProcess.cpp" line="527"/>
+        <source>%1 Cannot apply %2.</source>
+        <translation>%1 не могу прихватити %2.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="533"/>
-      <source>%1 failed</source>
-      <translation>%1 оштећено</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="80"/>
+        <source>Batch Action</source>
+        <translation>Групне радње</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="547"/>
-      <source>%1 saved...</source>
-      <translation>%1 сачувано...</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="262"/>
+        <source>transformed</source>
+        <translation>трансформисано</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="550"/>
-      <source>Could not save: %1</source>
-      <translation>Нисмо могли сачувати: %1</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="273"/>
+        <source>%1 image transformed and cropped.</source>
+        <translation>%1 слике је трансформисано и опсечено.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="565"/>
-      <source>Error: could not rename file, the target file exists already.</source>
-      <translation>Грешка: не могу преименовати фајл, циљани фајл већ постоји.</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="370"/>
+        <source>%1 %2 applied.</source>
+        <translation>%1 %2 примењено.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="573"/>
-      <source>Error: could not rename file</source>
-      <translation>Грешка: не могу преименовати фајл</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="379"/>
+        <source>%1 error, could not apply image adjustments.</source>
+        <translation>%1 грешка, немогуће применити подешавања слике.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="578"/>
-      <source>Renaming: %1 -&gt; %2</source>
-      <translation>Преименовање: %1 -&gt; %2</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="387"/>
+        <source>[Adjustment Batch]</source>
+        <translation>[Групна подешвања]</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="593"/>
-      <source>Error: could not copy file</source>
-      <translation>Грешка: не могу копирати фајл</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="519"/>
+        <source>%1 Cannot cast batch plugin %2.</source>
+        <translation>%1 Не могу да одредим групни прикључак %2.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="595"/>
-      <source>Output: %1</source>
-      <translation>Излаз: %1</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="530"/>
+        <source>%1 illegal plugin interface: %2</source>
+        <translation>%1 недозвољено сучеље за прикључак: %2</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="600"/>
-      <source>Copying: %1 -&gt; %2</source>
-      <translation>Копирање: %1 -&gt; %2</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="533"/>
+        <source>%1 Cannot apply plugin because it is NULL.</source>
+        <translation>%1 Не могу да прихватим прикључак јер је NULL.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="615"/>
-      <source>Error: back-up (%1) file already exists</source>
-      <translation>Грешка, резервна копија (%1)  фајла већ постоји</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="537"/>
+        <source>%1 error, could not apply plugins.</source>
+        <translation>%1 грешка, не могу применити прикључке.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="622"/>
-      <source>Error: could not rename existing file to %1</source>
-      <translation>Грешка: не могу преименовати постојећи фајл у %1</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="541"/>
+        <source>%1 plugins applied.</source>
+        <translation>%1 прикључака примењено.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="640"/>
-      <source>Error: could not delete existing file</source>
-      <translation>Грешка: не могу обрисати постојећи фајл</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="547"/>
+        <source>[Plugin Batch]</source>
+        <translation>[Групни додаци]</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="651"/>
-      <source>Ui - a lot of things went wrong sorry, your original file can be found here: %1</source>
-      <translation>Уј, извињавамо се за више грешака које су се догодиле, ваш оригинални фајл можете наћи овде: %1</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="660"/>
+        <source>%1 already exists -&gt; skipping (check &apos;overwrite&apos; if you want to overwrite the file)</source>
+        <translation>%1 већ постоји -&gt; прескочи (провери &apos;преписивање&apos; ако желиш да препишеш фајл)</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="656"/>
-      <source>I could not save to %1 so I restored the original file.</source>
-      <translation>Није могуће сачувати на %1 па је оригинални фајл враћен.</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="665"/>
+        <source>Error: input file does not exist</source>
+        <translation>Грешка: улазни фајл не постоји</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="672"/>
-      <source>%1 deleted.</source>
-      <translation>%1 уклоњено.</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="666"/>
+        <location filename="../src/DkCore/DkProcess.cpp" line="798"/>
+        <source>Input: %1</source>
+        <translation>Улаз: %1</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="675"/>
-      <source>I could not delete %1</source>
-      <translation>Није могло бити обрисано %1</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="671"/>
+        <source>Skipping: nothing to do here.</source>
+        <translation>Прескочи: нема везе овде.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="680"/>
-      <source>I did not delete the original because I detected %1 failure(s).</source>
-      <translation>Није могао бити обрисан оригинал јер је откривена %1 грешка(е).</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="707"/>
+        <source>processing %1</source>
+        <translation>обрађујем %1</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="932"/>
-      <source>nomacs - Image Lounge is a lightweight image viewer.</source>
-      <translation>nomacs - Салон слика је лагани прегледач слика.</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="712"/>
+        <source>Error while loading...</source>
+        <translation>Грешка код учитавања...</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPong.h" line="88"/>
-      <source>Player 1</source>
-      <translation>Плејер 1</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="720"/>
+        <source>Error: cannot process a NULL function.</source>
+        <translation>Грешка: не могу обрадити NULL функцију.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPong.h" line="89"/>
-      <source>Player 2</source>
-      <translation>Плејер 2</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="726"/>
+        <source>%1 failed</source>
+        <translation>%1 оштећено</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPong.h" line="99"/>
-      <source>Anonymous</source>
-      <translation>Анонимно</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="741"/>
+        <source>%1 not saved - option &apos;Do not Save&apos; is checked...</source>
+        <translation>%1 није сачуван - опција &apos;Немој сачувати&apos; је укључена...</translation>
     </message>
     <message>
-      <location filename="../src/main.cpp" line="121"/>
-      <source>An input image.</source>
-      <translation>Улазна слика.</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="746"/>
+        <source>%1 saved...</source>
+        <translation>%1 сачувано...</translation>
     </message>
     <message>
-      <location filename="../src/main.cpp" line="124"/>
-      <source>Start in fullscreen.</source>
-      <translation>Поккретање на целом екрану.</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="749"/>
+        <source>Could not save: %1</source>
+        <translation>Нисмо могли сачувати: %1</translation>
     </message>
     <message>
-      <location filename="../src/main.cpp" line="127"/>
-      <source>Start Pong.</source>
-      <translation>Покрени Понг.</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="764"/>
+        <source>Error: could not rename file, the target file exists already.</source>
+        <translation>Грешка: не могу преименовати фајл, циљани фајл већ постоји.</translation>
     </message>
     <message>
-      <location filename="../src/main.cpp" line="130"/>
-      <source>Start in private mode.</source>
-      <translation>Покрени у приватном режиму.</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="772"/>
+        <source>Error: could not rename file</source>
+        <translation>Грешка: не могу преименовати фајл</translation>
     </message>
     <message>
-      <location filename="../src/main.cpp" line="134"/>
-      <source>Set the viewing mode &lt;mode&gt;.</source>
-      <translation>Подеси режим прегледа &lt;mode&gt;.</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="777"/>
+        <source>Renaming: %1 -&gt; %2</source>
+        <translation>Преименовање: %1 -&gt; %2</translation>
     </message>
     <message>
-      <location filename="../src/main.cpp" line="135"/>
-      <source>default | frameless | pseudocolor</source>
-      <translation>подразумевано | frameless | pseudocolor</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="787"/>
+        <source>I should copy the file, but &apos;Do not Save&apos; is checked - so I will do nothing...</source>
+        <translation>Захтевано копирање, али је &apos;Немој сачувати&apos; укључено - игноришем...</translation>
     </message>
     <message>
-      <location filename="../src/main.cpp" line="139"/>
-      <source>Load all files of a &lt;directory&gt;.</source>
-      <translation>Учитај све фајлове из &lt;directory&gt;.</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="797"/>
+        <source>Error: could not copy file</source>
+        <translation>Грешка: не могу копирати фајл</translation>
     </message>
     <message>
-      <location filename="../src/main.cpp" line="140"/>
-      <source>directory</source>
-      <translation>фасцикла</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="799"/>
+        <source>Output: %1</source>
+        <translation>Излаз: %1</translation>
     </message>
     <message>
-      <location filename="../src/main.cpp" line="144"/>
-      <source>Load &lt;images&gt; to tabs.</source>
-      <translation>Учитај &lt;images&gt; на картице.</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="804"/>
+        <source>Copying: %1 -&gt; %2</source>
+        <translation>Копирање: %1 -&gt; %2</translation>
     </message>
     <message>
-      <location filename="../src/main.cpp" line="145"/>
-      <source>images</source>
-      <translation>слике</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="817"/>
+        <source>Error: back-up (%1) file already exists</source>
+        <translation>Грешка, резервна копија (%1)  фајла већ постоји</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUtils.cpp" line="636"/>
-      <source>Binary</source>
-      <translation>Бинарни</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="825"/>
+        <source>Error: could not rename existing file to %1</source>
+        <translation>Грешка: не могу преименовати постојећи фајл у %1</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUtils.cpp" line="637"/>
-      <source>Indexed 8-bit</source>
-      <translation>Indeksirani 8-bitni</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="843"/>
+        <source>Error: could not delete existing file</source>
+        <translation>Грешка: не могу обрисати постојећи фајл</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUtils.cpp" line="643"/>
-      <source>RGB 32-bit</source>
-      <translation>RGB 32-bit</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="854"/>
+        <source>Ui - a lot of things went wrong sorry, your original file can be found here: %1</source>
+        <translation>Уј, извињавамо се за више грешака које су се догодиле, ваш оригинални фајл можете наћи овде: %1</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUtils.cpp" line="649"/>
-      <source>ARGB 32-bit</source>
-      <translation>ARGB 32-bit</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="859"/>
+        <source>I could not save to %1 so I restored the original file.</source>
+        <translation>Није могуће сачувати на %1 па је оригинални фајл враћен.</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUtils.cpp" line="652"/>
-      <source>RGB 16-bit</source>
-      <translation>RGB 16-bit</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="875"/>
+        <source>%1 deleted.</source>
+        <translation>%1 уклоњено.</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUtils.cpp" line="655"/>
-      <source>ARGB 24-bit</source>
-      <translation>ARGB 24-bit</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="878"/>
+        <source>I could not delete %1</source>
+        <translation>Није могло бити обрисано %1</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUtils.cpp" line="657"/>
-      <source>RGB 24-bit</source>
-      <translation>RGB 24-bit</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="883"/>
+        <source>I did not delete the original because I detected %1 failure(s).</source>
+        <translation>Није могао бити обрисан оригинал јер је откривена %1 грешка(е).</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUtils.cpp" line="658"/>
-      <source>ARGB 16-bit</source>
-      <translation>ARGB 16-bit</translation>
+        <location filename="../src/DkCore/DkSettings.cpp" line="1027"/>
+        <source>nomacs - Image Lounge is a lightweight image viewer.</source>
+        <translation>nomacs - Салон слика је лагани прегледач слика.</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUtils.cpp" line="661"/>
-      <source>BGR 32-bit</source>
-      <translation>BGR 32-bit</translation>
+        <location filename="../src/DkGui/DkPong.h" line="88"/>
+        <source>Player 1</source>
+        <translation>Плејер 1</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUtils.cpp" line="662"/>
-      <source>ABGR 32-bit</source>
-      <translation>ABGR 32-bit</translation>
+        <location filename="../src/DkGui/DkPong.h" line="89"/>
+        <source>Player 2</source>
+        <translation>Плејер 2</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUtils.cpp" line="663"/>
-      <source>Grayscale 8-bit</source>
-      <translation>U sivim tonovima 8-bitni</translation>
+        <location filename="../src/DkGui/DkPong.h" line="99"/>
+        <source>Anonymous</source>
+        <translation>Анонимно</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUtils.cpp" line="664"/>
-      <source>Alpha 8-bit</source>
-      <translation>Алфа 8-битни</translation>
+        <location filename="../src/main.cpp" line="118"/>
+        <source>An input image.</source>
+        <translation>Улазна слика.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageContainer.cpp" line="142"/>
-      <source>Cropped</source>
-      <translation>Опсечено</translation>
+        <location filename="../src/main.cpp" line="121"/>
+        <source>Start in fullscreen.</source>
+        <translation>Поккретање на целом екрану.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkPluginManager.cpp" line="1094"/>
-      <source>Plugin Manager</source>
-      <translation>Менаџер прикључака</translation>
+        <location filename="../src/main.cpp" line="124"/>
+        <source>Start Pong.</source>
+        <translation>Покрени Понг.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkPluginManager.cpp" line="1094"/>
-      <source>The dll could not be deleted!
+        <location filename="../src/main.cpp" line="127"/>
+        <source>Start in private mode.</source>
+        <translation>Покрени у приватном режиму.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="131"/>
+        <source>Set the viewing mode &lt;mode&gt;.</source>
+        <translation>Подеси режим прегледа &lt;mode&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="132"/>
+        <source>default | frameless | pseudocolor</source>
+        <translation>подразумевано | frameless | pseudocolor</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="136"/>
+        <source>Load all files of a &lt;directory&gt;.</source>
+        <translation>Учитај све фајлове из &lt;directory&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="137"/>
+        <source>directory</source>
+        <translation>фасцикла</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="141"/>
+        <source>Load &lt;images&gt; to tabs.</source>
+        <translation>Учитај &lt;images&gt; на картице.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="142"/>
+        <source>images</source>
+        <translation>слике</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="146"/>
+        <source>Batch processing of &lt;batch-settings.pnm&gt;.</source>
+        <translation>Групно процесовање &lt;batch-settings.pnm&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="147"/>
+        <source>batch-settings-path</source>
+        <translation>путања групног подешавања</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="151"/>
+        <source>Saves batch log to &lt;log-path.txt&gt;.</source>
+        <translation>Сачува запис групног подешавања у &lt;log-path.txt&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="152"/>
+        <source>log-path.txt</source>
+        <translation>путања-записа.txt</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="156"/>
+        <source>Imports the settings from &lt;settings-path.nfo&gt; and saves them.</source>
+        <translation>Уноси поставке из &lt;settings-path.nfo&gt; и сачува их.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="157"/>
+        <source>settings-path.nfo</source>
+        <translation>поставке-путања.nfo</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="299"/>
+        <source>Critical Error</source>
+        <translation>Критична грешка</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="300"/>
+        <source>Sorry, nomacs ran out of memory...</source>
+        <translation>Жао нам је, nomacs је остао без меморије...</translation>
+    </message>
+    <message>
+        <location filename="../src/DkCore/DkUtils.cpp" line="772"/>
+        <source>Binary</source>
+        <translation>Бинарни</translation>
+    </message>
+    <message>
+        <location filename="../src/DkCore/DkUtils.cpp" line="773"/>
+        <source>Indexed 8-bit</source>
+        <translation>Indeksirani 8-bitni</translation>
+    </message>
+    <message>
+        <location filename="../src/DkCore/DkUtils.cpp" line="779"/>
+        <source>RGB 32-bit</source>
+        <translation>RGB 32-bit</translation>
+    </message>
+    <message>
+        <location filename="../src/DkCore/DkUtils.cpp" line="785"/>
+        <source>ARGB 32-bit</source>
+        <translation>ARGB 32-bit</translation>
+    </message>
+    <message>
+        <location filename="../src/DkCore/DkUtils.cpp" line="788"/>
+        <source>RGB 16-bit</source>
+        <translation>RGB 16-bit</translation>
+    </message>
+    <message>
+        <location filename="../src/DkCore/DkUtils.cpp" line="791"/>
+        <source>ARGB 24-bit</source>
+        <translation>ARGB 24-bit</translation>
+    </message>
+    <message>
+        <location filename="../src/DkCore/DkUtils.cpp" line="793"/>
+        <source>RGB 24-bit</source>
+        <translation>RGB 24-bit</translation>
+    </message>
+    <message>
+        <location filename="../src/DkCore/DkUtils.cpp" line="794"/>
+        <source>ARGB 16-bit</source>
+        <translation>ARGB 16-bit</translation>
+    </message>
+    <message>
+        <location filename="../src/DkCore/DkUtils.cpp" line="797"/>
+        <source>BGR 32-bit</source>
+        <translation>BGR 32-bit</translation>
+    </message>
+    <message>
+        <location filename="../src/DkCore/DkUtils.cpp" line="798"/>
+        <source>ABGR 32-bit</source>
+        <translation>ABGR 32-bit</translation>
+    </message>
+    <message>
+        <location filename="../src/DkCore/DkUtils.cpp" line="799"/>
+        <source>Grayscale 8-bit</source>
+        <translation>U sivim tonovima 8-bitni</translation>
+    </message>
+    <message>
+        <location filename="../src/DkCore/DkUtils.cpp" line="800"/>
+        <source>Alpha 8-bit</source>
+        <translation>Алфа 8-битни</translation>
+    </message>
+    <message>
+        <location filename="../src/DkCore/DkImageContainer.cpp" line="141"/>
+        <source>Cropped</source>
+        <translation>Опсечено</translation>
+    </message>
+    <message>
+        <location filename="../src/DkCore/DkPluginManager.cpp" line="1101"/>
+        <source>Plugin Manager</source>
+        <translation>Менаџер прикључака</translation>
+    </message>
+    <message>
+        <location filename="../src/DkCore/DkPluginManager.cpp" line="1102"/>
+        <source>The dll could not be deleted!
 Please restart nomacs and try again.</source>
-      <translation>Не могу уклонити dll!
+        <translation>Не могу уклонити dll!
 Молим поново покрените nomacs и пробајте поново.</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkPluginManager.cpp" line="1241"/>
-      <source>Close plugin</source>
-      <translation>Затвори прикључак</translation>
+        <location filename="../src/DkCore/DkPluginManager.cpp" line="1276"/>
+        <source>Close plugin</source>
+        <translation>Затвори прикључак</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkPluginManager.cpp" line="1243"/>
-      <source>Please close the currently opened plugin.</source>
-      <translation>Молим затворите тренутно отворене прикључке.</translation>
+        <location filename="../src/DkCore/DkPluginManager.cpp" line="1278"/>
+        <source>Please close the currently opened plugin.</source>
+        <translation>Молим затворите тренутно отворене прикључке.</translation>
     </message>
-  </context>
-  <context>
+    <message>
+        <location filename="../src/DkCore/DkManipulatorsIpl.cpp" line="54"/>
+        <source>Could not convert to grayscale</source>
+        <translation>Неуспело конвертовање у црно-бело</translation>
+    </message>
+    <message>
+        <location filename="../src/DkCore/DkManipulatorsIpl.cpp" line="71"/>
+        <source>Cannot auto adjust</source>
+        <translation>Немогуће аутоматско прилагођавање</translation>
+    </message>
+    <message>
+        <location filename="../src/DkCore/DkManipulatorsIpl.cpp" line="89"/>
+        <source>The Image is Already Normalized...</source>
+        <translation>Слика је већ нормализована...</translation>
+    </message>
+    <message>
+        <location filename="../src/DkCore/DkManipulatorsIpl.cpp" line="104"/>
+        <source>Cannot invert image</source>
+        <translation>Немогуће обрнути слику</translation>
+    </message>
+    <message>
+        <location filename="../src/DkCore/DkManipulatorsIpl.cpp" line="117"/>
+        <location filename="../src/DkCore/DkManipulatorsIpl.cpp" line="129"/>
+        <source>Cannot flip image</source>
+        <translation>Немогуће преврнути слику</translation>
+    </message>
+    <message>
+        <location filename="../src/DkCore/DkManipulatorsIpl.cpp" line="151"/>
+        <source>Sorry, I could not create a tiny planet</source>
+        <translation>Жао нам је, не може се направити мала планета</translation>
+    </message>
+    <message>
+        <location filename="../src/DkCore/DkManipulatorsIpl.cpp" line="205"/>
+        <source>Cannot sharpen image</source>
+        <translation>Немогуче изоштрити слику</translation>
+    </message>
+    <message>
+        <location filename="../src/DkCore/DkManipulatorsIpl.cpp" line="243"/>
+        <source>Cannot rotate image</source>
+        <translation>Немогуће ротирати слику</translation>
+    </message>
+    <message>
+        <location filename="../src/DkCore/DkManipulatorsIpl.cpp" line="269"/>
+        <source>Cannot threshold image</source>
+        <translation>Немогуће примјенити праг на слику</translation>
+    </message>
+    <message>
+        <location filename="../src/DkCore/DkManipulatorsIpl.cpp" line="307"/>
+        <source>Cannot change Hue/Saturation</source>
+        <translation>Немогуће применити нијансу/засићење</translation>
+    </message>
+    <message>
+        <location filename="../src/DkCore/DkManipulatorsIpl.cpp" line="357"/>
+        <source>Cannot apply exposure</source>
+        <translation>Немогуће применити експозицију</translation>
+    </message>
+</context>
+<context>
     <name>QObject::QObject</name>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1533"/>
-      <source>Lena</source>
-      <translation>Лена</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1518"/>
+        <source>Lena</source>
+        <translation>Лена</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1534"/>
-      <source>Show test image</source>
-      <translation>Прикажи тест слику</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1519"/>
+        <source>Show test image</source>
+        <translation>Прикажи тест слику</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1537"/>
-      <source>All Images</source>
-      <translation>Све слике</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1522"/>
+        <source>All Images</source>
+        <translation>Све слике</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1538"/>
-      <source>Generates all images in the world</source>
-      <translation>Генериши све слике у свету</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1523"/>
+        <source>Generates all images in the world</source>
+        <translation>Генериши све слике у свету</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkActionManager.cpp" line="1541"/>
-      <source>Pong</source>
-      <translation>Понг</translation>
+        <location filename="../src/DkCore/DkActionManager.cpp" line="1526"/>
+        <source>Pong</source>
+        <translation>Понг</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkAdvancedPreference</name>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1138"/>
-      <source>Always Load JPG if Embedded</source>
-      <translation>Увек учитај JPG ако је уграђен</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1228"/>
+        <source>Always Load JPG if Embedded</source>
+        <translation>Увек учитај JPG ако је уметнут</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1139"/>
-      <source>Load JPG if it Fits the Screen Resolution</source>
-      <translation>Учитај JPG ако се уклапа у резолуцију екрана</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1229"/>
+        <source>Load JPG if it Fits the Screen Resolution</source>
+        <translation>Учитај JPG ако се уклапа у резолуцију екрана</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1140"/>
-      <source>Always Load RAW Data</source>
-      <translation>Увек учитај RAW податке</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1230"/>
+        <source>Always Load RAW Data</source>
+        <translation>Увек учитај RAW податке</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1151"/>
-      <source>Apply Noise Filtering to RAW Images</source>
-      <translation>Примени филтрирање за RAW слике</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1241"/>
+        <source>Apply Noise Filtering to RAW Images</source>
+        <translation>Примени филтрирање за RAW слике</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1153"/>
-      <source>If checked, a noise filter is applied which reduced color noise</source>
-      <translation>Ако је означено, филтер је примењен да смањи интензитет боја</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1243"/>
+        <source>If checked, a noise filter is applied which reduced color noise</source>
+        <translation>Ако је означено, филтер је примењен да смањи интензитет боја</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1156"/>
-      <source>RAW Loader Settings</source>
-      <translation>Подешавање RAW учитавања</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1246"/>
+        <source>RAW Loader Settings</source>
+        <translation>Подешавање RAW учитавања</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1164"/>
-      <source>Ask to Save Deleted Files</source>
-      <translation>Питај за чување обрисаних фајлова</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1254"/>
+        <source>Ask to Save Deleted Files</source>
+        <translation>Питај за чување обрисаних фајлова</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1166"/>
-      <source>If checked, nomacs asked to save files which were deleted by other applications</source>
-      <translation>Ако је означено, nomacs је питао да сачува фајлове који су обрисани од стране других апликација</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1256"/>
+        <source>If checked, nomacs asked to save files which were deleted by other applications</source>
+        <translation>Ако је означено, nomacs је питао да сачува фајлове који су обрисани од стране других апликација</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1169"/>
-      <source>Ignore Exif Orientation when Loading</source>
-      <translation>Занемари Exif положај код учитавања</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1259"/>
+        <source>Ignore Exif Orientation when Loading</source>
+        <translation>Занемари Exif положај код учитавања</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1171"/>
-      <source>If checked, images are NOT rotated with respect to their Exif orientation</source>
-      <translation>Ако је означено, слике се НЕ ротирају у односу на њихов Exif положај</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1261"/>
+        <source>If checked, images are NOT rotated with respect to their Exif orientation</source>
+        <translation>Ако је означено, слике се НЕ ротирају у односу на њихов Exif положај</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1174"/>
-      <source>Save Exif Orientation</source>
-      <translation>Сачувај Exif положај</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1264"/>
+        <source>Save Exif Orientation</source>
+        <translation>Сачувај Exif положај</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1176"/>
-      <source>If checked, orientation is written to the Exif rather than rotating the image Matrix
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1266"/>
+        <source>If checked, orientation is written to the Exif rather than rotating the image Matrix
 </source>
-      <translation>Ако је означено, положај је записан у Exif уместо да ротира слику Matrix
+        <translation>Ако је означено, положај је записан у Exif уместо да ротира слику Matrix
 </translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1177"/>
-      <source>NOTE: this allows for rotating JPGs without losing information.</source>
-      <translation>НАПОМЕНА: ово омогућава ротирање ЈПГ слика без губљења информација.</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1267"/>
+        <source>NOTE: this allows for rotating JPGs without losing information.</source>
+        <translation>НАПОМЕНА: ово омогућава ротирање ЈПГ слика без губљења информација.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1180"/>
-      <source>File Loading/Saving</source>
-      <translation>Фајл учитавање/чување</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1270"/>
+        <source>File Loading/Saving</source>
+        <translation>Фајл учитавање/чување</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1188"/>
-      <source>Choose the number of Threads in the thread pool</source>
-      <translation>Одаберите број нити у укупном фонду</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1278"/>
+        <source>Choose the number of Threads in the thread pool</source>
+        <translation>Одаберите број нити у укупном фонду</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1193"/>
-      <source>Number of Threads</source>
-      <translation>Број нити</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1283"/>
+        <source>Number of Threads</source>
+        <translation>Број нити</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1197"/>
-      <source>Use Log File</source>
-      <translation>Користи лог фајл</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1287"/>
+        <source>Use Log File</source>
+        <translation>Користи фајл записа</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1199"/>
-      <source>If checked, a log file will be created.</source>
-      <translation>Ако означите, лог фајл је бити креиран.</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1289"/>
+        <source>If checked, a log file will be created.</source>
+        <translation>Ако је означено, фајл са записом ће бити креиран.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1202"/>
-      <source>Open Log</source>
-      <translation>Отвори запис</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1292"/>
+        <source>Open Log</source>
+        <translation>Отвори запис</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1210"/>
-      <source>Logging</source>
-      <translation>Вођење записа</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1300"/>
+        <source>Logging</source>
+        <translation>Вођење записа</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1256"/>
-      <source>Please Restart nomacs to apply changes</source>
-      <translation>Молим поново покрените nomacs да би применили промене</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1346"/>
+        <source>Please Restart nomacs to apply changes</source>
+        <translation>Молим поново покрените nomacs да би применили промене</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkAppManagerDialog</name>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="434"/>
-      <source>Manage Applications</source>
-      <translation>Управљање апликацијама</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="464"/>
+        <source>Manage Applications</source>
+        <translation>Управљање апликацијама</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="457"/>
-      <source>&amp;Run</source>
-      <translation>&amp;Покрени</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="487"/>
+        <source>&amp;Run</source>
+        <translation>&amp;Покрени</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="460"/>
-      <source>&amp;Add</source>
-      <translation>&amp;Додај</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="490"/>
+        <source>&amp;Add</source>
+        <translation>&amp;Додај</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="463"/>
-      <source>&amp;Delete</source>
-      <translation>&amp;Уклони</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="493"/>
+        <source>&amp;Delete</source>
+        <translation>&amp;Уклони</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="469"/>
-      <source>&amp;OK</source>
-      <translation>&amp;У реду</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="499"/>
+        <source>&amp;OK</source>
+        <translation>&amp;У реду</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="470"/>
-      <source>&amp;Cancel</source>
-      <translation>&amp;Откажи</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="500"/>
+        <source>&amp;Cancel</source>
+        <translation>&amp;Откажи</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="502"/>
-      <source>Executable Files (*.exe);;</source>
-      <translation>Извршни фајлови (*.exe);;</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="532"/>
+        <source>Executable Files (*.exe);;</source>
+        <translation>Извршни фајлови (*.exe);;</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="510"/>
-      <source>Open Application</source>
-      <translation>Отвори апликацију</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="540"/>
+        <source>Open Application</source>
+        <translation>Отвори апликацију</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkArchiveExtractionDialog</name>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4275"/>
-      <source>Extract images from an archive</source>
-      <translation>Распакуј слике из архиве</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3926"/>
+        <source>Extract images from an archive</source>
+        <translation>Распакуј слике из архиве</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4284"/>
-      <source>Archive (%1)</source>
-      <translation>Архива (%1)</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3935"/>
+        <source>Archive (%1)</source>
+        <translation>Архива (%1)</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4291"/>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4300"/>
-      <source>&amp;Browse</source>
-      <translation>&amp;Претрага</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3942"/>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3951"/>
+        <source>&amp;Browse</source>
+        <translation>&amp;Претрага</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4295"/>
-      <source>Extract to</source>
-      <translation>Распакуј у</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3946"/>
+        <source>Extract to</source>
+        <translation>Распакуј у</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4308"/>
-      <source>Remove Subfolders</source>
-      <translation>Обриши подфасциклу</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3959"/>
+        <source>Remove Subfolders</source>
+        <translation>Обриши подфасциклу</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4314"/>
-      <source>&amp;Extract</source>
-      <translation>&amp;Распакуј</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3965"/>
+        <source>&amp;Extract</source>
+        <translation>&amp;Распакуј</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4316"/>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4537"/>
-      <source>&amp;Cancel</source>
-      <translation>&amp;Откажи</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3967"/>
+        <location filename="../src/DkGui/DkDialog.cpp" line="4188"/>
+        <source>&amp;Cancel</source>
+        <translation>&amp;Откажи</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4395"/>
-      <source>Open Archive</source>
-      <translation>Отвори архиву</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="4046"/>
+        <source>Open Archive</source>
+        <translation>Отвори архиву</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4396"/>
-      <source>Archives (%1)</source>
-      <translation>Архиве (%1)</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="4047"/>
+        <source>Archives (%1)</source>
+        <translation>Архиве (%1)</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4407"/>
-      <source>Open Directory</source>
-      <translation>Отвори фасциклу</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="4058"/>
+        <source>Open Directory</source>
+        <translation>Отвори фасциклу</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4441"/>
-      <source>Not a valid archive.</source>
-      <translation>Архива није исправна.</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="4092"/>
+        <source>Not a valid archive.</source>
+        <translation>Архива није исправна.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4470"/>
-      <source>Number of images: </source>
-      <translation>Број слика: </translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="4121"/>
+        <source>Number of images: </source>
+        <translation>Број слика: </translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4472"/>
-      <source>The archive does not contain any images.</source>
-      <translation>Архива не садржи ниједну слику.</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="4123"/>
+        <source>The archive does not contain any images.</source>
+        <translation>Архива не садржи ниједну слику.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4497"/>
-      <source>The images could not be extracted!</source>
-      <translation>Слике није могуће распаковати!</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="4148"/>
+        <source>The images could not be extracted!</source>
+        <translation>Слике није могуће распаковати!</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4539"/>
-      <source>Extracting files...</source>
-      <translation>Распакивање фајлова...</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="4190"/>
+        <source>Extracting files...</source>
+        <translation>Распакивање фајлова...</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4548"/>
-      <source>Extracting file %1 of %2</source>
-      <translation>Распакивање фајла %1 од %2</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="4199"/>
+        <source>Extracting file %1 of %2</source>
+        <translation>Распакивање фајла %1 од %2</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkBasicLoader</name>
     <message>
-      <location filename="../src/DkLoader/DkBasicLoader.cpp" line="312"/>
-      <location filename="../src/DkLoader/DkBasicLoader.cpp" line="1044"/>
-      <source>Original Image</source>
-      <translation>Оригинална слика</translation>
+        <location filename="../src/DkCore/DkBasicLoader.cpp" line="301"/>
+        <location filename="../src/DkCore/DkBasicLoader.cpp" line="678"/>
+        <source>Original Image</source>
+        <translation>Оригинална слика</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkBasicLoader.cpp" line="1176"/>
-      <source>Sorry, I could not save: %1</source>
-      <translation>Извините, није било могуће сачувати: %1</translation>
+        <location filename="../src/DkCore/DkBasicLoader.cpp" line="824"/>
+        <source>Sorry, I could not save: %1</source>
+        <translation>Извините, није било могуће сачувати: %1</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
+    <name>nmc::DkBatchButtonsWidget</name>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2196"/>
+        <source>Start/Cancel Batch Processing (%1)</source>
+        <translation>Почни/откажи групну обраду (%1)</translation>
+    </message>
+</context>
+<context>
+    <name>nmc::DkBatchInput</name>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="339"/>
+        <source>File Explorer</source>
+        <translation>Претраживач</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="351"/>
+        <source>Thumbnails</source>
+        <translation>Сличице</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="352"/>
+        <source>File List</source>
+        <translation>Фајл листа</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="402"/>
+        <source>Open an Image Directory</source>
+        <translation>Отвори фасциклу са сликама</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="466"/>
+        <source>No Files Selected</source>
+        <translation>Без одабраних фајлова</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="468"/>
+        <source>%1 File Selected</source>
+        <translation>%1 Одабран фајл</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="470"/>
+        <source>%1 Files Selected</source>
+        <translation>%1 Одабрани фајлови</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="491"/>
+        <location filename="../src/DkGui/DkBatch.cpp" line="505"/>
+        <source>Results</source>
+        <translation>Резултати</translation>
+    </message>
+</context>
+<context>
+    <name>nmc::DkBatchManipulatorWidget</name>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1727"/>
+        <source>Select Image Adjustments</source>
+        <translation>Изабери подешавања слике</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1942"/>
+        <source>inactive</source>
+        <translation>неактиван</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1944"/>
+        <source>%1 manipulators selected</source>
+        <translation>%1 манипулатор одабран</translation>
+    </message>
+</context>
+<context>
     <name>nmc::DkBatchOutput</name>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="685"/>
-      <source>Output Directory</source>
-      <translation>Излазна фасцикла</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="733"/>
+        <source>Output Directory</source>
+        <translation>Излазна фасцикла</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="687"/>
-      <source>Browse</source>
-      <translation>Погледајте</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="736"/>
+        <source>Browse</source>
+        <translation>Погледајте</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="689"/>
-      <source>Select a Directory</source>
-      <translation>Одабери фасциклу</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="738"/>
+        <source>Select a Directory</source>
+        <translation>Одабери фасциклу</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="694"/>
-      <source>Overwrite Existing Files</source>
-      <translation>Препиши постојеће фајлове</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="743"/>
+        <source>Overwrite Existing Files</source>
+        <translation>Препиши постојеће фајлове</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="695"/>
-      <source>If checked, existing files are overwritten.
+        <location filename="../src/DkGui/DkBatch.cpp" line="744"/>
+        <source>If checked, existing files are overwritten.
 This option might destroy your images - so be careful!</source>
-      <translation>Ако је означено, пише преко постојећих фајлова.
+        <translation>Ако је означено, пише преко постојећих фајлова.
 Ова поставка може уништити ваше слике - будите пажљиви!</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="699"/>
-      <source>Use Input Folder</source>
-      <translation>Користи улазну фасциклу</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="748"/>
+        <source>Do not Save Output Images</source>
+        <translation>Немој сачувати излазне слике</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="700"/>
-      <source>If checked, the batch is applied to the input folder - so be careful!</source>
-      <translation>Ако је означено, измене се пишу у улазну фасциклу - будите опрезни!</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="749"/>
+        <source>If checked, output images are not saved at all.
+This option is only useful if plugins save sidecar files - so be careful!</source>
+        <translation>Ако је укључено, излазне слике неће бити никако сачуване.
+Ова опција је једино корисна ако додаци сачувају споредне фајлове - будите опрезни!</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="704"/>
-      <source>Delete Input Files</source>
-      <translation>Обриши улазне фајлове</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="753"/>
+        <source>Use Input Folder</source>
+        <translation>Користи улазну фасциклу</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="705"/>
-      <source>If checked, the original file will be deleted if the conversion was successful.
+        <location filename="../src/DkGui/DkBatch.cpp" line="754"/>
+        <source>If checked, the batch is applied to the input folder - so be careful!</source>
+        <translation>Ако је означено, измене се пишу у улазну фасциклу - будите опрезни!</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="758"/>
+        <source>Delete Input Files</source>
+        <translation>Обриши улазне фајлове</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="759"/>
+        <source>If checked, the original file will be deleted if the conversion was successful.
  So be careful!</source>
-      <translation>Ако је означено, оригинални фајл ће бити избрисан ако је конверзија успешна.
+        <translation>Ако је означено, оригинални фајл ће бити избрисан ако је конверзија успешна.
 Будите опрезни!</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="723"/>
-      <source>Filename</source>
-      <translation>Име фајла</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="777"/>
+        <source>Filename</source>
+        <translation>Име фајла</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="740"/>
-      <source>Keep Extension</source>
-      <translation>Задржи проширења</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="798"/>
+        <source>Keep Extension</source>
+        <translation>Задржи проширења</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="741"/>
-      <source>Convert To</source>
-      <translation>Конвертуј у</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="799"/>
+        <source>Convert To</source>
+        <translation>Конвертуј у</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="749"/>
-      <source>Compression</source>
-      <translation>Компресија</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="808"/>
+        <source>Quality</source>
+        <translation>Квалитет</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="764"/>
-      <source>Old: </source>
-      <translation>Старо: </translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="822"/>
+        <source>Preview</source>
+        <translation>Преглед</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="767"/>
-      <source>New: </source>
-      <translation>Ново: </translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="825"/>
+        <source>Old Filename: </source>
+        <translation>Старо име фајла: </translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="772"/>
-      <source>Filename Preview</source>
-      <translation>Преглед фајла</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="830"/>
+        <source>New Filename: </source>
+        <translation>Ново име фајла: </translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="796"/>
-      <source>Open an Image Directory</source>
-      <translation>Отвори фасциклу са сликама</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="863"/>
+        <source>Open an Image Directory</source>
+        <translation>Отвори фасциклу са сликама</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkBatchPluginWidget</name>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1081"/>
-      <source>Sorry, no Plugins found.</source>
-      <translation>Извини, прикључци нису пронађени.</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1466"/>
+        <source>Select Plugins</source>
+        <translation>Изабери прикључке</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1085"/>
-      <source>Drag Plugin Actions here.</source>
-      <translation>Пренеси акције прикључка овде.</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1636"/>
+        <source> Settings</source>
+        <translation> Поставке</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1118"/>
-      <source>inactive</source>
-      <translation>неактиван</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1711"/>
+        <source>inactive</source>
+        <translation>неактиван</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1120"/>
-      <source>%1 plugins selected</source>
-      <translation>%1 прикључака изабрано</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1713"/>
+        <source>%1 plugins selected</source>
+        <translation>%1 прикључака изабрано</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkBatchProcessing</name>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="863"/>
-      <source>[OK]</source>
-      <translation>[У РЕДУ]</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="1149"/>
+        <source>[OK]</source>
+        <translation>[У РЕДУ]</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkProcess.cpp" line="865"/>
-      <source>[FAIL]</source>
-      <translation>[ГРЕШКА]</translation>
+        <location filename="../src/DkCore/DkProcess.cpp" line="1151"/>
+        <source>[FAIL]</source>
+        <translation>[ГРЕШКА]</translation>
     </message>
-  </context>
-  <context>
-    <name>nmc::DkBatchResizeWidget</name>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="969"/>
-      <source>Percent</source>
-      <translation>Проценат</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="969"/>
-      <source>Long Side</source>
-      <translation>Дуга страна</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="969"/>
-      <source>Short Side</source>
-      <translation>Краћа страна</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="969"/>
-      <source>Width</source>
-      <translation>Ширина</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="969"/>
-      <source>Height</source>
-      <translation>Висина</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="974"/>
-      <source>Transform All</source>
-      <translation>Трансформиши све</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="974"/>
-      <source>Shrink Only</source>
-      <translation>Само скупи</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="974"/>
-      <source>Enlarge Only</source>
-      <translation>Само прошири</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="978"/>
-      <source>%</source>
-      <translation>%</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="984"/>
-      <source> px</source>
-      <translation> px</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1022"/>
-      <source>inactive</source>
-      <translation>неактиван</translation>
-    </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkBatchTransformWidget</name>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1134"/>
-      <source>Do &amp;Not Rotate</source>
-      <translation>Не &amp;ротирај</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1958"/>
+        <source>Resize</source>
+        <translation>Промени величину</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1136"/>
-      <source>90%1 Counter Clockwise</source>
-      <translation>90%1 супротно казаљци на сату</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1963"/>
+        <source>Percent</source>
+        <translation>Проценат</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1137"/>
-      <source>90%1 Clockwise</source>
-      <translation>90%1 у смеру казаљке на сату</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1963"/>
+        <source>Long Side</source>
+        <translation>Дуга страна</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1138"/>
-      <source>180%1</source>
-      <translation>180%1</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1963"/>
+        <source>Short Side</source>
+        <translation>Краћа страна</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1147"/>
-      <source>Flip &amp;Horizontal</source>
-      <translation>Окрени &amp;водоравно</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1963"/>
+        <source>Width</source>
+        <translation>Ширина</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1148"/>
-      <source>Flip &amp;Vertical</source>
-      <translation>Окрени &amp;усправно</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1963"/>
+        <source>Height</source>
+        <translation>Висина</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1149"/>
-      <source>&amp;Crop from Metadata</source>
-      <translation>&amp;Опсеци из метаподатака</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1967"/>
+        <source>%</source>
+        <translation>%</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1193"/>
-      <source>inactive</source>
-      <translation>неактиван</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1972"/>
+        <source> px</source>
+        <translation> px</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1198"/>
-      <source>Rotating by: %1</source>
-      <translation>Ротирај: %1</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1978"/>
+        <source>Transform All</source>
+        <translation>Трансформиши све</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1202"/>
-      <source>Flipping</source>
-      <translation>Превртање</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1978"/>
+        <source>Shrink Only</source>
+        <translation>Само скупи</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1207"/>
-      <source>Crop</source>
-      <translation>Опсеци</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1978"/>
+        <source>Enlarge Only</source>
+        <translation>Само прошири</translation>
     </message>
-  </context>
-  <context>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1992"/>
+        <source>Orientation</source>
+        <translation>Оријентација</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1995"/>
+        <source>Do &amp;Not Rotate</source>
+        <translation>Не &amp;ротирај</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1997"/>
+        <source>90%1 Counter Clockwise</source>
+        <translation>90%1 супротно казаљци на сату</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1998"/>
+        <source>90%1 Clockwise</source>
+        <translation>90%1 у смеру казаљке на сату</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1999"/>
+        <source>180%1</source>
+        <translation>180%1</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2008"/>
+        <source>Transformations</source>
+        <translation>Трансформације</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2011"/>
+        <source>&amp;Crop from Metadata</source>
+        <translation>&amp;Опсеци из метаподатака</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2063"/>
+        <source>inactive</source>
+        <translation>неактиван</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2069"/>
+        <source>Resize by: %1%</source>
+        <translation>Промени величину за: %1%</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2073"/>
+        <source>Resize %1 to: %2 px</source>
+        <translation>Промени величину %1 у %2 px</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2079"/>
+        <source>Rotating by: %1</source>
+        <translation>Ротирај: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2085"/>
+        <source>Crop</source>
+        <translation>Опсеци</translation>
+    </message>
+</context>
+<context>
     <name>nmc::DkBatchWidget</name>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1241"/>
-      <source>Batch Conversion</source>
-      <translation>Групна конверзија</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2288"/>
+        <source>next</source>
+        <translation>следеће</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1250"/>
-      <source>next</source>
-      <translation>следеће</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2293"/>
+        <source>previous</source>
+        <translation>претходно</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1255"/>
-      <source>previous</source>
-      <translation>претходно</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2314"/>
+        <source>no files selected</source>
+        <translation>без одабраних фајлова</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1277"/>
-      <source>Input Directory</source>
-      <translation>Улазна фасцикла</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2319"/>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2322"/>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2326"/>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2334"/>
+        <source>inactive</source>
+        <translation>неактиван</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1277"/>
-      <source>no files selected</source>
-      <translation>без одабраних фајлова</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2319"/>
+        <source>Adjustments</source>
+        <translation>Подешавања</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1283"/>
-      <source>Resize</source>
-      <translation>Промени величину</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2322"/>
+        <source>Transform</source>
+        <translation>Трансформиши</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1283"/>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1287"/>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1292"/>
-      <source>inactive</source>
-      <translation>неактиван</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2326"/>
+        <source>Plugins</source>
+        <translation>Прикључци</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1287"/>
-      <source>Transform</source>
-      <translation>Трансформиши</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2330"/>
+        <source>Output</source>
+        <translation>Излаз</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1292"/>
-      <source>Plugins</source>
-      <translation>Прикључци</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2330"/>
+        <source>not set</source>
+        <translation>није подешено</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1297"/>
-      <source>Output</source>
-      <translation>Излаз</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2515"/>
+        <source>Please select files for processing.</source>
+        <translation>Молим одабери фајлове за обраду.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1297"/>
-      <source>not set</source>
-      <translation>није подешено</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2522"/>
+        <source>I am missing a widget.</source>
+        <translation>Недостаје виџет.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1310"/>
-      <source>Show &amp;Log</source>
-      <translation>Прикажи &amp;лог</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2536"/>
+        <source>Please check &apos;Overwrite Existing Files&apos; or choose a different output directory.</source>
+        <translation>Молим означите &apos;Препиши постојеће фајлове&apos; или одабери другу излазну фасциклу.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1311"/>
-      <source>Shows detailed status messages.</source>
-      <translation>Прикажи детаље статусне поруке.</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2557"/>
+        <source>Create Output Directory</source>
+        <translation>Креирај излазну фасциклу</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1317"/>
-      <source>&amp;OK</source>
-      <translation>&amp;У реду</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1383"/>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1401"/>
-      <source>Wrong Configuration</source>
-      <translation>Погрешна конфигурација</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1383"/>
-      <source>Please select files for processing.</source>
-      <translation>Молим одабери фајлове за обраду.</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1391"/>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1452"/>
-      <source>Fatal Error</source>
-      <translation>Фатална грешка</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1391"/>
-      <source>I am missing a widget.</source>
-      <translation>Недостаје виџет.</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1401"/>
-      <source>Please check 'Overwrite Existing Files' or choose a different output directory.</source>
-      <translation>Молим означите 'Препиши постојеће фајлове' или одабери другу излазну фасциклу.</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1414"/>
-      <source>Create Output Directory</source>
-      <translation>Креирај излазну фасциклу</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1415"/>
-      <source>Should I create:
+        <location filename="../src/DkGui/DkBatch.cpp" line="2558"/>
+        <source>Should I create:
 %1</source>
-      <translation>Требало би да креирам:
+        <translation>Требало би да креирам:
 %1</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1431"/>
-      <source>Info</source>
-      <translation>Информације</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2575"/>
+        <source>Please select an output directory.</source>
+        <translation>Молим одаберите излазну фасциклу.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1431"/>
-      <source>Please select an output directory.</source>
-      <translation>Молим одаберите излазну фасциклу.</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2722"/>
+        <source>Batch Log</source>
+        <translation>Запис групног подешавања</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1435"/>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1439"/>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1443"/>
-      <source>Error</source>
-      <translation>Грешка</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2787"/>
+        <source>Save Profile</source>
+        <translation>Сачувај профил</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1435"/>
-      <source>Sorry, I cannot create %1.</source>
-      <translation>Извини, не могу креирати %1.</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2787"/>
+        <source>Cannot save empty profile.</source>
+        <translation>Немогуће сачувати празан профил.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1439"/>
-      <source>Sorry, I cannot find files to process.</source>
-      <translation>Извини, не могу пронаћи фајлове за обраду.</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2792"/>
+        <source>Error</source>
+        <translation>Грешка</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1443"/>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1452"/>
-      <source>Sorry, the file pattern is empty.</source>
-      <translation>Извини, фајл за образац је празан.</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2580"/>
+        <source>Sorry, I cannot create %1.</source>
+        <translation>Жао нам је, не могу креирати %1.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="1559"/>
-      <source>%1/%2 files processed... %3 failed.</source>
-      <translation>%1/%2 фајлова обрађено... %3 није успело.</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2314"/>
+        <source>Input</source>
+        <translation>Улаз</translation>
     </message>
-  </context>
-  <context>
-    <name>nmc::DkBrightness</name>
     <message>
-      <location filename="../src/DkGui/DkManipulationWidgets.cpp" line="875"/>
-      <source>Brightness</source>
-      <translation>Бистрина</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2334"/>
+        <source>Profiles</source>
+        <translation>Профили</translation>
     </message>
-  </context>
-  <context>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2585"/>
+        <source>Sorry, I cannot find files to process.</source>
+        <translation>Жао нам је, не могу пронаћи фајлове за обраду.</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2590"/>
+        <source>Sorry, the file pattern is empty.</source>
+        <translation>Жао нам је, фајл за образац је празан.</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2600"/>
+        <source>Sorry, I cannot start processing - please check the configuration.</source>
+        <translation>Жао нам је, немогуће полети процесирање - молимо провјерите конфигурацију.</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2642"/>
+        <source>Canceling...</source>
+        <translation>Отказујем...</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2696"/>
+        <source>%1/%2 files processed... %3 failed.</source>
+        <translation>%1/%2 фајлова обрађено... %3 није успело.</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2792"/>
+        <source>Sorry, I cannot save the settings...</source>
+        <translation>Жао нам је, немогуће сачувати ове поставке...</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2808"/>
+        <source>Error Loading Profile</source>
+        <translation>Грешка при учитавању профила</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="2809"/>
+        <source>Sorry, I cannot load batch settings from: 
+%1</source>
+        <translation>Жао нам је, немогуће учитати групне поставке из:
+%1</translation>
+    </message>
+</context>
+<context>
     <name>nmc::DkCentralWidget</name>
     <message>
-      <location filename="../src/DkGui/DkCentralWidget.cpp" line="485"/>
-      <source>General</source>
-      <translation>Опште</translation>
+        <location filename="../src/DkGui/DkCentralWidget.cpp" line="275"/>
+        <source>Go to Tab</source>
+        <translation>Иди на картицу</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkCentralWidget.cpp" line="491"/>
-      <source>Display</source>
-      <translation>Екран</translation>
+        <location filename="../src/DkGui/DkCentralWidget.cpp" line="275"/>
+        <source>Go to tab number: </source>
+        <translation>Иди на картицу број: </translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkCentralWidget.cpp" line="497"/>
-      <source>File</source>
-      <translation>Фајл</translation>
+        <location filename="../src/DkGui/DkCentralWidget.cpp" line="532"/>
+        <source>General</source>
+        <translation>Опште</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkCentralWidget.cpp" line="503"/>
-      <source>File Associations</source>
-      <translation>Придруживања фајлова</translation>
+        <location filename="../src/DkGui/DkCentralWidget.cpp" line="538"/>
+        <source>Display</source>
+        <translation>Екран</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkCentralWidget.cpp" line="510"/>
-      <source>Advanced</source>
-      <translation>Напредно</translation>
+        <location filename="../src/DkGui/DkCentralWidget.cpp" line="544"/>
+        <source>File</source>
+        <translation>Фајл</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkCentralWidget.cpp" line="1083"/>
-      <source>Sorry, I could not drop the content.</source>
-      <translation>Извини, не могу спустити садржај.</translation>
+        <location filename="../src/DkGui/DkCentralWidget.cpp" line="550"/>
+        <source>File Associations</source>
+        <translation>Придруживања фајлова</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkCentralWidget.cpp" line="1115"/>
-      <source>Save File</source>
-      <translation>Сачувај фајл</translation>
+        <location filename="../src/DkGui/DkCentralWidget.cpp" line="556"/>
+        <source>Advanced</source>
+        <translation>Напредно</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkCentralWidget.cpp" line="1123"/>
-      <source>%1 vec files merged</source>
-      <translation>%1 фајлова је спојено</translation>
+        <location filename="../src/DkGui/DkCentralWidget.cpp" line="562"/>
+        <source>Editor</source>
+        <translation>Уређивач</translation>
     </message>
-  </context>
-  <context>
+    <message>
+        <location filename="../src/DkGui/DkCentralWidget.cpp" line="1100"/>
+        <source>I could not load &quot;%1&quot;</source>
+        <translation>Немогуће учитати &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkCentralWidget.cpp" line="1132"/>
+        <source>Unable to load file &quot;%1&quot;</source>
+        <translation>Немогуће учитати фајл &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkCentralWidget.cpp" line="1140"/>
+        <source>&quot;%1&quot; cannot be loaded</source>
+        <translation>&quot;%1&quot; немогуће учитати</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkCentralWidget.cpp" line="1146"/>
+        <source>downloading &quot;%1&quot;</source>
+        <translation>преузимам &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkCentralWidget.cpp" line="1160"/>
+        <source>Too many urls to load. Loading only the first %1</source>
+        <translation>Превише URLова за учитати. Учитавам само првих %1</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkCentralWidget.cpp" line="1219"/>
+        <source>Sorry, I could not drop the content.</source>
+        <translation>Извини, не могу спустити садржај.</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkCentralWidget.cpp" line="1303"/>
+        <source>Save File</source>
+        <translation>Сачувај фајл</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkCentralWidget.cpp" line="1311"/>
+        <source>%1 vec files merged</source>
+        <translation>%1 фајлова је спојено</translation>
+    </message>
+</context>
+<context>
     <name>nmc::DkColorChooser</name>
     <message>
-      <location filename="../src/DkLoader/DkBasicWidgets.cpp" line="167"/>
-      <source>Reset</source>
-      <translation>Ресетуј</translation>
+        <location filename="../src/DkCore/DkBasicWidgets.cpp" line="283"/>
+        <source>Reset</source>
+        <translation>Ресетуј</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkColorSlider</name>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="114"/>
-      <source>Drag the slider downwards for elimination</source>
-      <translation>Превуците клизач доле за елиминацију</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="112"/>
+        <source>Drag the slider downwards for elimination</source>
+        <translation>Превуците клизач доле за елиминацију</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkCommentTextEdit</name>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="1143"/>
-      <source>Click here to add notes</source>
-      <translation>Кликни овде за додавање напомена</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="1144"/>
+        <source>Click here to add notes</source>
+        <translation>Кликни овде за додавање напомена</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkCommentWidget</name>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="1162"/>
-      <source>NOTES</source>
-      <translation>НАПОМЕНЕ</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="1163"/>
+        <source>NOTES</source>
+        <translation>НАПОМЕНЕ</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="1176"/>
-      <source>Enter your notes here. They will be saved to the image metadata.</source>
-      <translation>Унеси напомене овде. Оне ће бити сачуване у подацима слике.</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="1177"/>
+        <source>Enter your notes here. They will be saved to the image metadata.</source>
+        <translation>Унеси напомене овде. Оне ће бити сачуване у подацима слике.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="1182"/>
-      <source>Save Note (CTRL + ENTER)</source>
-      <translation>Сачувај напомену (CTRL + ENTER)</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="1183"/>
+        <source>Save Note (CTRL + ENTER)</source>
+        <translation>Сачувај напомену (CTRL + ENTER)</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="1189"/>
-      <source>Discard Changes (ESC)</source>
-      <translation>Одбаци промене (ESC)</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="1190"/>
+        <source>Discard Changes (ESC)</source>
+        <translation>Одбаци промене (ESC)</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="1230"/>
-      <source>Sorry, I cannot save comments for this image format.</source>
-      <translation>Извини, не могу сачувати коментаре за овај формат слике.</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="1231"/>
+        <source>Sorry, I cannot save comments for this image format.</source>
+        <translation>Извини, не могу сачувати коментаре за овај формат слике.</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkCompressDialog</name>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="178"/>
-      <source>Original</source>
-      <translation>Оригинал</translation>
+        <location filename="../src/DkCore/DkSaveDialog.cpp" line="180"/>
+        <source>Original</source>
+        <translation>Оригинал</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="180"/>
-      <source>New</source>
-      <translation>Нова</translation>
+        <location filename="../src/DkCore/DkSaveDialog.cpp" line="182"/>
+        <source>New</source>
+        <translation>Нова</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="206"/>
-      <source>Medium (1024 x 786)</source>
-      <translation>Средња (1024 x 786)</translation>
+        <location filename="../src/DkCore/DkSaveDialog.cpp" line="208"/>
+        <source>Medium (1024 x 786)</source>
+        <translation>Средња (1024 x 786)</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="212"/>
-      <source>Image Quality</source>
-      <translation>Квалитет слике</translation>
+        <location filename="../src/DkCore/DkSaveDialog.cpp" line="214"/>
+        <source>Image Quality</source>
+        <translation>Квалитет слике</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="218"/>
-      <source>Lossless Compression</source>
-      <translation>Компресија без губитака</translation>
+        <location filename="../src/DkCore/DkSaveDialog.cpp" line="220"/>
+        <source>Lossless Compression</source>
+        <translation>Компресија без губитака</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="225"/>
-      <source>Background Color</source>
-      <translation>Позадинска боја</translation>
+        <location filename="../src/DkCore/DkSaveDialog.cpp" line="227"/>
+        <source>Background Color</source>
+        <translation>Позадинска боја</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="257"/>
-      <source>&amp;OK</source>
-      <translation>&amp;У реду</translation>
+        <location filename="../src/DkCore/DkSaveDialog.cpp" line="259"/>
+        <source>&amp;OK</source>
+        <translation>&amp;У реду</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="254"/>
-      <source>&amp;Cancel</source>
-      <translation>&amp;Откажи</translation>
+        <location filename="../src/DkCore/DkSaveDialog.cpp" line="256"/>
+        <source>&amp;Cancel</source>
+        <translation>&amp;Откажи</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="140"/>
-      <source>JPG Settings</source>
-      <translation>ЈПГ подешавања</translation>
+        <location filename="../src/DkCore/DkSaveDialog.cpp" line="142"/>
+        <source>JPG Settings</source>
+        <translation>ЈПГ подешавања</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="142"/>
-      <source>J2K Settings</source>
-      <translation>Ј2К подешавања</translation>
+        <location filename="../src/DkCore/DkSaveDialog.cpp" line="144"/>
+        <source>J2K Settings</source>
+        <translation>Ј2К подешавања</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="151"/>
-      <source>WebP Settings</source>
-      <translation>ВебП подешавања</translation>
+        <location filename="../src/DkCore/DkSaveDialog.cpp" line="153"/>
+        <source>WebP Settings</source>
+        <translation>ВебП подешавања</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="164"/>
-      <source>Save for Web</source>
-      <translation>Сачувај за веб</translation>
+        <location filename="../src/DkCore/DkSaveDialog.cpp" line="166"/>
+        <source>Save for Web</source>
+        <translation>Сачувај за веб</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="205"/>
-      <source>Small  (800 x 600)</source>
-      <translation>Мала  (800 x 600)</translation>
+        <location filename="../src/DkCore/DkSaveDialog.cpp" line="207"/>
+        <source>Small  (800 x 600)</source>
+        <translation>Мала  (800 x 600)</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="207"/>
-      <source>Large  (1920 x 1080)</source>
-      <translation>Велика  (1920 x 1080)</translation>
+        <location filename="../src/DkCore/DkSaveDialog.cpp" line="209"/>
+        <source>Large  (1920 x 1080)</source>
+        <translation>Велика  (1920 x 1080)</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="208"/>
-      <source>Original Size</source>
-      <translation>Оригинал величина</translation>
+        <location filename="../src/DkCore/DkSaveDialog.cpp" line="210"/>
+        <source>Original Size</source>
+        <translation>Оригинал величина</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="375"/>
-      <source>File Size: --</source>
-      <translation>Величина фајла: --</translation>
+        <location filename="../src/DkCore/DkSaveDialog.cpp" line="377"/>
+        <source>File Size: --</source>
+        <translation>Величина фајла: --</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="392"/>
-      <source>File Size: ~%1</source>
-      <translation>Величина фајла: ~%1</translation>
+        <location filename="../src/DkCore/DkSaveDialog.cpp" line="394"/>
+        <source>File Size: ~%1</source>
+        <translation>Величина фајла: ~%1</translation>
     </message>
-  </context>
-  <context>
-    <name>nmc::DkContrast</name>
-    <message>
-      <location filename="../src/DkGui/DkManipulationWidgets.cpp" line="969"/>
-      <source>Contrast</source>
-      <translation>Контраст</translation>
-    </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkControlWidget</name>
     <message>
-      <location filename="../src/DkGui/DkControlWidget.cpp" line="579"/>
-      <source>Closing Plugin</source>
-      <translation>Затвори прикључак</translation>
+        <location filename="../src/DkGui/DkControlWidget.cpp" line="558"/>
+        <source>Closing Plugin</source>
+        <translation>Затвори прикључак</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkControlWidget.cpp" line="580"/>
-      <source>Apply plugin changes?</source>
-      <translation>Примени измене прикључка?</translation>
+        <location filename="../src/DkGui/DkControlWidget.cpp" line="559"/>
+        <source>Apply plugin changes?</source>
+        <translation>Примени измене прикључка?</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkCropToolBar</name>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="959"/>
-      <source>Crop (ENTER)</source>
-      <translation>Исеци (ENTER)</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="938"/>
+        <source>Crop (ENTER)</source>
+        <translation>Исеци (ENTER)</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="963"/>
-      <source>Cancel (ESC)</source>
-      <translation>Откажи (ESC)</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="942"/>
+        <source>Cancel (ESC)</source>
+        <translation>Откажи (ESC)</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="967"/>
-      <source>Pan</source>
-      <translation>Пан</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="946"/>
+        <source>Pan</source>
+        <translation>Пан</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="975"/>
-      <source>User Defined</source>
-      <translation>Кориснички дефинисано</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="954"/>
+        <source>User Defined</source>
+        <translation>Кориснички дефинисано</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="976"/>
-      <source>No Aspect Ratio</source>
-      <translation>Без односа слике</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="955"/>
+        <source>No Aspect Ratio</source>
+        <translation>Без односа слике</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="984"/>
-      <source>Horizontal Constraint</source>
-      <translation>Хоризонтално ограничење</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="963"/>
+        <source>Horizontal Constraint</source>
+        <translation>Хоризонтално ограничење</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="987"/>
-      <source>Swap</source>
-      <translation>Swap</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="966"/>
+        <source>Swap</source>
+        <translation>Swap</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="989"/>
-      <source>Swap Dimensions</source>
-      <translation>Swap димензије</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="968"/>
+        <source>Swap Dimensions</source>
+        <translation>Swap димензије</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="995"/>
-      <source>Vertical Constraint</source>
-      <translation>Вертикално ограничење</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="974"/>
+        <source>Vertical Constraint</source>
+        <translation>Вертикално ограничење</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="1009"/>
-      <source>Background Color</source>
-      <translation>Позадинска боја</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="988"/>
+        <source>Background Color</source>
+        <translation>Позадинска боја</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="1018"/>
-      <source>Guides</source>
-      <translation>Водичи</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="997"/>
+        <source>Guides</source>
+        <translation>Водичи</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="1018"/>
-      <source>Rule of Thirds</source>
-      <translation>Правило трећине</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="997"/>
+        <source>Rule of Thirds</source>
+        <translation>Правило трећине</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="1018"/>
-      <source>Grid</source>
-      <translation>Мрежа</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="997"/>
+        <source>Grid</source>
+        <translation>Мрежа</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="1022"/>
-      <source>Show Guides in the Preview</source>
-      <translation>Покажи упутства у прегледу</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="1001"/>
+        <source>Show Guides in the Preview</source>
+        <translation>Покажи упутства у прегледу</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="1026"/>
-      <source>Invert Crop Tool Color</source>
-      <translation>Обрни боју алата за исецање</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="1005"/>
+        <source>Invert Crop Tool Color</source>
+        <translation>Обрни боју алата за исецање</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="1031"/>
-      <source>Show Info</source>
-      <translation>Покажи информације</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="1010"/>
+        <source>Show Info</source>
+        <translation>Покажи информације</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="1036"/>
-      <source>Crop to Metadata</source>
-      <translation>Опсеци за метаподатке</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="1015"/>
+        <source>Crop to Metadata</source>
+        <translation>Опсеци за метаподатке</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkCropWidget</name>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="2003"/>
-      <source>Crop Toolbar</source>
-      <translation>Трака алата за исецање</translation>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="2010"/>
+        <source>Crop Toolbar</source>
+        <translation>Трака алата за исецање</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkDescriptionEdit</name>
     <message>
-      <location filename="../src/DkLoader/DkPluginManager.cpp" line="956"/>
-      <source>No metadata available!</source>
-      <translation>Без доступних метаподатака!</translation>
+        <location filename="../src/DkCore/DkPluginManager.cpp" line="994"/>
+        <source>No metadata available!</source>
+        <translation>Без доступних метаподатака!</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkDialogManager</name>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4597"/>
-      <source>Preview</source>
-      <translation>Преглед</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="4249"/>
+        <source>Preview</source>
+        <translation>Преглед</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4612"/>
-      <source>Shortcuts</source>
-      <translation>Пречице</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="4264"/>
+        <source>Shortcuts</source>
+        <translation>Пречице</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkDirectoryChooser</name>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="2733"/>
-      <source>...</source>
-      <translation>...</translation>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="2845"/>
+        <source>...</source>
+        <translation>...</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="2747"/>
-      <source>Open an Image Directory</source>
-      <translation>Отвори фасциклу са сликама</translation>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="2859"/>
+        <source>Open an Image Directory</source>
+        <translation>Отвори фасциклу са сликама</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkDisplayPreference</name>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="597"/>
-      <source>Invert mouse wheel behaviour for zooming</source>
-      <translation>Обрни понашање точкића за зумирање</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="685"/>
+        <source>Invert mouse wheel behaviour for zooming</source>
+        <translation>Обрни понашање точкића за зумирање</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="599"/>
-      <source>If checked, the mouse wheel behaviour is inverted while zooming.</source>
-      <translation>Ако је означено, понашање точкића миша је обрнуто док зумира.</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="687"/>
+        <source>If checked, the mouse wheel behaviour is inverted while zooming.</source>
+        <translation>Ако је означено, понашање точкића миша је обрнуто док зумира.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="602"/>
-      <source>Show pixels if zoom level is above</source>
-      <translation>Прикажи пикселе ако је ниво зумирања изнад</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="690"/>
+        <source>Show pixels if zoom level is above</source>
+        <translation>Прикажи пикселе ако је ниво зумирања изнад</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="606"/>
-      <source>nomacs will not interpolate images if the zoom level is larger.</source>
-      <translation>nomacs неће интерполирати слике ако је ниво зума већи.</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="694"/>
+        <source>nomacs will not interpolate images if the zoom level is larger.</source>
+        <translation>nomacs неће интерполирати слике ако је ниво зума већи.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="612"/>
-      <source>Zoom</source>
-      <translation>Зум</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="700"/>
+        <source>Zoom</source>
+        <translation>Зум</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="620"/>
-      <source>Always keep zoom</source>
-      <translation>Увек задржи зум</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="708"/>
+        <source>Always keep zoom</source>
+        <translation>Увек задржи зум</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="621"/>
-      <source>Keep zoom if the size is the same</source>
-      <translation>Држи зум ако је величина иста</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="709"/>
+        <source>Keep zoom if the size is the same</source>
+        <translation>Држи зум ако је величина иста</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="622"/>
-      <source>If checked, the zoom level is only kept, if the image loaded has the same level as the previous.</source>
-      <translation>Ако је означено, зум ниво се задржава, ако учитана слика има исти ниво као и претходна.</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="710"/>
+        <source>If checked, the zoom level is only kept, if the image loaded has the same level as the previous.</source>
+        <translation>Ако је означено, зум ниво се задржава, ако учитана слика има исти ниво као и претходна.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="623"/>
-      <source>Never keep zoom</source>
-      <translation>Никада не задржавај зум</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="711"/>
+        <source>Never keep zoom</source>
+        <translation>Никада не задржавај зум</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="625"/>
-      <source>Always zoom to fit</source>
-      <translation>Увек зумирај оптимално</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="713"/>
+        <source>Always zoom to fit</source>
+        <translation>Увек зумирај оптимално</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="638"/>
-      <source>When Displaying New Images</source>
-      <translation>Код приказивања нових слика</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="726"/>
+        <source>When Displaying New Images</source>
+        <translation>Код приказивања нових слика</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="647"/>
-      <source>Define the icon size in pixel.</source>
-      <translation>Одреди величину иконе у пикселима.</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="735"/>
+        <source>Define the icon size in pixel.</source>
+        <translation>Одреди величину иконе у пикселима.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="653"/>
-      <source>Icon Size</source>
-      <translation>Величина иконе</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="741"/>
+        <source>Icon Size</source>
+        <translation>Величина иконе</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="657"/>
-      <source>Image Transition</source>
-      <translation>Слика транзиције</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="745"/>
+        <source>Image Transition</source>
+        <translation>Слика транзиције</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="661"/>
-      <source>Choose a transition when loading a new image</source>
-      <translation>Одабери прелаз код учитавања нове слике</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="749"/>
+        <source>Choose a transition when loading a new image</source>
+        <translation>Одабери прелаз код учитавања нове слике</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="665"/>
-      <source>Unknown Transition</source>
-      <translation>Непозната транзиција</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="753"/>
+        <source>Unknown Transition</source>
+        <translation>Непозната транзиција</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="668"/>
-      <source>Appear</source>
-      <translation>Изглед</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="756"/>
+        <source>Appear</source>
+        <translation>Изглед</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="669"/>
-      <source>Swipe</source>
-      <translation>Узми</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="757"/>
+        <source>Swipe</source>
+        <translation>Узми</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="670"/>
-      <source>Fade</source>
-      <translation>Изчезни</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="758"/>
+        <source>Fade</source>
+        <translation>Изчезни</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="679"/>
-      <source>Define the image transition speed.</source>
-      <translation>Одреди брзину транзиције слика.</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="767"/>
+        <source>Define the image transition speed.</source>
+        <translation>Одреди брзину транзиције слика.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="686"/>
-      <source>Always Animate Image Loading</source>
-      <translation>Увек учитај анимирану слику</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="774"/>
+        <source>Always Animate Image Loading</source>
+        <translation>Увек учитај анимирану слику</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="688"/>
-      <source>If unchecked, loading is only animated if nomacs is fullscreen</source>
-      <translation>Ако је неозначено, учитавање је анимирано ако је nomacs у пуном екрану</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="776"/>
+        <source>If unchecked, loading is only animated if nomacs is fullscreen</source>
+        <translation>Ако је неозначено, учитавање је анимирано ако је nomacs у пуном екрану</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="691"/>
-      <source>Display Time</source>
-      <translation>Приказ времена</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="779"/>
+        <source>Display Time</source>
+        <translation>Приказ времена</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="695"/>
-      <source>Define the time an image is displayed.</source>
-      <translation>Одреди време приказивање поједине слике.</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="783"/>
+        <source>Define the time an image is displayed.</source>
+        <translation>Одреди време приказивање поједине слике.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="702"/>
-      <source>Slideshow</source>
-      <translation>Слајдшоу</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="790"/>
+        <source>Slideshow</source>
+        <translation>Слајдшоу</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="711"/>
-      <source>Show crop rectangle</source>
-      <translation>Прикажи правоугаоник за опсецање</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="799"/>
+        <source>Show crop rectangle</source>
+        <translation>Прикажи правоугаоник за опсецање</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="715"/>
-      <source>Show Metadata Cropping</source>
-      <translation>Прикажи метаподатке опсецања</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="803"/>
+        <source>Show Metadata Cropping</source>
+        <translation>Прикажи метаподатке опсецања</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="765"/>
-      <source>Please Restart nomacs to apply changes</source>
-      <translation>Молим поново покрените nomacs да би применили промене</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="853"/>
+        <source>Please Restart nomacs to apply changes</source>
+        <translation>Молим поново покрените nomacs да би применили промене</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkExplorer</name>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="479"/>
-      <source>Editable</source>
-      <translation>Могуће уређивање</translation>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="484"/>
+        <source>Editable</source>
+        <translation>Могуће уређивање</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="485"/>
-      <source>Open Selected Image</source>
-      <translation>Отвори одабрану слику</translation>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="490"/>
+        <source>Open Selected Image</source>
+        <translation>Отвори одабрану слику</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="495"/>
-      <source>Adjust Columns</source>
-      <translation>Прилагоди колоне</translation>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="500"/>
+        <source>Adjust Columns</source>
+        <translation>Прилагоди колоне</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkExportTiffDialog</name>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2523"/>
-      <source>Export Multi-Page TIFF</source>
-      <translation>Извоз вишестраног TIFF</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2552"/>
+        <source>Export Multi-Page TIFF</source>
+        <translation>Извоз вишестраног TIFF</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2569"/>
-      <source>Multi-Page TIFF:</source>
-      <translation>Вишестрани TIFF:</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2598"/>
+        <source>Multi-Page TIFF:</source>
+        <translation>Вишестрани TIFF:</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2572"/>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2581"/>
-      <source>&amp;Browse</source>
-      <translation>&amp;Претрага</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2601"/>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2610"/>
+        <source>&amp;Browse</source>
+        <translation>&amp;Претрага</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2575"/>
-      <source>No Multi-Page TIFF loaded</source>
-      <translation>Без учитаног вишестраног TIFF</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2604"/>
+        <source>No Multi-Page TIFF loaded</source>
+        <translation>Без учитаног вишестраног TIFF</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2578"/>
-      <source>Save Folder:</source>
-      <translation>Сачувај фасциклу:</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2607"/>
+        <source>Save Folder:</source>
+        <translation>Сачувај фасциклу:</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2584"/>
-      <source>Specify a Save Folder</source>
-      <translation>Одреди фасциклу за чување</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2613"/>
+        <source>Specify a Save Folder</source>
+        <translation>Одреди фасциклу за чување</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2587"/>
-      <source>Filename:</source>
-      <translation>Име фајла:</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2616"/>
+        <source>Filename:</source>
+        <translation>Име фајла:</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2598"/>
-      <source>Export Pages</source>
-      <translation>Извези стране</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2627"/>
+        <source>Export Pages</source>
+        <translation>Извези стране</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2605"/>
-      <source>Overwrite</source>
-      <translation>Препиши</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2634"/>
+        <source>Overwrite</source>
+        <translation>Препиши</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2637"/>
-      <source>&amp;Export</source>
-      <translation>&amp;Извоз</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2666"/>
+        <source>&amp;Export</source>
+        <translation>&amp;Извоз</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2638"/>
-      <source>&amp;Cancel</source>
-      <translation>&amp;Откажи</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2667"/>
+        <source>&amp;Cancel</source>
+        <translation>&amp;Откажи</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2655"/>
-      <source>Open TIFF</source>
-      <translation>Отвори TIFF</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2684"/>
+        <source>Open TIFF</source>
+        <translation>Отвори TIFF</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2666"/>
-      <source>Open an Image Directory</source>
-      <translation>Отвори фасциклу са сликама</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2695"/>
+        <source>Open an Image Directory</source>
+        <translation>Отвори фасциклу са сликама</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2753"/>
-      <source>%1 exists, skipping...</source>
-      <translation>%1 постоји, прескочи...</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2782"/>
+        <source>%1 exists, skipping...</source>
+        <translation>%1 постоји, прескочи...</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2766"/>
-      <source>Sorry, I could not save: %1</source>
-      <translation>Извините, није било могуће сачувати: %1</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2795"/>
+        <source>Sorry, I could not save: %1</source>
+        <translation>Извините, није било могуће сачувати: %1</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2758"/>
-      <source>Sorry, I could not load page: %1</source>
-      <translation>Извини, не могу учитати страну: %1</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2787"/>
+        <source>Sorry, I could not load page: %1</source>
+        <translation>Извини, не могу учитати страну: %1</translation>
     </message>
-  </context>
-  <context>
-    <name>nmc::DkExposure</name>
+</context>
+<context>
+    <name>nmc::DkExposureWidget</name>
     <message>
-      <location filename="../src/DkGui/DkManipulationWidgets.cpp" line="1368"/>
-      <source>Exposure</source>
-      <translation>Експозиција</translation>
+        <location filename="../src/DkGui/DkManipulatorWidgets.cpp" line="457"/>
+        <source>Exposure</source>
+        <translation>Експозиција</translation>
     </message>
-  </context>
-  <context>
+    <message>
+        <location filename="../src/DkGui/DkManipulatorWidgets.cpp" line="464"/>
+        <source>Offset</source>
+        <translation>Иступ</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkManipulatorWidgets.cpp" line="471"/>
+        <source>Gamma</source>
+        <translation>Гама</translation>
+    </message>
+</context>
+<context>
     <name>nmc::DkFileAssociationsPreference</name>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="997"/>
-      <source>Filter</source>
-      <translation>Филтер</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1087"/>
+        <source>Filter</source>
+        <translation>Филтер</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="998"/>
-      <source>Browse</source>
-      <translation>Погледајте</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1088"/>
+        <source>Browse</source>
+        <translation>Погледајте</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="999"/>
-      <source>Register</source>
-      <translation>Регистар</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1089"/>
+        <source>Register</source>
+        <translation>Региструј</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1011"/>
-      <source>Set as Default Viewer</source>
-      <translation>Подеси подразумевани прегледач</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1101"/>
+        <source>Set as Default Viewer</source>
+        <translation>Подеси подразумевани прегледач</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1029"/>
-      <source>Please Restart nomacs to apply changes</source>
-      <translation>Молим поново покрените nomacs да би применили промене</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1119"/>
+        <source>Please Restart nomacs to apply changes</source>
+        <translation>Молим поново покрените nomacs да би применили промене</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1102"/>
-      <source>Image</source>
-      <translation>Слика</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="1192"/>
+        <source>Image</source>
+        <translation>Слика</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkFileInfoLabel</name>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="1147"/>
-      <source>Info Box</source>
-      <translation>Инфо бар</translation>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="1152"/>
+        <source>Info Box</source>
+        <translation>Инфо бар</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="1148"/>
-      <source>All information fields are currently hidden.
+        <location filename="../src/DkGui/DkWidgets.cpp" line="1153"/>
+        <source>All information fields are currently hidden.
 Do you want to show them again?</source>
-      <translation>Сва инфо поља су тренутно невидљива.
+        <translation>Сва инфо поља су тренутно невидљива.
 Да ли желите да их покажете поново?</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkFilePreference</name>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="835"/>
-      <source>Screenshots are automatically saved to this folder</source>
-      <translation>Снимци екрана се аутоматски чувају у овој фасцикли</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="922"/>
+        <source>Screenshots are automatically saved to this folder</source>
+        <translation>Снимци екрана се аутоматски чувају у овој фасцикли</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="837"/>
-      <source>Use Temporary Folder</source>
-      <translation>Користи привремену фасциклу</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="924"/>
+        <source>Use Temporary Folder</source>
+        <translation>Користи привремену фасциклу</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="852"/>
-      <source>We recommend to set a moderate cache value around 100 MB</source>
-      <translation>Препоручујемо да одредите вредност кеша за историју на око 100 MB</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="942"/>
+        <source>Maximal Cache Size</source>
+        <translation>Максимална величина за кеш</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="854"/>
-      <source>Maximal Cache Size</source>
-      <translation>Максимална величина за кеш</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="939"/>
+        <source>We recommend to set a moderate cache value around 100 MB. [%1-%2 MB]</source>
+        <translation>Предлажемо да се постави умерена вредност кеша око 100МБ, [%1-%2 МБ]</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="868"/>
-      <source>We recommend to set a moderate edit history value around 100 MB</source>
-      <translation>Препоручујемо да подесите вредност за историју око 100 MB</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="956"/>
+        <source>We recommend to set a moderate edit history value around 100 MB. [%1-%2 MB]</source>
+        <translation>Предлажемо да се постави умерена вредност историје уређивања око 100МБ. [%1-%2 МБ]</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="870"/>
-      <source>History Size</source>
-      <translation>Величина историје</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="959"/>
+        <source>History Size</source>
+        <translation>Величина историје</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="877"/>
-      <source>Skip Images</source>
-      <translation>Прескочи слике</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="966"/>
+        <source>Skip Images</source>
+        <translation>Прескочи слике</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="878"/>
-      <source>Images are skipped until the Next key is released</source>
-      <translation>Слике су прескочене док је Next тастер опуштен</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="967"/>
+        <source>Images are skipped until the Next key is released</source>
+        <translation>Слике су прескочене док је Next тастер опуштен</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="879"/>
-      <source>Wait for Images to be Loaded</source>
-      <translation>Сачекајте да слике буду учитане</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="968"/>
+        <source>Wait for Images to be Loaded</source>
+        <translation>Сачекајте да слике буду учитане</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="880"/>
-      <source>The next image is loaded after the current image is shown.</source>
-      <translation>Следећа слика је учитана након што се прикаже тренутна слика.</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="969"/>
+        <source>The next image is loaded after the current image is shown.</source>
+        <translation>Следећа слика је учитана након што се прикаже тренутна слика.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="891"/>
-      <source>Image Loading Policy</source>
-      <translation>Политика учитавања слика</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="980"/>
+        <source>Image Loading Policy</source>
+        <translation>Политика учитавања слика</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="903"/>
-      <source>Number of Skipped Images on PgUp/PgDown</source>
-      <translation>Број прескочених слика на PgUp/PgDown</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="992"/>
+        <source>Number of Skipped Images on PgUp/PgDown</source>
+        <translation>Број прескочених слика на PgUp/PgDown</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkFilePreview</name>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="191"/>
-      <source>Show Left</source>
-      <translation>Прикажи лево</translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="191"/>
+        <source>Show Left</source>
+        <translation>Прикажи лево</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="192"/>
-      <source>Shows the Thumbnail Bar on the Left</source>
-      <translation>Прикажи траку сличица лево</translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="192"/>
+        <source>Shows the Thumbnail Bar on the Left</source>
+        <translation>Прикажи траку сличица лево</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="195"/>
-      <source>Show Top</source>
-      <translation>Прикажи врх</translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="195"/>
+        <source>Show Top</source>
+        <translation>Прикажи врх</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="196"/>
-      <source>Shows the Thumbnail Bar at the Top</source>
-      <translation>Прикажи траку сличица на врху</translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="196"/>
+        <source>Shows the Thumbnail Bar at the Top</source>
+        <translation>Прикажи траку сличица на врху</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="199"/>
-      <source>Show Right</source>
-      <translation>Прикажи десно</translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="199"/>
+        <source>Show Right</source>
+        <translation>Прикажи десно</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="200"/>
-      <source>Shows the Thumbnail Bar on the Right</source>
-      <translation>Прикажи траку сличица на десно</translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="200"/>
+        <source>Shows the Thumbnail Bar on the Right</source>
+        <translation>Прикажи траку сличица на десно</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="203"/>
-      <source>Show Bottom</source>
-      <translation>Прикажи дно</translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="203"/>
+        <source>Show Bottom</source>
+        <translation>Прикажи дно</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="204"/>
-      <source>Shows the Thumbnail Bar at the Bottom</source>
-      <translation>Прикажи траку сличица на дну</translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="204"/>
+        <source>Shows the Thumbnail Bar at the Bottom</source>
+        <translation>Прикажи траку сличица на дну</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="207"/>
-      <source>Undock</source>
-      <translation>Одвоји</translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="207"/>
+        <source>Undock</source>
+        <translation>Одвоји</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="208"/>
-      <source>Undock the thumbnails</source>
-      <translation>Одвоји траку сличица</translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="208"/>
+        <source>Undock the thumbnails</source>
+        <translation>Одвоји траку сличица</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="211"/>
-      <source>File Preview Menu</source>
-      <translation>Мени преглед фајла</translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="211"/>
+        <source>File Preview Menu</source>
+        <translation>Мени преглед фајла</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="578"/>
-      <source>Name: </source>
-      <translation>Име: </translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="585"/>
+        <source>Name: </source>
+        <translation>Име: </translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="579"/>
-      <source>Size: </source>
-      <translation>Величина: </translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="586"/>
+        <source>Size: </source>
+        <translation>Величина: </translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="580"/>
-      <source>Created: </source>
-      <translation>Креирано: </translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="587"/>
+        <source>Created: </source>
+        <translation>Креирано: </translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="597"/>
-      <source>CTRL+Zoom resizes the thumbnails</source>
-      <translation>CTRL+Zoom мења величину сличице</translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="604"/>
+        <source>CTRL+Zoom resizes the thumbnails</source>
+        <translation>CTRL+Zoom мења величину сличице</translation>
     </message>
-  </context>
-  <context>
-    <name>nmc::DkFileSelection</name>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="446"/>
-      <source>No Files Selected</source>
-      <translation>Без одабраних фајлова</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="325"/>
-      <source>File Explorer</source>
-      <translation>Претраживач</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="337"/>
-      <source>Thumbnails</source>
-      <translation>Сличице</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="338"/>
-      <source>File List</source>
-      <translation>Фајл листа</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="382"/>
-      <source>Open an Image Directory</source>
-      <translation>Отвори фасциклу са сликама</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="448"/>
-      <source>%1 File Selected</source>
-      <translation>%1 Одабран фајл</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="450"/>
-      <source>%1 Files Selected</source>
-      <translation>%1 Одабрани фајлови</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="471"/>
-      <location filename="../src/DkGui/DkBatch.cpp" line="485"/>
-      <source>Results</source>
-      <translation>Резултати</translation>
-    </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkFilenameWidget</name>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="514"/>
-      <source>Current Filename</source>
-      <translation>Тренутно име фајла</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="534"/>
+        <source>Current Filename</source>
+        <translation>Тренутно име фајла</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="515"/>
-      <source>Text</source>
-      <translation>Текст</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="535"/>
+        <source>Text</source>
+        <translation>Текст</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="516"/>
-      <source>Number</source>
-      <translation>Број</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="536"/>
+        <source>Number</source>
+        <translation>Број</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="522"/>
-      <source>Keep Case</source>
-      <translation>Задржи случај</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="542"/>
+        <source>Keep Case</source>
+        <translation>Задржи случај</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="523"/>
-      <source>To lowercase</source>
-      <translation>У мала слова</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="543"/>
+        <source>To lowercase</source>
+        <translation>У мала слова</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="524"/>
-      <source>To UPPERCASE</source>
-      <translation>У ВЕЛИКА СЛОВА</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="544"/>
+        <source>To UPPERCASE</source>
+        <translation>У ВЕЛИКА СЛОВА</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="535"/>
-      <source>1 digit</source>
-      <translation>1 цифра</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="555"/>
+        <source>1 digit</source>
+        <translation>1 цифра</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="536"/>
-      <source>2 digits</source>
-      <translation>2 цифре</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="556"/>
+        <source>2 digits</source>
+        <translation>2 цифре</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="537"/>
-      <source>3 digits</source>
-      <translation>3 цифре</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="557"/>
+        <source>3 digits</source>
+        <translation>3 цифре</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="538"/>
-      <source>4 digits</source>
-      <translation>4 цифре</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="558"/>
+        <source>4 digits</source>
+        <translation>4 цифре</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkBatch.cpp" line="539"/>
-      <source>5 digits</source>
-      <translation>5 цифара</translation>
+        <location filename="../src/DkGui/DkBatch.cpp" line="559"/>
+        <source>5 digits</source>
+        <translation>5 цифара</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkForceThumbDialog</name>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4159"/>
-      <source>Overwrite Existing Thumbnails</source>
-      <translation>Пребриши постојеће сличице</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3810"/>
+        <source>Overwrite Existing Thumbnails</source>
+        <translation>Пребриши постојеће сличице</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4164"/>
-      <source>&amp;OK</source>
-      <translation>&amp;У реду</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3815"/>
+        <source>&amp;OK</source>
+        <translation>&amp;У реду</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4165"/>
-      <source>&amp;Cancel</source>
-      <translation>&amp;Откажи</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3816"/>
+        <source>&amp;Cancel</source>
+        <translation>&amp;Откажи</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4182"/>
-      <source>Compute thumbnails for all images in:
+        <location filename="../src/DkGui/DkDialog.cpp" line="3833"/>
+        <source>Compute thumbnails for all images in:
  %1
 </source>
-      <translation>Израчунај сличице за све слике у:
+        <translation>Израчунај сличице за све слике у:
  %1
 </translation>
     </message>
-  </context>
-  <context>
-    <name>nmc::DkGamma</name>
-    <message>
-      <location filename="../src/DkGui/DkManipulationWidgets.cpp" line="1270"/>
-      <source>Gamma</source>
-      <translation>Гама</translation>
-    </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkGeneralPreference</name>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="306"/>
-      <source>Highlight Color</source>
-      <translation>Истакнута боја</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="298"/>
+        <source>Highlight Color</source>
+        <translation>Истакнута боја</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="311"/>
-      <source>Icon Color</source>
-      <translation>Боја икона</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="303"/>
+        <source>Icon Color</source>
+        <translation>Боја икона</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="316"/>
-      <source>Background Color</source>
-      <translation>Позадинска боја</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="308"/>
+        <source>Background Color</source>
+        <translation>Позадинска боја</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="321"/>
-      <source>Fullscreen Color</source>
-      <translation>Боја целог екрана</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="313"/>
+        <source>Fullscreen Color</source>
+        <translation>Боја целог екрана</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="326"/>
-      <source>HUD Foreground Color</source>
-      <translation>HUD боја предњег плана</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="318"/>
+        <source>HUD Foreground Color</source>
+        <translation>HUD боја предњег плана</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="331"/>
-      <source>HUD Background Color</source>
-      <translation>HUD позадинска боја</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="323"/>
+        <source>HUD Background Color</source>
+        <translation>HUD позадинска боја</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="337"/>
-      <source>Color Settings</source>
-      <translation>Подешавање боје</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="329"/>
+        <source>Color Settings</source>
+        <translation>Подешавање боје</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="346"/>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="554"/>
-      <source>Reset All Settings</source>
-      <translation>Врати поставке на почетно</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="339"/>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="607"/>
+        <source>Reset All Settings</source>
+        <translation>Врати поставке на почетно</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="350"/>
-      <source>Default Settings</source>
-      <translation>Подразумеване поставке</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="343"/>
+        <source>&amp;Import Settings</source>
+        <translation>&amp;Импортуј поставке</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="363"/>
-      <source>Show Recent Files on Start-Up</source>
-      <translation>Прикажи недавне фајлове на старту</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="347"/>
+        <source>&amp;Export Settings</source>
+        <translation>&amp;Експортуј поставке</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="365"/>
-      <source>Show the History Panel on Start-Up</source>
-      <translation>Прикажи панел историје на старту</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="351"/>
+        <source>Default Settings</source>
+        <translation>Подразумеване поставке</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="368"/>
-      <source>Log Recent Files</source>
-      <translation>Лог недавних фајлова</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="366"/>
+        <source>Show Recent Files on Start-Up</source>
+        <translation>Прикажи недавне фајлове на старту</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="370"/>
-      <source>If checked, recent files will be saved.</source>
-      <translation>Ако је означено, недавни фајлови ће бити сачувани.</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="368"/>
+        <source>Show the History Panel on Start-Up</source>
+        <translation>Прикажи панел историје на старту</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="373"/>
-      <source>Loop Images</source>
-      <translation>Заокружи слике</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="371"/>
+        <source>Log Recent Files</source>
+        <translation>Лог недавних фајлова</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="375"/>
-      <source>Start with the first image in a folder after showing the last.</source>
-      <translation>Почни са првом сликом у фасцикли по приказивању последње.</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="373"/>
+        <source>If checked, recent files will be saved.</source>
+        <translation>Ако је означено, недавни фајлови ће бити сачувани.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="378"/>
-      <source>Mouse Wheel Zooms</source>
-      <translation>Зумирање точкићем миша</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="376"/>
+        <source>Check for Duplicates on Open</source>
+        <translation>Провери отворене дупликате</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="380"/>
-      <source>If checked, the mouse wheel zooms - otherwise it is used to switch between images.</source>
-      <translation>Ако је означено, точкић миша зумира - иначе се користи за пребацивање између слика.</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="378"/>
+        <source>If any files are opened which are already open in a tab, don&apos;t open them again.</source>
+        <translation>Не отварај поново фајлове који су већ отворени у некој картици.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="383"/>
-      <source>Double Click Opens Fullscreen</source>
-      <translation>Дупли клик отвара режим пуног екрана</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="381"/>
+        <source>Show extra options related to tabs</source>
+        <translation>Прикажи додатне поставке у повезаним картицама</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="385"/>
-      <source>If checked, a double click on the canvas opens the fullscreen mode.</source>
-      <translation>Ако је означено, дупли клик на подлози отвара режим пуног екрана.</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="383"/>
+        <source>Enables the &quot;Go to Tab&quot;, &quot;First Tab&quot;, and &quot;Last Tab&quot; options in the View menu, and the &quot;Open Tabs&quot; and &quot;Save Tabs&quot; options in the File menu.</source>
+        <translation>Приказује &quot;Иди на картицу&quot;, Прва картица&quot;, и &quot;Задња картица&quot; могућности у изборнику погледа, и &quot;Отвори картице&quot; и &quot;Сачувај картице&quot; могућности у изборнику фајлова.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="388"/>
-      <source>Show Background Image</source>
-      <translation>Прикажи позадинску слику</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="386"/>
+        <source>Loop Images</source>
+        <translation>Заокружи слике</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="390"/>
-      <source>If checked, the nomacs logo is shown in the bottom right corner.</source>
-      <translation>Ако је означено, nomacs лого ће бити приказан у доњем десном углу.</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="388"/>
+        <source>Start with the first image in a folder after showing the last.</source>
+        <translation>Почни са првом сликом у фасцикли по приказивању последње.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="393"/>
-      <source>Switch CTRL with ALT</source>
-      <translation>Пребаци CTRL са ALT</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="391"/>
+        <source>Mouse Wheel Zooms</source>
+        <translation>Зумирање точкићем миша</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="395"/>
-      <source>If checked, CTRL + Mouse is switched with ALT + Mouse.</source>
-      <translation>Ако је означено, CTRL + миш је пребачен са ALT + миш.</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="393"/>
+        <source>If checked, the mouse wheel zooms - otherwise it is used to switch between images.</source>
+        <translation>Ако је означено, точкић миша зумира - иначе се користи за пребацивање између слика.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="398"/>
-      <source>Enable LAN Sync</source>
-      <translation>Омогући LAN синхронизацију</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="396"/>
+        <source>Next Image on Horizontal Zoom</source>
+        <translation>Следећа слика при хоризонталном зумирању</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="400"/>
-      <source>If checked, syncing in your LAN is enabled.</source>
-      <translation>Ако је означено, синхронизација је омогућена у LAN.</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="398"/>
+        <source>If checked, horizontal wheel events load the next/previous images.</source>
+        <translation>Ако је укључено, хоризонтално кретање точкића учитава следећу/претходну слику.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="403"/>
-      <source>Close on ESC</source>
-      <translation>Затвори на ESC</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="401"/>
+        <source>Double Click Opens Fullscreen</source>
+        <translation>Дупли клик отвара режим пуног екрана</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="405"/>
-      <source>Close nomacs if ESC is pressed.</source>
-      <translation>Затвори nomacs ако је ESC притиснуто.</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="403"/>
+        <source>If checked, a double click on the canvas opens the fullscreen mode.</source>
+        <translation>Ако је означено, дупли клик на подлози отвара режим пуног екрана.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="408"/>
-      <source>Check For Updates</source>
-      <translation>Провери ажурирање</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="406"/>
+        <source>Show Background Image</source>
+        <translation>Прикажи позадинску слику</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="410"/>
-      <source>Check for updates on start-up.</source>
-      <translation>Провери ажурирање при покретању.</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="408"/>
+        <source>If checked, the nomacs logo is shown in the bottom right corner.</source>
+        <translation>Ако је означено, nomacs лого ће бити приказан у доњем десном углу.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="413"/>
-      <source>General</source>
-      <translation>Опште</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="411"/>
+        <source>Switch CTRL with ALT</source>
+        <translation>Пребаци CTRL са ALT</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="428"/>
-      <source>Choose your preferred language.</source>
-      <translation>Одабери жељени језик.</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="413"/>
+        <source>If checked, CTRL + Mouse is switched with ALT + Mouse.</source>
+        <translation>Ако је означено, CTRL + миш је пребачен са ALT + миш.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="433"/>
-      <source>Info on how to translate nomacs.</source>
-      <translation>Информације како превести nomacs.</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="416"/>
+        <source>Enable LAN Sync</source>
+        <translation>Омогући LAN синхронизацију</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="436"/>
-      <source>Language</source>
-      <translation>Језик</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="418"/>
+        <source>If checked, syncing in your LAN is enabled.</source>
+        <translation>Ако је означено, синхронизација је омогућена у LAN.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="457"/>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="558"/>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="571"/>
-      <source>Please Restart nomacs to apply changes</source>
-      <translation>Молим поново покрените nomacs да би применили промене</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="421"/>
+        <source>Close on ESC</source>
+        <translation>Затвори на ESC</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="554"/>
-      <source>This will reset all personal settings!</source>
-      <translation>Ово ће поништити све личне поставке!</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="423"/>
+        <source>Close nomacs if ESC is pressed.</source>
+        <translation>Затвори nomacs ако је ESC притиснуто.</translation>
     </message>
-  </context>
-  <context>
+    <message>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="426"/>
+        <source>Check For Updates</source>
+        <translation>Провери ажурирање</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="428"/>
+        <source>Check for updates on start-up.</source>
+        <translation>Провери ажурирање при покретању.</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="431"/>
+        <source>General</source>
+        <translation>Опште</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="449"/>
+        <source>Choose your preferred language.</source>
+        <translation>Одабери жељени језик.</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="454"/>
+        <source>Info on how to translate nomacs.</source>
+        <translation>Информације како превести nomacs.</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="457"/>
+        <source>Language</source>
+        <translation>Језик</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="478"/>
+        <source>Please Restart nomacs to apply changes</source>
+        <translation>Молим поново покрените nomacs да би применили промене</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="607"/>
+        <source>This will reset all personal settings!</source>
+        <translation>Ово ће поништити све личне поставке!</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="621"/>
+        <source>Import Settings</source>
+        <translation>Унеси поставке</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="638"/>
+        <source>Export Settings</source>
+        <translation>Извези поставке</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="649"/>
+        <source>Settings exported</source>
+        <translation>Поставке изведене</translation>
+    </message>
+</context>
+<context>
+    <name>nmc::DkGenericProfileWidget</name>
+    <message>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="3074"/>
+        <source>Set As Default</source>
+        <translation>Постави као задано</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="3132"/>
+        <source>Profile Name</source>
+        <translation>Име профила</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="3133"/>
+        <source>Profile Name:</source>
+        <translation>Име профила:</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="3145"/>
+        <source>Profile Already Exists</source>
+        <translation>Профил већ постоји</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="3146"/>
+        <source>Do you want to overwrite %1?</source>
+        <translation>Да ли желите снимити преко %1?</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="3210"/>
+        <source>No Profiles</source>
+        <translation>Нема профила</translation>
+    </message>
+</context>
+<context>
     <name>nmc::DkGlobalSettingsWidget</name>
     <message>
-      <location filename="../src/DkCore/DkUtils.cpp" line="344"/>
-      <source>English</source>
-      <extracomment>this should be the name of the language in which nomacs is translated to</extracomment>
-      <translation>српски</translation>
+        <location filename="../src/DkCore/DkUtils.cpp" line="409"/>
+        <source>English</source>
+        <extracomment>this should be the name of the language in which nomacs is translated to</extracomment>
+        <translation>српски</translation>
     </message>
-  </context>
-  <context>
-    <name>nmc::DkHue</name>
+</context>
+<context>
+    <name>nmc::DkHistogram</name>
     <message>
-      <location filename="../src/DkGui/DkManipulationWidgets.cpp" line="1166"/>
-      <source>Hue</source>
-      <translation>Нијанса</translation>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="2113"/>
+        <source>Show Statistics</source>
+        <translation>Прикажи статистику</translation>
     </message>
-  </context>
-  <context>
+    <message>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="2118"/>
+        <source>Histogram Settings</source>
+        <translation>Хистограм поставке</translation>
+    </message>
+</context>
+<context>
+    <name>nmc::DkHueWidget</name>
+    <message>
+        <location filename="../src/DkGui/DkManipulatorWidgets.cpp" line="403"/>
+        <source>Hue</source>
+        <translation>Нијанса</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkManipulatorWidgets.cpp" line="410"/>
+        <source>Saturation</source>
+        <translation>Засићење</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkManipulatorWidgets.cpp" line="417"/>
+        <source>Brightness</source>
+        <translation>Бистрина</translation>
+    </message>
+</context>
+<context>
     <name>nmc::DkImageContainerT</name>
     <message>
-      <location filename="../src/DkLoader/DkImageContainer.cpp" line="666"/>
-      <source>Sorry, the file: %1 does not exist... </source>
-      <translation>Извини, фајл: %1 не постоји...</translation>
+        <location filename="../src/DkCore/DkImageContainer.cpp" line="671"/>
+        <source>Sorry, the file: %1 does not exist... </source>
+        <translation>Извини, фајл: %1 не постоји... </translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageContainer.cpp" line="673"/>
-      <source>Sorry, you are not allowed to read: %1</source>
-      <translation>Извини, није одобрено читање: %1</translation>
+        <location filename="../src/DkCore/DkImageContainer.cpp" line="678"/>
+        <source>Sorry, you are not allowed to read: %1</source>
+        <translation>Извини, није одобрено читање: %1</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageContainer.cpp" line="784"/>
-      <source>Sorry, I could not load: %1</source>
-      <translation>Извини, није могуће учитавање: %1</translation>
+        <location filename="../src/DkCore/DkImageContainer.cpp" line="796"/>
+        <source>updated...</source>
+        <translation>ажурирано...</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageContainer.cpp" line="827"/>
-      <source>Sorry, I could not download:
+        <location filename="../src/DkCore/DkImageContainer.cpp" line="804"/>
+        <source>Sorry, I could not load: %1</source>
+        <translation>Извини, није могуће учитавање: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/DkCore/DkImageContainer.cpp" line="847"/>
+        <source>Sorry, I could not download:
 %1</source>
-      <translation>Извини, не могу преузети:
+        <translation>Извини, не могу преузети:
 %1</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageContainer.cpp" line="893"/>
-      <source>I can't save an empty file, sorry...
+        <location filename="../src/DkCore/DkImageContainer.cpp" line="913"/>
+        <source>I can&apos;t save an empty file, sorry...
 </source>
-      <translation>Не могу сачувати празан фајл, извини...
+        <translation>Не могу сачувати празан фајл, извини...
 </translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageContainer.cpp" line="898"/>
-      <source>Sorry, the directory: %1  does not exist
+        <location filename="../src/DkCore/DkImageContainer.cpp" line="918"/>
+        <source>Sorry, the directory: %1  does not exist
 </source>
-      <translation>Извини, фасцикла: %1  не постоји
+        <translation>Извини, фасцикла: %1  не постоји
 </translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageContainer.cpp" line="903"/>
-      <source>Sorry, I can't write to the file: %1</source>
-      <translation>Извини, не могу уписати фајл: %1</translation>
+        <location filename="../src/DkCore/DkImageContainer.cpp" line="923"/>
+        <source>Sorry, I can&apos;t write to the file: %1</source>
+        <translation>Извини, не могу уписати фајл: %1</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkImageLoader</name>
     <message>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="852"/>
-      <source>sorry, %1 does not exist anymore...</source>
-      <translation>извини, %1 не постоји више...</translation>
+        <location filename="../src/DkCore/DkImageLoader.cpp" line="857"/>
+        <source>sorry, %1 does not exist anymore...</source>
+        <translation>извини, %1 не постоји више...</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="561"/>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="623"/>
-      <source>You have reached the beginning</source>
-      <translation>Стигли сте на почетак</translation>
+        <location filename="../src/DkCore/DkImageLoader.cpp" line="561"/>
+        <location filename="../src/DkCore/DkImageLoader.cpp" line="623"/>
+        <source>You have reached the beginning</source>
+        <translation>Стигли сте на почетак</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="567"/>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="628"/>
-      <source>You have reached the end</source>
-      <translation>Стигли сте на крај</translation>
+        <location filename="../src/DkCore/DkImageLoader.cpp" line="567"/>
+        <location filename="../src/DkCore/DkImageLoader.cpp" line="628"/>
+        <source>You have reached the end</source>
+        <translation>Стигли сте на крај</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="736"/>
-      <source>Save Image</source>
-      <translation>Сачувај слику</translation>
+        <location filename="../src/DkCore/DkImageLoader.cpp" line="739"/>
+        <source>Save Image</source>
+        <translation>Сачувај слику</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="736"/>
-      <source>Do you want to save changes to:
+        <location filename="../src/DkCore/DkImageLoader.cpp" line="740"/>
+        <source>Do you want to save changes to:
 %1</source>
-      <translation>Да ли желите да сачувате промене у:
+        <translation>Да ли желите да сачувате промене у:
 %1</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="948"/>
-      <source>%1 of %2</source>
-      <translation>%1 од %2</translation>
+        <location filename="../src/DkCore/DkImageLoader.cpp" line="953"/>
+        <source>%1 of %2</source>
+        <translation>%1 од %2</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="1043"/>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="1121"/>
-      <source>Save File %1</source>
-      <translation>Сачувај фајл %1</translation>
+        <location filename="../src/DkCore/DkImageLoader.cpp" line="1051"/>
+        <location filename="../src/DkCore/DkImageLoader.cpp" line="1129"/>
+        <source>Save File %1</source>
+        <translation>Сачувај фајл %1</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="1108"/>
-      <source>Overwrite File</source>
-      <translation>Препиши фајл</translation>
+        <location filename="../src/DkCore/DkImageLoader.cpp" line="1116"/>
+        <source>Overwrite File</source>
+        <translation>Препиши фајл</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="1109"/>
-      <source>Do you want to overwrite:
+        <location filename="../src/DkCore/DkImageLoader.cpp" line="1117"/>
+        <source>Do you want to overwrite:
 %1?</source>
-      <translation>Да ли желите да препишете:
+        <translation>Да ли желите да препишете:
 %1?</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="1237"/>
-      <source>Sorry, I cannot save an empty image...</source>
-      <translation>Извини, не могу сачувати празну слику...</translation>
+        <location filename="../src/DkCore/DkImageLoader.cpp" line="1245"/>
+        <source>Sorry, I cannot save an empty image...</source>
+        <translation>Извини, не могу сачувати празну слику...</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="1420"/>
-      <source>Rotated</source>
-      <translation>Ротирано</translation>
+        <location filename="../src/DkCore/DkImageLoader.cpp" line="1428"/>
+        <source>Rotated</source>
+        <translation>Ротирано</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="1684"/>
-      <source>Error</source>
-      <translation>Грешка</translation>
+        <location filename="../src/DkCore/DkImageLoader.cpp" line="1692"/>
+        <source>Error</source>
+        <translation>Грешка</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="993"/>
-      <source>Save Directory</source>
-      <translation>Сачувај фасциклу</translation>
+        <location filename="../src/DkCore/DkImageLoader.cpp" line="1000"/>
+        <source>Save Directory</source>
+        <translation>Сачувај фасциклу</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="1366"/>
-      <source>%1 deleted...</source>
-      <translation>%1 уклоњено...</translation>
+        <location filename="../src/DkCore/DkImageLoader.cpp" line="1374"/>
+        <source>%1 deleted...</source>
+        <translation>%1 уклоњено...</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="1370"/>
-      <source>Sorry, I could not delete: %1</source>
-      <translation>Извини, не могу уклонити: %1</translation>
+        <location filename="../src/DkCore/DkImageLoader.cpp" line="1378"/>
+        <source>Sorry, I could not delete: %1</source>
+        <translation>Извини, не могу уклонити: %1</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="196"/>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="232"/>
-      <location filename="../src/DkLoader/DkImageLoader.cpp" line="268"/>
-      <source>%1 
+        <location filename="../src/DkCore/DkImageLoader.cpp" line="196"/>
+        <location filename="../src/DkCore/DkImageLoader.cpp" line="232"/>
+        <location filename="../src/DkCore/DkImageLoader.cpp" line="268"/>
+        <source>%1 
  does not contain any image</source>
-      <translation>%1 
+        <translation>%1 
  не садржи никакву слику</translation>
     </message>
-  </context>
-  <context>
-    <name>nmc::DkImageManipulationDialog</name>
-    <message>
-      <location filename="../src/DkGui/DkManipulationWidgets.cpp" line="94"/>
-      <source>Image Manipulation Tools</source>
-      <translation>Алат за обраду слика</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkManipulationWidgets.cpp" line="170"/>
-      <source>&amp;OK</source>
-      <translation>&amp;У реду</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkManipulationWidgets.cpp" line="171"/>
-      <source>&amp;Cancel</source>
-      <translation>&amp;Откажи</translation>
-    </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkImageStorage</name>
     <message>
-      <location filename="../src/DkLoader/DkImageStorage.cpp" line="1245"/>
-      <source>Anti Aliasing Enabled</source>
-      <translation>Омогућен анти-алиас</translation>
+        <location filename="../src/DkCore/DkImageStorage.cpp" line="1572"/>
+        <source>Anti Aliasing Enabled</source>
+        <translation>Омогућен анти-алиас</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkImageStorage.cpp" line="1245"/>
-      <source>Anti Aliasing Disabled</source>
-      <translation>Онемогућен анти-алиас</translation>
+        <location filename="../src/DkCore/DkImageStorage.cpp" line="1572"/>
+        <source>Anti Aliasing Disabled</source>
+        <translation>Онемогућен анти-алиас</translation>
     </message>
-  </context>
-  <context>
-    <name>nmc::DkInstallUpdater</name>
-    <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="228"/>
-      <source>There are new packages available: </source>
-      <translation>Доступни су нови пакети: </translation>
-    </message>
-    <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="235"/>
-      <source>Updates Available</source>
-      <translation>Доступне исправке</translation>
-    </message>
-    <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="240"/>
-      <source>&amp;Upgrade</source>
-      <translation>&amp;Надоградња</translation>
-    </message>
-    <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="241"/>
-      <source>Remind Me &amp;Later</source>
-      <translation>Подсети ме &amp;касније</translation>
-    </message>
-    <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="242"/>
-      <source>&amp;Skip this Version</source>
-      <translation>&amp;Прескочи ову верзију</translation>
-    </message>
-    <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="258"/>
-      <source>nomacs Updates</source>
-      <translation>nomacs ажурирања</translation>
-    </message>
-    <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="258"/>
-      <source>nomacs is up-to-date</source>
-      <translation>nomacs је ажуриран</translation>
-    </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkInstalledPluginsModel</name>
     <message>
-      <location filename="../src/DkLoader/DkPluginManager.cpp" line="745"/>
-      <source>Uninstall</source>
-      <translation>Деинсталирај</translation>
+        <location filename="../src/DkCore/DkPluginManager.cpp" line="783"/>
+        <source>Uninstall</source>
+        <translation>Деинсталирај</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkPluginManager.cpp" line="758"/>
-      <source>Name</source>
-      <translation>Име</translation>
+        <location filename="../src/DkCore/DkPluginManager.cpp" line="796"/>
+        <source>Name</source>
+        <translation>Име</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkPluginManager.cpp" line="760"/>
-      <source>Version</source>
-      <translation>Верзија</translation>
+        <location filename="../src/DkCore/DkPluginManager.cpp" line="798"/>
+        <source>Version</source>
+        <translation>Верзија</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkPluginManager.cpp" line="762"/>
-      <source>Uninstall plugin</source>
-      <translation>Деинсталирај прикључак</translation>
+        <location filename="../src/DkCore/DkPluginManager.cpp" line="800"/>
+        <source>Uninstall plugin</source>
+        <translation>Деинсталирај прикључак</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkListWidget</name>
     <message>
-      <location filename="../src/DkGui/DkWidgets.h" line="945"/>
-      <source>Drag Items Here</source>
-      <translation>Пренеси ствари овде</translation>
+        <location filename="../src/DkGui/DkWidgets.h" line="969"/>
+        <source>Drag Items Here</source>
+        <translation>Пренеси ствари овде</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
+    <name>nmc::DkManipulatorWidget</name>
+    <message>
+        <location filename="../src/DkGui/DkManipulatorWidgets.cpp" line="120"/>
+        <source>Undo</source>
+        <translation>Опозови</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkManipulatorWidgets.cpp" line="128"/>
+        <source>Redo</source>
+        <translation>Понови</translation>
+    </message>
+</context>
+<context>
     <name>nmc::DkMessageBox</name>
     <message>
-      <location filename="../src/DkLoader/DkMessageBox.cpp" line="66"/>
-      <source>Error</source>
-      <translation>Грешка</translation>
+        <location filename="../src/DkCore/DkMessageBox.cpp" line="66"/>
+        <source>Error</source>
+        <translation>Грешка</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkMessageBox.cpp" line="99"/>
-      <source>Remember my choice</source>
-      <translation>Запамти мој избор</translation>
+        <location filename="../src/DkCore/DkMessageBox.cpp" line="100"/>
+        <source>Remember my choice</source>
+        <translation>Запамти мој избор</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkMetaData</name>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="60"/>
-      <source>Image Size</source>
-      <translation>Величина слике</translation>
+        <location filename="../src/DkCore/DkSettings.cpp" line="65"/>
+        <source>Image Size</source>
+        <translation>Величина слике</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="61"/>
-      <source>Orientation</source>
-      <translation>Оријентација</translation>
+        <location filename="../src/DkCore/DkSettings.cpp" line="66"/>
+        <source>Orientation</source>
+        <translation>Оријентација</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="62"/>
-      <source>Make</source>
-      <translation>Марка</translation>
+        <location filename="../src/DkCore/DkSettings.cpp" line="67"/>
+        <source>Make</source>
+        <translation>Марка</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="63"/>
-      <source>Model</source>
-      <translation>Модел</translation>
+        <location filename="../src/DkCore/DkSettings.cpp" line="68"/>
+        <source>Model</source>
+        <translation>Модел</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="64"/>
-      <source>Aperture Value</source>
-      <translation>Отвор бленде</translation>
+        <location filename="../src/DkCore/DkSettings.cpp" line="69"/>
+        <source>Aperture Value</source>
+        <translation>Отвор бленде</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="65"/>
-      <source>ISO</source>
-      <translation>ИСО</translation>
+        <location filename="../src/DkCore/DkSettings.cpp" line="70"/>
+        <source>ISO</source>
+        <translation>ИСО</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="66"/>
-      <source>Flash</source>
-      <translation>Блиц</translation>
+        <location filename="../src/DkCore/DkSettings.cpp" line="71"/>
+        <source>Flash</source>
+        <translation>Блиц</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="67"/>
-      <source>Focal Length</source>
-      <translation>Фокусна даљина</translation>
+        <location filename="../src/DkCore/DkSettings.cpp" line="72"/>
+        <source>Focal Length</source>
+        <translation>Фокусна даљина</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="68"/>
-      <source>Exposure Mode</source>
-      <translation>Режим експозиције</translation>
+        <location filename="../src/DkCore/DkSettings.cpp" line="73"/>
+        <source>Exposure Mode</source>
+        <translation>Режим експозиције</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="69"/>
-      <source>Exposure Time</source>
-      <translation>Време експозиције</translation>
+        <location filename="../src/DkCore/DkSettings.cpp" line="74"/>
+        <source>Exposure Time</source>
+        <translation>Време експозиције</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="72"/>
-      <source>Rating</source>
-      <translation>Оцена</translation>
+        <location filename="../src/DkCore/DkSettings.cpp" line="77"/>
+        <source>Rating</source>
+        <translation>Оцена</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="73"/>
-      <source>User Comment</source>
-      <translation>Коментар корисника</translation>
+        <location filename="../src/DkCore/DkSettings.cpp" line="78"/>
+        <source>User Comment</source>
+        <translation>Коментар корисника</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="74"/>
-      <source>Date Time</source>
-      <translation>Датум и време</translation>
+        <location filename="../src/DkCore/DkSettings.cpp" line="79"/>
+        <source>Date Time</source>
+        <translation>Датум и време</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="75"/>
-      <source>Date Time Original</source>
-      <translation>Оригинал датум и време</translation>
+        <location filename="../src/DkCore/DkSettings.cpp" line="80"/>
+        <source>Date Time Original</source>
+        <translation>Оригинал датум и време</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="76"/>
-      <source>Image Description</source>
-      <translation>Опис слике</translation>
+        <location filename="../src/DkCore/DkSettings.cpp" line="81"/>
+        <source>Image Description</source>
+        <translation>Опис слике</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="77"/>
-      <source>Creator</source>
-      <translation>Креатор</translation>
+        <location filename="../src/DkCore/DkSettings.cpp" line="82"/>
+        <source>Creator</source>
+        <translation>Креатор</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="78"/>
-      <source>Creator Title</source>
-      <translation>Наслов креатора</translation>
+        <location filename="../src/DkCore/DkSettings.cpp" line="83"/>
+        <source>Creator Title</source>
+        <translation>Наслов креатора</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="79"/>
-      <source>City</source>
-      <translation>Град</translation>
+        <location filename="../src/DkCore/DkSettings.cpp" line="84"/>
+        <source>City</source>
+        <translation>Град</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="80"/>
-      <source>Country</source>
-      <translation>Држава</translation>
+        <location filename="../src/DkCore/DkSettings.cpp" line="85"/>
+        <source>Country</source>
+        <translation>Држава</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="81"/>
-      <source>Headline</source>
-      <translation>Наслов</translation>
+        <location filename="../src/DkCore/DkSettings.cpp" line="86"/>
+        <source>Headline</source>
+        <translation>Наслов</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="82"/>
-      <source>Caption</source>
-      <translation>Натпис</translation>
+        <location filename="../src/DkCore/DkSettings.cpp" line="87"/>
+        <source>Caption</source>
+        <translation>Натпис</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="83"/>
-      <source>Copyright</source>
-      <translation>Ауторска права</translation>
+        <location filename="../src/DkCore/DkSettings.cpp" line="88"/>
+        <source>Copyright</source>
+        <translation>Ауторска права</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="84"/>
-      <source>Keywords</source>
-      <translation>Кључне речи</translation>
+        <location filename="../src/DkCore/DkSettings.cpp" line="89"/>
+        <source>Keywords</source>
+        <translation>Кључне речи</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="85"/>
-      <source>Path</source>
-      <translation>Путања</translation>
+        <location filename="../src/DkCore/DkSettings.cpp" line="90"/>
+        <source>Path</source>
+        <translation>Путања</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkSettings.cpp" line="86"/>
-      <source>File Size</source>
-      <translation>Величина фајла</translation>
+        <location filename="../src/DkCore/DkSettings.cpp" line="91"/>
+        <source>File Size</source>
+        <translation>Величина фајла</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkMetaDataDock</name>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="389"/>
-      <source>Thumbnail</source>
-      <translation>Сличица</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="389"/>
+        <source>Thumbnail</source>
+        <translation>Сличица</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkMetaDataHUD</name>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="682"/>
-      <source>Image Information</source>
-      <translation>Информације о слици</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="683"/>
+        <source>Image Information</source>
+        <translation>Информације о слици</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="729"/>
-      <source>Change Entries</source>
-      <translation>Измени уписе</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="730"/>
+        <source>Change Entries</source>
+        <translation>Измени уписе</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="730"/>
-      <source>You can customize the entries displayed here.</source>
-      <translation>Овде можете прилагодити приказане уписе.</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="731"/>
+        <source>You can customize the entries displayed here.</source>
+        <translation>Овде можете прилагодити приказане уписе.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="733"/>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="1113"/>
-      <source>Number of Columns</source>
-      <translation>Број колона</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="734"/>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="1114"/>
+        <source>Number of Columns</source>
+        <translation>Број колона</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="734"/>
-      <source>Select the desired number of columns.</source>
-      <translation>Изаберите жељени број колона.</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="735"/>
+        <source>Select the desired number of columns.</source>
+        <translation>Изаберите жељени број колона.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="737"/>
-      <source>Set to Default</source>
-      <translation>Врати на стандардне поставке</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="738"/>
+        <source>Set to Default</source>
+        <translation>Врати на стандардне поставке</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="738"/>
-      <source>Reset the metadata panel.</source>
-      <translation>Ресетуј панел о информацијама.</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="739"/>
+        <source>Reset the metadata panel.</source>
+        <translation>Ресетуј панел о информацијама.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="742"/>
-      <source>Show Left</source>
-      <translation>Прикажи лево</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="743"/>
+        <source>Show Left</source>
+        <translation>Прикажи лево</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="743"/>
-      <source>Shows the Metadata on the Left</source>
-      <translation>Приказује информације лево</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="744"/>
+        <source>Shows the Metadata on the Left</source>
+        <translation>Приказује информације лево</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="746"/>
-      <source>Show Top</source>
-      <translation>Прикажи врх</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="747"/>
+        <source>Show Top</source>
+        <translation>Прикажи врх</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="747"/>
-      <source>Shows the Metadata at the Top</source>
-      <translation>Приказује информације на врху</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="748"/>
+        <source>Shows the Metadata at the Top</source>
+        <translation>Приказује информације на врху</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="750"/>
-      <source>Show Right</source>
-      <translation>Прикажи десно</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="751"/>
+        <source>Show Right</source>
+        <translation>Прикажи десно</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="751"/>
-      <source>Shows the Metadata on the Right</source>
-      <translation>Приказује информације десно</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="752"/>
+        <source>Shows the Metadata on the Right</source>
+        <translation>Приказује информације десно</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="754"/>
-      <source>Show Bottom</source>
-      <translation>Прикажи дно</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="755"/>
+        <source>Show Bottom</source>
+        <translation>Прикажи дно</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="755"/>
-      <source>Shows the Metadata at the Bottom</source>
-      <translation>Приказује информације на дну</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="756"/>
+        <source>Shows the Metadata at the Bottom</source>
+        <translation>Приказује информације на дну</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="1030"/>
-      <source>Metadata Menu</source>
-      <translation>Мени са информацијама</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="1031"/>
+        <source>Metadata Menu</source>
+        <translation>Мени са информацијама</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="1092"/>
-      <source>&amp;OK</source>
-      <translation>&amp;У реду</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="1093"/>
+        <source>&amp;OK</source>
+        <translation>&amp;У реду</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="1093"/>
-      <source>&amp;Cancel</source>
-      <translation>&amp;Откажи</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="1094"/>
+        <source>&amp;Cancel</source>
+        <translation>&amp;Откажи</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="1113"/>
-      <source>Number of columns (-1 is default)</source>
-      <translation>Број колона (обично -1)</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="1114"/>
+        <source>Number of columns (-1 is default)</source>
+        <translation>Број колона (обично -1)</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkMetaDataModel</name>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="64"/>
-      <source>Key</source>
-      <translation>Кључ</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="64"/>
+        <source>Key</source>
+        <translation>Кључ</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="64"/>
-      <source>Value</source>
-      <translation>Вредност</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="64"/>
+        <source>Value</source>
+        <translation>Вредност</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="146"/>
-      <source>Data.</source>
-      <translation>Подаци.</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="145"/>
+        <source>Data.</source>
+        <translation>Подаци.</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkMetaDataSelection</name>
     <message>
-      <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="550"/>
-      <source>Check All</source>
-      <translation>Провери све</translation>
+        <location filename="../src/DkGui/DkMetaDataWidgets.cpp" line="550"/>
+        <source>Check All</source>
+        <translation>Провери све</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkMosaicDialog</name>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3207"/>
-      <source>Create Mosaic Image</source>
-      <translation>Креирај мозаик</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2858"/>
+        <source>Create Mosaic Image</source>
+        <translation>Креирај мозаик</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3270"/>
-      <source>Darken</source>
-      <translation>Тамније</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2921"/>
+        <source>Darken</source>
+        <translation>Тамније</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3271"/>
-      <source>Lighten</source>
-      <translation>Светлије</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2922"/>
+        <source>Lighten</source>
+        <translation>Светлије</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3272"/>
-      <source>Saturation</source>
-      <translation>Засићење</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2923"/>
+        <source>Saturation</source>
+        <translation>Засићење</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3280"/>
-      <source>Mosaic Image:</source>
-      <translation>Мозаик:</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2931"/>
+        <source>Mosaic Image:</source>
+        <translation>Мозаик:</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3283"/>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3293"/>
-      <source>&amp;Browse</source>
-      <translation>&amp;Прегледај</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2934"/>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2944"/>
+        <source>&amp;Browse</source>
+        <translation>&amp;Прегледај</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3285"/>
-      <source>Choose which image to mosaic.</source>
-      <translation>Одабери слику за мозаик.</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2936"/>
+        <source>Choose which image to mosaic.</source>
+        <translation>Одабери слику за мозаик.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3287"/>
-      <source>No Image loaded</source>
-      <translation>Слике нису учитане</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2938"/>
+        <source>No Image loaded</source>
+        <translation>Слике нису учитане</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3290"/>
-      <source>Image Database:</source>
-      <translation>Сликовна база:</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2941"/>
+        <source>Image Database:</source>
+        <translation>Сликовна база:</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3295"/>
-      <source>Specify the root folder of the image database.</source>
-      <translation>Одреди основну фасциклу за базу слика.</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2946"/>
+        <source>Specify the root folder of the image database.</source>
+        <translation>Одреди основну фасциклу за базу слика.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3297"/>
-      <source>Specify an Image Database</source>
-      <translation>Подесите сликовну базу</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2948"/>
+        <source>Specify an Image Database</source>
+        <translation>Подесите сликовну базу</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3300"/>
-      <source>Resolution:</source>
-      <translation>Резолуција:</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2951"/>
+        <source>Resolution:</source>
+        <translation>Резолуција:</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3304"/>
-      <source>Pixel Width</source>
-      <translation>Ширина пиксела</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2955"/>
+        <source>Pixel Width</source>
+        <translation>Ширина пиксела</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3309"/>
-      <source>Pixel Height</source>
-      <translation>Висина пиксела</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2960"/>
+        <source>Pixel Height</source>
+        <translation>Висина пиксела</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3316"/>
-      <source>Patches:</source>
-      <translation>Закрпе:</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2967"/>
+        <source>Patches:</source>
+        <translation>Закрпе:</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3320"/>
-      <source>Number of Horizontal Patches</source>
-      <translation>Број водоравних закрпа</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2971"/>
+        <source>Number of Horizontal Patches</source>
+        <translation>Број водоравних закрпа</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3325"/>
-      <source>Number of Vertical Patches</source>
-      <translation>Број усправних закрпа</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2976"/>
+        <source>Number of Vertical Patches</source>
+        <translation>Број усправних закрпа</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3330"/>
-      <source>If this label turns red, the computation might be slower.</source>
-      <translation>Ако поцрвени, обрачун може бити спорији.</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2981"/>
+        <source>If this label turns red, the computation might be slower.</source>
+        <translation>Ако поцрвени, обрачун може бити спорији.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3333"/>
-      <source>Filters:</source>
-      <translation>Филтери:</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2984"/>
+        <source>Filters:</source>
+        <translation>Филтери:</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3338"/>
-      <source>You can split multiple ignore words with ;</source>
-      <translation>Више занемари речи можете поделити са ;</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2989"/>
+        <source>You can split multiple ignore words with ;</source>
+        <translation>Више занемари речи можете поделити са ;</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3342"/>
-      <source>All Images</source>
-      <translation>Све слике</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2993"/>
+        <source>All Images</source>
+        <translation>Све слике</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3391"/>
-      <source>&amp;Save</source>
-      <translation>&amp;Сачувај</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3042"/>
+        <source>&amp;Save</source>
+        <translation>&amp;Сачувај</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3392"/>
-      <source>&amp;Generate</source>
-      <translation>&amp;Генериши</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3043"/>
+        <source>&amp;Generate</source>
+        <translation>&amp;Генериши</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3393"/>
-      <source>&amp;Cancel</source>
-      <translation>&amp;Откажи</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3044"/>
+        <source>&amp;Cancel</source>
+        <translation>&amp;Откажи</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3413"/>
-      <source>Open TIFF</source>
-      <translation>Oтвори TIFF</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3064"/>
+        <source>Open TIFF</source>
+        <translation>Oтвори TIFF</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3423"/>
-      <source>Open an Image Directory</source>
-      <translation>Отвори фасциклу са сликама</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3074"/>
+        <source>Open an Image Directory</source>
+        <translation>Отвори фасциклу са сликама</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3444"/>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3456"/>
-      <source>%1 x %2 cm @150 dpi</source>
-      <translation>%1 x %2 cm @150 dpi</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3095"/>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3107"/>
+        <source>%1 x %2 cm @150 dpi</source>
+        <translation>%1 x %2 cm @150 dpi</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3501"/>
-      <source>Patch Resolution: %1 px</source>
-      <translation>Закрпи резолуцију: %1 px</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3152"/>
+        <source>Patch Resolution: %1 px</source>
+        <translation>Закрпи резолуцију: %1 px</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3699"/>
-      <source>Filling empty areas...</source>
-      <translation>Попуњавање празних подручја...</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3350"/>
+        <source>Filling empty areas...</source>
+        <translation>Попуњавање празних подручја...</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3703"/>
-      <source>I need to use some images twice - maybe the database is too small?</source>
-      <translation>Морам да користим неке слике два пута - можда је база слика премала?</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3354"/>
+        <source>I need to use some images twice - maybe the database is too small?</source>
+        <translation>Морам да користим неке слике два пута - можда је база слика премала?</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3708"/>
-      <source>Sorry, it seems that i cannot create your mosaic with this database.</source>
-      <translation>Извини, изгледа да не могу креирати твој мозаик са овом базом.</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3359"/>
+        <source>Sorry, it seems that i cannot create your mosaic with this database.</source>
+        <translation>Извини, изгледа да не могу креирати твој мозаик са овом базом.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3832"/>
-      <source>Something is seriously wrong, I could not load: %1</source>
-      <translation>Нешто је озбиљно није у реду, не могу да учитам: %1</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3483"/>
+        <source>Something is seriously wrong, I could not load: %1</source>
+        <translation>Нешто је озбиљно није у реду, не могу да учитам: %1</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4079"/>
-      <source>Error</source>
-      <translation>Грешка</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3730"/>
+        <source>Error</source>
+        <translation>Грешка</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4079"/>
-      <source>Sorry, I could not mix the image...</source>
-      <translation>Извини, не могу спојити слику...</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3730"/>
+        <source>Sorry, I could not mix the image...</source>
+        <translation>Извини, не могу спојити слику...</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkNoMacs</name>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="248"/>
-      <source>Edit</source>
-      <translation>Измени</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="328"/>
+        <source>&amp;Sync</source>
+        <translation>&amp;Синхронизација</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="361"/>
-      <source>&amp;Sync</source>
-      <translation>&amp;Синхронизација</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="287"/>
+        <source>Movie Toolbar</source>
+        <translation>Трака алата за видео</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="295"/>
-      <source>Movie Toolbar</source>
-      <translation>Трака алата за видео</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="239"/>
+        <source>Edit Toolbar</source>
+        <translation>Уреди алтану траку</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="365"/>
-      <source>Pl&amp;ugins</source>
-      <translation>П&amp;рикључак</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="332"/>
+        <source>Pl&amp;ugins</source>
+        <translation>П&amp;рикључак</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="626"/>
-      <source>Quit nomacs</source>
-      <translation>Напусти nomacs</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="562"/>
+        <source>Quit nomacs</source>
+        <translation>Напусти nomacs</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="627"/>
-      <source>Do you want nomacs to save your tabs?</source>
-      <translation>Да ли желите да nomacs сачува ваше картице?</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="563"/>
+        <source>Do you want nomacs to save your tabs?</source>
+        <translation>Да ли желите да nomacs сачува ваше картице?</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="629"/>
-      <source>&amp;Save and Quit</source>
-      <translation>&amp;Сачувај и напусти</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="565"/>
+        <source>&amp;Save and Quit</source>
+        <translation>&amp;Сачувај и напусти</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="630"/>
-      <source>&amp;Quit</source>
-      <translation>&amp;Напусти</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="566"/>
+        <source>&amp;Quit</source>
+        <translation>&amp;Напусти</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="815"/>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="833"/>
-      <source>Sorry, I cannot Flip the Image...</source>
-      <translation>Извини, не могу окренути слику...</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="923"/>
+        <source>Recursive Folder Scan is Now Enabled</source>
+        <translation>Повратно скенирање фасцикле је сада омогућено</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="817"/>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="835"/>
-      <source>Flipped</source>
-      <translation>Преврнуто</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="925"/>
+        <source>Recursive Folder Scan is Now Disabled</source>
+        <translation>Повратно скенирање фасцикле је сада онемогућено</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="852"/>
-      <source>Sorry, I cannot Invert the Image...</source>
-      <translation>Извини, не могу обрнути слику...</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="934"/>
+        <source>Change Opacity</source>
+        <translation>Измени провидност</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="854"/>
-      <source>Inverted</source>
-      <translation>Преокренуто</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="897"/>
-      <source>Sorry, I cannot convert the Image...</source>
-      <translation>Извини, не могу конвертовати слику...</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="899"/>
-      <source>Grayscale</source>
-      <translation>У сивим тоновима</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="916"/>
-      <source>The Image is Already Normalized...</source>
-      <translation>Слика је већ нормализована...</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="918"/>
-      <source>Normalized</source>
-      <translation>Нормализовано</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="935"/>
-      <source>Sorry, I cannot Auto Adjust</source>
-      <translation>Извини, не могу аутоматски подесити</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="937"/>
-      <source>Auto Adjust</source>
-      <translation>Аутоматско прилагођавање</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="949"/>
-      <source>Unsharp Mask</source>
-      <translation>Маска изоштравања</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="969"/>
-      <source>Tiny Planet</source>
-      <translation>Мала планета</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1136"/>
-      <source>Recursive Folder Scan is Now Enabled</source>
-      <translation>Повратно скенирање фасцикле је сада омогућено</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1138"/>
-      <source>Recursive Folder Scan is Now Disabled</source>
-      <translation>Повратно скенирање фасцикле је сада онемогућено</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1147"/>
-      <source>Change Opacity</source>
-      <translation>Измени провидност</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1222"/>
-      <source>Window Locked
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1009"/>
+        <source>Window Locked
 To unlock: gain focus (ALT+Tab),
 then press CTRL+SHIFT+ALT+B</source>
-      <translation>Прозор закључан
+        <translation>Прозор закључан
 Да откључате: изаберите (ALT+Tab),
 онда притисните CTRL+SHIFT+ALT+B</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1225"/>
-      <source>You should first reduce opacity
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1012"/>
+        <source>You should first reduce opacity
  before working through the window.</source>
-      <translation>Прво треба да смањите провидност
+        <translation>Прво треба да смањите провидност
  пре рада преко прозора.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1316"/>
-      <source>File Explorer</source>
-      <translation>Претраживач</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1102"/>
+        <source>File Explorer</source>
+        <translation>Претраживач</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1344"/>
-      <source>Meta Data Info</source>
-      <translation>Мета подаци</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1130"/>
+        <source>Meta Data Info</source>
+        <translation>Мета подаци</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1362"/>
-      <source>History</source>
-      <translation>Историја</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1148"/>
+        <source>Edit Image</source>
+        <translation>Уреди слику</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1400"/>
-      <source>Thumbnails</source>
-      <translation>Сличице</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1166"/>
+        <source>History</source>
+        <translation>Историја</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1437"/>
-      <source>Open an Image Directory</source>
-      <translation>Отвори фасциклу са сликама</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1204"/>
+        <source>Thumbnails</source>
+        <translation>Сличице</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1455"/>
-      <source>All Files (*.*)</source>
-      <translation>Сви фајлови (*.*)</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1241"/>
+        <source>Open an Image Directory</source>
+        <translation>Отвори фасциклу са сликама</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1458"/>
-      <source>Open Image</source>
-      <translation>Отвори слику</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1259"/>
+        <source>All Files (*.*)</source>
+        <translation>Сви фајлови (*.*)</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1522"/>
-      <source>Sorry, the directory: %1  does not exist
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1262"/>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1310"/>
+        <source>Open Image</source>
+        <translation>Отвори слику</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1293"/>
+        <source>The following duplicates were not added:</source>
+        <translation>Следећи дупликати нису додани:</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1306"/>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1341"/>
+        <source>Text file (*.txt)</source>
+        <translation>Текстуални фајл (*.txt)</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1307"/>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1342"/>
+        <source>All files (*.*)</source>
+        <translation>Сви фајлови (*.*)</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1344"/>
+        <source>Save Tab List</source>
+        <translation>Сними листу картица</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1415"/>
+        <source>Sorry, the directory: %1  does not exist
 </source>
-      <translation>Извини, фасцикла: %1  не постоји
+        <translation>Извини, фасцикла: %1  не постоји
 </translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1535"/>
-      <source>Rename:</source>
-      <translation>Преименуј:</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1428"/>
+        <source>Rename:</source>
+        <translation>Преименуј:</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1550"/>
-      <source>Question</source>
-      <translation>Питање</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1443"/>
+        <source>Question</source>
+        <translation>Питање</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1565"/>
-      <source>Sorry, I can't delete: %1</source>
-      <translation>Извини, не могу уклонити: %1</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1458"/>
+        <source>Sorry, I can&apos;t delete: %1</source>
+        <translation>Извини, не могу уклонити: %1</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1580"/>
-      <source>Sorry, I can't rename: %1</source>
-      <translation>Извини, не могу преименовати: %1</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1473"/>
+        <source>Sorry, I can&apos;t rename: %1</source>
+        <translation>Извини, не могу преименовати: %1</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1660"/>
-      <source>Go To Image</source>
-      <translation>Иди на слику</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1553"/>
+        <source>Go To Image</source>
+        <translation>Иди на слику</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1660"/>
-      <source>Image Index:</source>
-      <translation>Индекс слике:</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1553"/>
+        <source>Image Index:</source>
+        <translation>Индекс слике:</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1765"/>
-      <source>Resize</source>
-      <translation>Промени величину</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1636"/>
+        <source>Resize</source>
+        <translation>Промени величину</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1789"/>
-      <source>Shall I move %1 to trash?</source>
-      <translation>Преместити %1 у смеће?</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1660"/>
+        <source>Shall I move %1 to trash?</source>
+        <translation>Преместити %1 у смеће?</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1791"/>
-      <source>Do you want to permanently delete %1?</source>
-      <translation>Да ли желите бесповратно уклонити %1?</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1662"/>
+        <source>Do you want to permanently delete %1?</source>
+        <translation>Да ли желите бесповратно уклонити %1?</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1796"/>
-      <source>Delete File</source>
-      <translation>Уклони фајл</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1667"/>
+        <source>Delete File</source>
+        <translation>Уклони фајл</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1836"/>
-      <source>Mosaic</source>
-      <translation>Мозаик</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1707"/>
+        <source>Mosaic</source>
+        <translation>Мозаик</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1866"/>
-      <source>Adjusted</source>
-      <translation>Прилагођено</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1727"/>
+        <source>Sorry, I could not create a wallpaper...</source>
+        <translation>Извини, не могу креирати позадинску слику...</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1886"/>
-      <source>Sorry, I could not create a wallpaper...</source>
-      <translation>Извини, не могу креирати позадинску слику...</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1771"/>
+        <source>Save Thumbnails</source>
+        <translation>Сачувај сличице</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1930"/>
-      <source>Save Thumbnails</source>
-      <translation>Сачувај сличице</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="2117"/>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="2133"/>
+        <source> [Private Mode]</source>
+        <translation> [Приватни режим]</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="2315"/>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="2331"/>
-      <source> [Private Mode]</source>
-      <translation> [Приватни режим]</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="2219"/>
+        <source>Already downloading update</source>
+        <translation>Већ је преузето ажурирање</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="2413"/>
-      <source>Already downloading update</source>
-      <translation>Већ је преузето ажурирање</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="2246"/>
+        <source>Downloading update...</source>
+        <translation>Преузимам ажурирање...</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="2440"/>
-      <source>Downloading update...</source>
-      <translation>Преузимам ажурирање...</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="2246"/>
+        <source>Cancel Update</source>
+        <translation>Неуспело ажурирање</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="2440"/>
-      <source>Cancel Update</source>
-      <translation>Неуспело ажурирање</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="2280"/>
+        <source>Unable to install new version&lt;br&gt;</source>
+        <translation>Онемогућена инсталација нове верзије&lt;br&gt;</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="2474"/>
-      <source>Unable to install new version&lt;br&gt;</source>
-      <translation>Онемогућена инсталација нове верзије&lt;br&gt;</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="2281"/>
+        <source>You can download the new version from our web page</source>
+        <translation>Можете преузети нову верзију са наше веб странице</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="2475"/>
-      <source>You can download the new version from our web page</source>
-      <translation>Можете преузети нову верзију са наше веб странице</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1727"/>
+        <source>Error</source>
+        <translation>Грешка</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1886"/>
-      <source>Error</source>
-      <translation>Грешка</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1419"/>
+        <source>Sorry, I can&apos;t write to the fileInfo: %1</source>
+        <translation>Извини, не могу писати у фајл: %1</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1526"/>
-      <source>Sorry, I can't write to the fileInfo: %1</source>
-      <translation>Извини, не могу писати у фајл: %1</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="1551"/>
-      <source>The fileInfo: %1  already exists.
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="1444"/>
+        <source>The fileInfo: %1  already exists.
  Do you want to replace it?</source>
-      <translation>фајл: %1 већ постоји.
+        <translation>фајл: %1 већ постоји.
 Да ли желите да га замените?</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="2489"/>
-      <source>Downloading new translations...</source>
-      <translation>Преузимам нове преводе...</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="2295"/>
+        <source>Downloading new translations...</source>
+        <translation>Преузимам нове преводе...</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="2489"/>
-      <source>Cancel</source>
-      <translation>Отказано</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="2295"/>
+        <source>Cancel</source>
+        <translation>Отказано</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkNoMacsSync</name>
     <message>
-      <location filename="../src/DkGui/DkNoMacs.cpp" line="2861"/>
-      <source>Sorry, I could not find any clients.</source>
-      <translation>Извини, не могу пронаћи било ког клијента.</translation>
+        <location filename="../src/DkGui/DkNoMacs.cpp" line="2546"/>
+        <source>Sorry, I could not find any clients.</source>
+        <translation>Извини, не могу пронаћи било ког клијента.</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkOpacityDialog</name>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2502"/>
-      <source>Window Opacity</source>
-      <translation>Провидност прозора</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2531"/>
+        <source>Window Opacity</source>
+        <translation>Провидност прозора</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2507"/>
-      <source>&amp;OK</source>
-      <translation>&amp;У реду</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2536"/>
+        <source>&amp;OK</source>
+        <translation>&amp;У реду</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2508"/>
-      <source>&amp;Cancel</source>
-      <translation>&amp;Откажи</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2537"/>
+        <source>&amp;Cancel</source>
+        <translation>&amp;Откажи</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkPlayer</name>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="1256"/>
-      <source>Show previous image</source>
-      <translation>Прикажи претходну поруку</translation>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="1263"/>
+        <source>Show previous image</source>
+        <translation>Прикажи претходну слику</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="1268"/>
-      <source>Play/Pause</source>
-      <translation>Репродукуј/Паузирај</translation>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="1275"/>
+        <source>Play/Pause</source>
+        <translation>Репродукуј/Паузирај</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="1280"/>
-      <source>Show next image</source>
-      <translation>Прикажи следећу слику</translation>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="1287"/>
+        <source>Show next image</source>
+        <translation>Прикажи следећу слику</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="1323"/>
-      <source>play</source>
-      <translation>емитуј</translation>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="1330"/>
+        <source>play</source>
+        <translation>емитуј</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkPluginContainer</name>
     <message>
-      <location filename="../src/DkLoader/DkPluginManager.cpp" line="395"/>
-      <source>Author:</source>
-      <translation>Аутор:</translation>
+        <location filename="../src/DkCore/DkPluginManager.cpp" line="435"/>
+        <source>Author:</source>
+        <translation>Аутор:</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkPluginManager.cpp" line="396"/>
-      <source>Company:</source>
-      <translation>Фирма:</translation>
+        <location filename="../src/DkCore/DkPluginManager.cpp" line="436"/>
+        <source>Company:</source>
+        <translation>Фирма:</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkPluginManager.cpp" line="397"/>
-      <source>Created:</source>
-      <translation>Креирано:</translation>
+        <location filename="../src/DkCore/DkPluginManager.cpp" line="437"/>
+        <source>Created:</source>
+        <translation>Креирано:</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkPluginManager.cpp" line="398"/>
-      <source>Last Modified:</source>
-      <translation>Последње измењено:</translation>
+        <location filename="../src/DkCore/DkPluginManager.cpp" line="438"/>
+        <source>Last Modified:</source>
+        <translation>Последње измењено:</translation>
     </message>
-    <message>
-      <location filename="../src/DkLoader/DkPluginManager.cpp" line="399"/>
-      <source>Dependencies:</source>
-      <translation>Зависности:</translation>
-    </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkPluginManagerDialog</name>
     <message>
-      <location filename="../src/DkLoader/DkPluginManager.cpp" line="507"/>
-      <source>Plugin Manager</source>
-      <translation>Менаџер прикључака</translation>
+        <location filename="../src/DkCore/DkPluginManager.cpp" line="547"/>
+        <source>Plugin Manager</source>
+        <translation>Менаџер прикључака</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkPluginManager.cpp" line="519"/>
-      <source>&amp;Close</source>
-      <translation>&amp;Затвори</translation>
+        <location filename="../src/DkCore/DkPluginManager.cpp" line="559"/>
+        <source>&amp;Close</source>
+        <translation>&amp;Затвори</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkPluginTableWidget</name>
     <message>
-      <location filename="../src/DkLoader/DkPluginManager.cpp" line="581"/>
-      <source>Search plugins</source>
-      <translation>Тражи прикључке</translation>
+        <location filename="../src/DkCore/DkPluginManager.cpp" line="618"/>
+        <source>Search plugins</source>
+        <translation>Тражи прикључке</translation>
     </message>
-    <message>
-      <location filename="../src/DkLoader/DkPluginManager.cpp" line="584"/>
-      <source>Add or Remove Plugins</source>
-      <translation>Додај или уклони прикључке</translation>
-    </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkPongPort</name>
     <message>
-      <location filename="../src/DkGui/DkPong.cpp" line="336"/>
-      <source>PAUSED</source>
-      <translation>ПАУЗИРАНО</translation>
+        <location filename="../src/DkGui/DkPong.cpp" line="336"/>
+        <source>PAUSED</source>
+        <translation>ПАУЗИРАНО</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPong.cpp" line="337"/>
-      <source>Press &lt;SPACE&gt; to start.</source>
-      <translation>Притисни &lt;SPACE&gt; за почетак.</translation>
+        <location filename="../src/DkGui/DkPong.cpp" line="337"/>
+        <source>Press &lt;SPACE&gt; to start.</source>
+        <translation>Притисни &lt;SPACE&gt; за почетак.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPong.cpp" line="485"/>
-      <source>%1 won!</source>
-      <translation>%1 је освојио!</translation>
+        <location filename="../src/DkGui/DkPong.cpp" line="485"/>
+        <source>%1 won!</source>
+        <translation>%1 је освојио!</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPong.cpp" line="486"/>
-      <source>Hit &lt;SPACE&gt; to start a new Game</source>
-      <translation>Удари &lt;SPACE&gt; за почетак нове игре</translation>
+        <location filename="../src/DkGui/DkPong.cpp" line="486"/>
+        <source>Hit &lt;SPACE&gt; to start a new Game</source>
+        <translation>Удари &lt;SPACE&gt; за почетак нове игре</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkPreferenceWidget</name>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="65"/>
-      <source>next</source>
-      <translation>следеће</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="70"/>
+        <source>next</source>
+        <translation>следеће</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="70"/>
-      <source>previous</source>
-      <translation>претходно</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="75"/>
+        <source>previous</source>
+        <translation>претходно</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="89"/>
-      <source>Restart nomacs</source>
-      <translation>Поново покрени nomacs</translation>
+        <location filename="../src/DkGui/DkPreferenceWidgets.cpp" line="95"/>
+        <source>Restart nomacs</source>
+        <translation>Поново покрени nomacs</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkPrintPreviewDialog</name>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2186"/>
-      <source>Fit Width</source>
-      <translation>Уклопи ширину</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2215"/>
+        <source>Fit Width</source>
+        <translation>Уклопи ширину</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2187"/>
-      <source>Fit Page</source>
-      <translation>Уклопи страну</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2216"/>
+        <source>Fit Page</source>
+        <translation>Уклопи страну</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2197"/>
-      <source>Zoom in</source>
-      <translation>Увећај</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2226"/>
+        <source>Zoom in</source>
+        <translation>Увећај</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2199"/>
-      <source>Zoom out</source>
-      <translation>Смањи</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2228"/>
+        <source>Zoom out</source>
+        <translation>Смањи</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2204"/>
-      <source>Portrait</source>
-      <translation>Портрет</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2233"/>
+        <source>Portrait</source>
+        <translation>Портрет</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2205"/>
-      <source>Landscape</source>
-      <translation>Пејзаж</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2234"/>
+        <source>Landscape</source>
+        <translation>Пејзаж</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2216"/>
-      <source>Print</source>
-      <translation>Штампај</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2245"/>
+        <source>Print</source>
+        <translation>Штампај</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2217"/>
-      <source>Page setup</source>
-      <translation>Подешавање стране</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2246"/>
+        <source>Page setup</source>
+        <translation>Подешавање стране</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2222"/>
-      <source>Reset dpi</source>
-      <translation>Ресетуј дпи</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2251"/>
+        <source>Reset dpi</source>
+        <translation>Ресетуј дпи</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2243"/>
-      <source>keep ALT key pressed to zoom with the mouse wheel</source>
-      <translation>држите АЛТ притиснуто за зумирање за точкићем миша</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2272"/>
+        <source>keep ALT key pressed to zoom with the mouse wheel</source>
+        <translation>држите АЛТ притиснуто за зумирање за точкићем миша</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2084"/>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2265"/>
-      <source>Print Preview</source>
-      <translation>Преглед пре штампе</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2118"/>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2294"/>
+        <source>Print Preview</source>
+        <translation>Преглед пре штампе</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
+    <name>nmc::DkProfileSummaryWidget</name>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1140"/>
+        <source>Summary: </source>
+        <translation>Сажетак: </translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1141"/>
+        <source>Files</source>
+        <translation>Фајлови</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1170"/>
+        <source>Input</source>
+        <translation>Улаз</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1174"/>
+        <source>Output</source>
+        <translation>Излаз</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1178"/>
+        <source>Functions</source>
+        <translation>Фуннкције</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1197"/>
+        <source>Update</source>
+        <translation>Ажурирај</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1202"/>
+        <source>Delete</source>
+        <translation>Избриши</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1207"/>
+        <source>Export</source>
+        <translation>Извези</translation>
+    </message>
+</context>
+<context>
+    <name>nmc::DkProfileWidget</name>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1238"/>
+        <source>Create New Profile</source>
+        <translation>Направи нови профил</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1241"/>
+        <source>Apply Default</source>
+        <translation>Прихвати задано</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1280"/>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1336"/>
+        <source>inactive</source>
+        <translation>неактиван</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1305"/>
+        <source>Default</source>
+        <translation>Задано</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1372"/>
+        <source>Deleting Profile</source>
+        <translation>Бришем профил</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1373"/>
+        <source>Sorry, I cannot delete %1</source>
+        <translation>Жао нам је, немогуће избрисати %1</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1390"/>
+        <source>Export Batch Profile</source>
+        <translation>Избези групни профил</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1392"/>
+        <source>nomacs Batch Profile (*.%1)</source>
+        <translation>nomacs групни профил (*.%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1404"/>
+        <source>Profile Name</source>
+        <translation>Име профила</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1405"/>
+        <source>Profile Name:</source>
+        <translation>Име профила:</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1416"/>
+        <source>Profile Already Exists</source>
+        <translation>Профил већ постоји</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkBatch.cpp" line="1417"/>
+        <source>Do you want to overwrite %1?</source>
+        <translation>Да ли желите да снимите преко %1?</translation>
+    </message>
+</context>
+<context>
     <name>nmc::DkQuickAccessEdit</name>
     <message>
-      <location filename="../src/DkGui/DkQuickAccess.cpp" line="139"/>
-      <source>Quick Launch (%1)</source>
-      <translation>Брзо покретање (%1)</translation>
+        <location filename="../src/DkGui/DkQuickAccess.cpp" line="141"/>
+        <source>Quick Launch (%1)</source>
+        <translation>Брзо покретање (%1)</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkRatingLabel</name>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="1018"/>
-      <source>one star</source>
-      <translation>једна звезда</translation>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="1023"/>
+        <source>one star</source>
+        <translation>једна звезда</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="1022"/>
-      <source>two stars</source>
-      <translation>две звезде</translation>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="1027"/>
+        <source>two stars</source>
+        <translation>две звезде</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="1026"/>
-      <source>three star</source>
-      <translation>три звезде</translation>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="1031"/>
+        <source>three star</source>
+        <translation>три звезде</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="1030"/>
-      <source>four star</source>
-      <translation>четири звезде</translation>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="1035"/>
+        <source>four star</source>
+        <translation>четири звезде</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="1034"/>
-      <source>five star</source>
-      <translation>пет звезди</translation>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="1039"/>
+        <source>five star</source>
+        <translation>пет звезди</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkRatingLabelBg</name>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="1055"/>
-      <source>no rating</source>
-      <translation>без оцене</translation>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="1060"/>
+        <source>no rating</source>
+        <translation>без оцене</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="1059"/>
-      <source>one star</source>
-      <translation>једна звезда</translation>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="1064"/>
+        <source>one star</source>
+        <translation>једна звезда</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="1063"/>
-      <source>two stars</source>
-      <translation>две звезде</translation>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="1068"/>
+        <source>two stars</source>
+        <translation>две звезде</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="1067"/>
-      <source>three stars</source>
-      <translation>три звезде</translation>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="1072"/>
+        <source>three stars</source>
+        <translation>три звезде</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="1071"/>
-      <source>four stars</source>
-      <translation>четири звезде</translation>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="1076"/>
+        <source>four stars</source>
+        <translation>четири звезде</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="1075"/>
-      <source>five stars</source>
-      <translation>пет звезди</translation>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="1080"/>
+        <source>five stars</source>
+        <translation>пет звезди</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkResizeDialog</name>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="850"/>
-      <source>Resize Image</source>
-      <translation>Промени величину слике</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="884"/>
+        <source>Resize Image</source>
+        <translation>Промени величину слике</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="869"/>
-      <source>Original</source>
-      <translation>Оригинал</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="903"/>
+        <source>Original</source>
+        <translation>Оригинал</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="871"/>
-      <source>New</source>
-      <translation>Нова</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="905"/>
+        <source>New</source>
+        <translation>Нова</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="900"/>
-      <location filename="../src/DkGui/DkDialog.cpp" line="937"/>
-      <source>Width: </source>
-      <translation>Ширина: </translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="934"/>
+        <location filename="../src/DkGui/DkDialog.cpp" line="971"/>
+        <source>Width: </source>
+        <translation>Ширина: </translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="913"/>
-      <location filename="../src/DkGui/DkDialog.cpp" line="952"/>
-      <source>Height: </source>
-      <translation>Висина: </translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="947"/>
+        <location filename="../src/DkGui/DkDialog.cpp" line="986"/>
+        <source>Height: </source>
+        <translation>Висина: </translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="978"/>
-      <source>Resolution: </source>
-      <translation>Резолуција: </translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="1012"/>
+        <source>Resolution: </source>
+        <translation>Резолуција: </translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="987"/>
-      <source>pixel/inch</source>
-      <translation>пиксел/инч</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="1021"/>
+        <source>pixel/inch</source>
+        <translation>пиксел/инч</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="988"/>
-      <source>pixel/cm</source>
-      <translation>пиксел/цм</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="1022"/>
+        <source>pixel/cm</source>
+        <translation>пиксел/цм</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="999"/>
-      <source>Resample Image:</source>
-      <translation>Измени резолуцију слике:</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="1033"/>
+        <source>Resample Image:</source>
+        <translation>Измени резолуцију слике:</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1006"/>
-      <source>Nearest Neighbor</source>
-      <translation>Најближи сусед</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="1040"/>
+        <source>Nearest Neighbor</source>
+        <translation>Најближи сусед</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1007"/>
-      <source>Area (best for downscaling)</source>
-      <translation>Област (најбоље за смањивање)</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="1041"/>
+        <source>Area (best for downscaling)</source>
+        <translation>Област (најбоље за смањивање)</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1008"/>
-      <source>Linear</source>
-      <translation>Линијски</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="1042"/>
+        <source>Linear</source>
+        <translation>Линијски</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1009"/>
-      <source>Bicubic (4x4 pixel interpolation)</source>
-      <translation>Bicubic (4x4 пиксела интерполација)</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="1043"/>
+        <source>Bicubic (4x4 pixel interpolation)</source>
+        <translation>Bicubic (4x4 пиксела интерполација)</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1010"/>
-      <source>Lanczos (8x8 pixel interpolation)</source>
-      <translation>Lanczos (8x8 пиксела интерполација)</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="1044"/>
+        <source>Lanczos (8x8 pixel interpolation)</source>
+        <translation>Lanczos (8x8 пиксела интерполација)</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1019"/>
-      <source>Gamma Correction</source>
-      <translation>Корекција гаме</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="1053"/>
+        <source>Gamma Correction</source>
+        <translation>Корекција гаме</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1030"/>
-      <source>&amp;OK</source>
-      <translation>&amp;У реду</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="1064"/>
+        <source>&amp;OK</source>
+        <translation>&amp;У реду</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1031"/>
-      <source>&amp;Cancel</source>
-      <translation>&amp;Откажи</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="1065"/>
+        <source>&amp;Cancel</source>
+        <translation>&amp;Откажи</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1418"/>
-      <source>Sorry, but the image size %1 x %2 is illegal.</source>
-      <translation>Извини, али величина слике %1 x %2 је противзаконита.</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="1452"/>
+        <source>Sorry, but the image size %1 x %2 is illegal.</source>
+        <translation>Извини, али величина слике %1 x %2 је противзаконита.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1430"/>
-      <source>Sorry, the image is too large: %1</source>
-      <translation>Извини, слика је превелика: %1</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="1464"/>
+        <source>Sorry, the image is too large: %1</source>
+        <translation>Извини, слика је превелика: %1</translation>
     </message>
-  </context>
-  <context>
-    <name>nmc::DkSaturation</name>
+</context>
+<context>
+    <name>nmc::DkRotateWidget</name>
     <message>
-      <location filename="../src/DkGui/DkManipulationWidgets.cpp" line="1063"/>
-      <source>Saturation</source>
-      <translation>Засићење</translation>
+        <location filename="../src/DkGui/DkManipulatorWidgets.cpp" line="338"/>
+        <source>Angle</source>
+        <translation>Угао</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkSearchDialog</name>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="592"/>
-      <source>Find &amp; Filter</source>
-      <translation>Пронађи &amp; Филтрирај</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="622"/>
+        <source>Find &amp; Filter</source>
+        <translation>Пронађи &amp; Филтрирај</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="594"/>
-      <source>Load All</source>
-      <translation>Учитај све</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="624"/>
+        <source>Load All</source>
+        <translation>Учитај све</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="602"/>
-      <source>Type a search word or a regular expression</source>
-      <translation>Откуцајте реч или израз за претрагу</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="648"/>
+        <source>F&amp;ind</source>
+        <translation>Пр&amp;онађи</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="618"/>
-      <source>F&amp;ind</source>
-      <translation>Пр&amp;онађи</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="643"/>
+        <source>&amp;Filter</source>
+        <translation>&amp;Филтер</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="613"/>
-      <source>&amp;Filter</source>
-      <translation>&amp;Филтер</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="632"/>
+        <source>Type search words or a regular expression</source>
+        <translation>Унесите појам за претрагу или regular expression</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="660"/>
-      <source>No Matching Items</source>
-      <translation>Нема релевантних ставки</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="690"/>
+        <source>No Matching Items</source>
+        <translation>Нема релевантних ставки</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
+    <name>nmc::DkSettingsModel</name>
+    <message>
+        <location filename="../src/DkGui/DkSettingsWidget.cpp" line="299"/>
+        <source>Settings</source>
+        <translation>Подешавање</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkSettingsWidget.cpp" line="299"/>
+        <source>Value</source>
+        <translation>Вредност</translation>
+    </message>
+</context>
+<context>
+    <name>nmc::DkSettingsWidget</name>
+    <message>
+        <location filename="../src/DkGui/DkSettingsWidget.cpp" line="131"/>
+        <source>Filter Settings</source>
+        <translation>Поставке филтера</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkSettingsWidget.cpp" line="157"/>
+        <source>Delete</source>
+        <translation>Избриши</translation>
+    </message>
+</context>
+<context>
     <name>nmc::DkShortcutsDialog</name>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1874"/>
-      <source>Keyboard Shortcuts</source>
-      <translation>Пречице тастатуре</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="1908"/>
+        <source>Keyboard Shortcuts</source>
+        <translation>Пречице тастатуре</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1910"/>
-      <source>Set to &amp;Default</source>
-      <translation>Подеси као &amp;подразумевано</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="1944"/>
+        <source>Set to &amp;Default</source>
+        <translation>Подеси као &amp;подразумевано</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1911"/>
-      <source>Removes All Custom Shortcuts</source>
-      <translation>Уклони све прилагођене пречице</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="1945"/>
+        <source>Removes All Custom Shortcuts</source>
+        <translation>Уклони све прилагођене пречице</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1924"/>
-      <source>&amp;OK</source>
-      <translation>&amp;У реду</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="1958"/>
+        <source>&amp;OK</source>
+        <translation>&amp;У реду</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1925"/>
-      <source>&amp;Cancel</source>
-      <translation>&amp;Откажи</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="1959"/>
+        <source>&amp;Cancel</source>
+        <translation>&amp;Откажи</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkShortcutsModel</name>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1579"/>
-      <source>Name</source>
-      <translation>Име</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="1613"/>
+        <source>Name</source>
+        <translation>Име</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1579"/>
-      <source>Shortcut</source>
-      <translation>Пречица</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="1613"/>
+        <source>Shortcut</source>
+        <translation>Пречица</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1785"/>
-      <source>%1 already used by %2 &gt; %3
+        <location filename="../src/DkGui/DkDialog.cpp" line="1819"/>
+        <source>%1 already used by %2 &gt; %3
 Press ESC to undo changes</source>
-      <translation>%1 већ користи %2 &gt; %3
+        <translation>%1 већ користи %2 &gt; %3
 Притисни ESC за опозив промена</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1791"/>
-      <source>%1 already used by %2
+        <location filename="../src/DkGui/DkDialog.cpp" line="1825"/>
+        <source>%1 already used by %2
 Press ESC to undo changes</source>
-      <translation>%1 већ користи %2
+        <translation>%1 већ користи %2
 Притисни ESC за опозив промена</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkSplashScreen</name>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="126"/>
-      <source>CLOSE</source>
-      <translation>ЗАТВОРИ</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="126"/>
+        <source>CLOSE</source>
+        <translation>ЗАТВОРИ</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="130"/>
-      <source>Close (ESC)</source>
-      <translation>Затвори (ESC)</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="130"/>
+        <source>Close (ESC)</source>
+        <translation>Затвори (ESC)</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="184"/>
-      <source>Portable</source>
-      <translation>Преносиво</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="255"/>
+        <source>Portable</source>
+        <translation>Преносиво</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkStatusBar</name>
     <message>
-      <location filename="../src/DkLoader/DkStatusBar.cpp" line="56"/>
-      <source>CTRL activates the crosshair cursor</source>
-      <translation>CTRL активира курсор</translation>
+        <location filename="../src/DkCore/DkStatusBar.cpp" line="56"/>
+        <source>CTRL activates the crosshair cursor</source>
+        <translation>CTRL активира курсор</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkTcpMenu</name>
     <message>
-      <location filename="../src/DkGui/DkMenu.cpp" line="227"/>
-      <source>no clients found</source>
-      <translation>клијенти нису нађени</translation>
+        <location filename="../src/DkGui/DkMenu.cpp" line="227"/>
+        <source>no clients found</source>
+        <translation>клијенти нису нађени</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkTextDialog</name>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1971"/>
-      <source>Text Editor</source>
-      <translation>Текстуални едитор</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2005"/>
+        <source>Text Editor</source>
+        <translation>Текстуални едитор</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1981"/>
-      <source>&amp;Save</source>
-      <translation>&amp;Сачувај</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2015"/>
+        <source>&amp;Save</source>
+        <translation>&amp;Сачувај</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="1982"/>
-      <source>&amp;Close</source>
-      <translation>&amp;Затвори</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2016"/>
+        <source>&amp;Close</source>
+        <translation>&amp;Затвори</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2006"/>
-      <source>Text File (*.txt)</source>
-      <translation>Текстуални фајл (*.txt)</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2040"/>
+        <source>Text File (*.txt)</source>
+        <translation>Текстуални фајл (*.txt)</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2006"/>
-      <source>All Files (*.*)</source>
-      <translation>Сви фајлови (*.*)</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2040"/>
+        <source>All Files (*.*)</source>
+        <translation>Сви фајлови (*.*)</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2009"/>
-      <source>Save Text File</source>
-      <translation>Сачувај текстуални фајл</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2043"/>
+        <source>Save Text File</source>
+        <translation>Сачувај текстуални фајл</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2022"/>
-      <source>Error</source>
-      <translation>Грешка</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2056"/>
+        <source>Error</source>
+        <translation>Грешка</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2022"/>
-      <source>Could not save: %1
+        <location filename="../src/DkGui/DkDialog.cpp" line="2056"/>
+        <source>Could not save: %1
 %2</source>
-      <translation>Не могу сачувати: %1
+        <translation>Не могу сачувати: %1
 %2</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
+    <name>nmc::DkThresholdWidget</name>
+    <message>
+        <location filename="../src/DkGui/DkManipulatorWidgets.cpp" line="369"/>
+        <source>Threshold</source>
+        <translation>Праг</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkManipulatorWidgets.cpp" line="376"/>
+        <source>Color</source>
+        <translation>Боја</translation>
+    </message>
+</context>
+<context>
     <name>nmc::DkThumbLabel</name>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="900"/>
-      <source>Name: </source>
-      <translation>Име: </translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="907"/>
+        <source>Name: </source>
+        <translation>Име: </translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="901"/>
-      <source>Size: </source>
-      <translation>Величина: </translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="908"/>
+        <source>Size: </source>
+        <translation>Величина: </translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="902"/>
-      <source>Created: </source>
-      <translation>Креирано: </translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="909"/>
+        <source>Created: </source>
+        <translation>Креирано: </translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkThumbScene</name>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1252"/>
-      <source>%1 Images</source>
-      <translation>%1 слика</translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1260"/>
+        <source>%1 selected</source>
+        <translation>%1 изабран</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1394"/>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1443"/>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1482"/>
-      <source>Error</source>
-      <translation>Грешка</translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1262"/>
+        <source>%1 images</source>
+        <translation>%1 слика</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1394"/>
-      <source>Sorry, I cannot copy %1 to %2</source>
-      <translation>Извини, не могу копирати %1 за %2</translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1409"/>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1460"/>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1506"/>
+        <source>Error</source>
+        <translation>Грешка</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1415"/>
-      <source>Shall I move %1 file(s) to trash?</source>
-      <translation>Преместити %1 фајл(ове) у смеће?</translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1409"/>
+        <source>Sorry, I cannot copy %1 to %2</source>
+        <translation>Извини, не могу копирати %1 за %2</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1417"/>
-      <source>Are you sure you want to permanently delete %1 file(s)?</source>
-      <translation>Да ли сте сигурни да желите трајно уклонити %1 фајл(ове)?</translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1430"/>
+        <source>Shall I move %1 file(s) to trash?</source>
+        <translation>Преместити %1 фајл(ове) у смеће?</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1422"/>
-      <source>Delete File</source>
-      <translation>Уклони фајл</translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1432"/>
+        <source>Are you sure you want to permanently delete %1 file(s)?</source>
+        <translation>Да ли сте сигурни да желите трајно уклонити %1 фајл(ове)?</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1443"/>
-      <source>Sorry, I cannot delete:
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1437"/>
+        <source>Delete File</source>
+        <translation>Уклони фајл</translation>
+    </message>
+    <message>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1461"/>
+        <source>Sorry, I cannot delete:
 %1</source>
-      <translation>Извини, не могу уклонити:
+        <translation>Извини, не могу уклонити:
 %1</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1467"/>
-      <source>Rename File(s)</source>
-      <translation>Преименуј фајл(ове)</translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1488"/>
+        <source>Rename File(s)</source>
+        <translation>Преименуј фајл(ове)</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1468"/>
-      <source>New Filename:</source>
-      <translation>Ново име фајла:</translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1489"/>
+        <source>New Filename:</source>
+        <translation>Ново име фајла:</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1482"/>
-      <source>Sorry, I cannot rename: %1 to %2</source>
-      <translation>Извини, не могу преименовати: %1 за %2</translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1507"/>
+        <source>Sorry, I cannot rename: %1 to %2</source>
+        <translation>Извини, не могу преименовати: %1 за %2</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkThumbScrollWidget</name>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1870"/>
-      <source>&amp;Sort</source>
-      <translation>&amp;Сортирај</translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1895"/>
+        <source>&amp;Sort</source>
+        <translation>&amp;Сортирај</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1847"/>
-      <source>Thumb Preview Toolbar</source>
-      <translation>Трака алата за сличице</translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1872"/>
+        <source>Thumb Preview Toolbar</source>
+        <translation>Трака алата за сличице</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1890"/>
-      <source>Filter Files (Ctrl + F)</source>
-      <translation>Филтер фајлова (Ctrl + F)</translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1915"/>
+        <source>Filter Files (Ctrl + F)</source>
+        <translation>Филтер фајлова (Ctrl + F)</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1903"/>
-      <source>Thumb</source>
-      <translation>Сличица</translation>
+        <location filename="../src/DkGui/DkThumbsWidgets.cpp" line="1928"/>
+        <source>Thumb</source>
+        <translation>Сличица</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkThumbsSaver</name>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="295"/>
-      <source>Cancel</source>
-      <translation>Отказано</translation>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="295"/>
+        <source>Cancel</source>
+        <translation>Отказано</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="295"/>
-      <source>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="294"/>
+        <source>
 Creating thumbnails...
 </source>
-      <translation>
+        <translation>
 Креирање сличица...
 </translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkWidgets.cpp" line="296"/>
-      <source>Thumbnails</source>
-      <translation>Сличице</translation>
+        <location filename="../src/DkGui/DkWidgets.cpp" line="299"/>
+        <source>Thumbnails</source>
+        <translation>Сличице</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkTifDialog</name>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="65"/>
-      <source>TIF compression</source>
-      <translation>TIF компресија</translation>
+        <location filename="../src/DkCore/DkSaveDialog.cpp" line="65"/>
+        <source>TIF compression</source>
+        <translation>TIF компресија</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="68"/>
-      <source>&amp;no compression</source>
-      <translation>&amp;без компресије</translation>
+        <location filename="../src/DkCore/DkSaveDialog.cpp" line="68"/>
+        <source>&amp;no compression</source>
+        <translation>&amp;без компресије</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="69"/>
-      <source>&amp;LZW compression (lossless)</source>
-      <translation>&amp;LZW компресија (без губитака)</translation>
+        <location filename="../src/DkCore/DkSaveDialog.cpp" line="69"/>
+        <source>&amp;LZW compression (lossless)</source>
+        <translation>&amp;LZW компресија (без губитака)</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="79"/>
-      <source>&amp;OK</source>
-      <translation>&amp;У реду</translation>
+        <location filename="../src/DkCore/DkSaveDialog.cpp" line="79"/>
+        <source>&amp;OK</source>
+        <translation>&amp;У реду</translation>
     </message>
     <message>
-      <location filename="../src/DkLoader/DkSaveDialog.cpp" line="80"/>
-      <source>&amp;Cancel</source>
-      <translation>&amp;Откажи</translation>
+        <location filename="../src/DkCore/DkSaveDialog.cpp" line="80"/>
+        <source>&amp;Cancel</source>
+        <translation>&amp;Откажи</translation>
     </message>
-  </context>
-  <context>
-    <name>nmc::DkTinyPlanetDialog</name>
+</context>
+<context>
+    <name>nmc::DkTinyPlanetWidget</name>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3006"/>
-      <source>Tiny Planet</source>
-      <translation>Мала планета</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3040"/>
-      <source>Planet Size</source>
-      <translation>Величина планете</translation>
+        <location filename="../src/DkGui/DkManipulatorWidgets.cpp" line="248"/>
+        <source>Planet Size</source>
+        <translation>Величина планете</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3048"/>
-      <source>Angle</source>
-      <translation>Угао</translation>
+        <location filename="../src/DkGui/DkManipulatorWidgets.cpp" line="254"/>
+        <source>Angle</source>
+        <translation>Угао</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="3054"/>
-      <source>Invert Planet</source>
-      <translation>Обрни планету</translation>
+        <location filename="../src/DkGui/DkManipulatorWidgets.cpp" line="260"/>
+        <source>Invert Planet</source>
+        <translation>Обрни планету</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkTrainDialog</name>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="254"/>
-      <source>Add New Image Format</source>
-      <translation>Додај нови формат слике</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="284"/>
+        <source>Add New Image Format</source>
+        <translation>Додај нови формат слике</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="263"/>
-      <source>Load New Image Format</source>
-      <translation>Учитај нови формат слике</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="293"/>
+        <source>Load New Image Format</source>
+        <translation>Учитај нови формат слике</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="270"/>
-      <source>&amp;Browse</source>
-      <translation>&amp;Претрага</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="300"/>
+        <source>&amp;Browse</source>
+        <translation>&amp;Претрага</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="283"/>
-      <source>&amp;Add</source>
-      <translation>&amp;Додај</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="313"/>
+        <source>&amp;Add</source>
+        <translation>&amp;Додај</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="285"/>
-      <source>&amp;Cancel</source>
-      <translation>&amp;Откажи</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="315"/>
+        <source>&amp;Cancel</source>
+        <translation>&amp;Откажи</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="317"/>
-      <source>Open Image</source>
-      <translation>Отвори слику</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="347"/>
+        <source>Open Image</source>
+        <translation>Отвори слику</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="318"/>
-      <source>All Files (*.*)</source>
-      <translation>Сви фајлови (*.*)</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="348"/>
+        <source>All Files (*.*)</source>
+        <translation>Сви фајлови (*.*)</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="364"/>
-      <source>Sorry, currently we don't support: *.%1 files</source>
-      <translation>Опростите, тренутно не подржавамо: *.%1 фајлове</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="394"/>
+        <source>Sorry, currently we don&apos;t support: *.%1 files</source>
+        <translation>Опростите, тренутно не подржавамо: *.%1 фајлове</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="369"/>
-      <source>*.%1 is already supported.</source>
-      <translation>*.%1 је већ подржано.</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="399"/>
+        <source>*.%1 is already supported.</source>
+        <translation>*.%1 је већ подржано.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="373"/>
-      <source>*.%1 is supported.</source>
-      <translation>*.%1 је подржано.</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="403"/>
+        <source>*.%1 is supported.</source>
+        <translation>*.%1 је подржано.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="390"/>
-      <source>Please name the new format:</source>
-      <translation>Молим именујте нови формат:</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="420"/>
+        <source>Please name the new format:</source>
+        <translation>Молим именујте нови формат:</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkTransferToolBar</name>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="538"/>
-      <source>Enable</source>
-      <translation>Омогући</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="527"/>
+        <source>Enable</source>
+        <translation>Омогући</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="622"/>
-      <source>Resets the Pseudo Color function</source>
-      <translation>Ресетуј функцију псеудо боја</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="602"/>
+        <source>Resets the Pseudo Color function</source>
+        <translation>Ресетуј функцију псеудо боја</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="796"/>
-      <source>Disables the Pseudo Color function</source>
-      <translation>Онемогући псеудо колор функцију</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="776"/>
+        <source>Disables the Pseudo Color function</source>
+        <translation>Онемогући псеудо колор функцију</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="548"/>
-      <source>Changes the displayed color channel</source>
-      <translation>Измени приказане канале боја</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="537"/>
+        <source>Changes the displayed color channel</source>
+        <translation>Измени приказане канале боја</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="533"/>
-      <source>Pseudo Color Toolbar</source>
-      <translation>Трака алата за псеудо боје</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="522"/>
+        <source>Pseudo Color Toolbar</source>
+        <translation>Трака алата за псеудо боје</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="553"/>
-      <source>Delete</source>
-      <translation>Избриши</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="542"/>
+        <source>Delete</source>
+        <translation>Избриши</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="568"/>
-      <source>Click into the field for a new slider</source>
-      <translation>Кликните у поље за нови слајд</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="557"/>
+        <source>Click into the field for a new slider</source>
+        <translation>Кликните у поље за нови слајд</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="621"/>
-      <source>Reset</source>
-      <translation>Ресетуј</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="601"/>
+        <source>Reset</source>
+        <translation>Ресетуј</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="627"/>
-      <source>Select Color</source>
-      <translation>Изабери боју</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="607"/>
+        <source>Select Color</source>
+        <translation>Изабери боју</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="628"/>
-      <source>Adds a slider at the selected color value</source>
-      <translation>Додаје клизач вредности у изабраној боји</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="608"/>
+        <source>Adds a slider at the selected color value</source>
+        <translation>Додаје клизач вредности у изабраној боји</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="633"/>
-      <source>Save Gradient</source>
-      <translation>Сачувај слојевитост</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="613"/>
+        <source>Save Gradient</source>
+        <translation>Сачувај слојевитост</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="634"/>
-      <source>Saves the current Gradient</source>
-      <translation>Сачувај тренутну слојевитост</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="614"/>
+        <source>Saves the current Gradient</source>
+        <translation>Сачувај тренутну слојевитост</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="762"/>
-      <source>Gray</source>
-      <translation>Сива</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="742"/>
+        <source>Gray</source>
+        <translation>Сива</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="765"/>
-      <source>RGB</source>
-      <translation>RGB</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="745"/>
+        <source>RGB</source>
+        <translation>RGB</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="766"/>
-      <source>Red</source>
-      <translation>Црвена</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="746"/>
+        <source>Red</source>
+        <translation>Црвена</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="767"/>
-      <source>Green</source>
-      <translation>Зелена</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="747"/>
+        <source>Green</source>
+        <translation>Зелена</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="768"/>
-      <source>Blue</source>
-      <translation>Плава</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="748"/>
+        <source>Blue</source>
+        <translation>Плава</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="539"/>
-      <location filename="../src/DkGui/DkToolbars.cpp" line="798"/>
-      <source>Enables the Pseudo Color function</source>
-      <translation>Онемогући псеудо колор функцију</translation>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="528"/>
+        <location filename="../src/DkGui/DkToolbars.cpp" line="778"/>
+        <source>Enables the Pseudo Color function</source>
+        <translation>Онемогући псеудо колор функцију</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkTranslationUpdater</name>
     <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="557"/>
-      <source>Unable to download translation</source>
-      <translation>Онемогућено преузимање превода</translation>
+        <location filename="../src/DkCore/DkUpdater.cpp" line="398"/>
+        <source>Unable to download translation</source>
+        <translation>Онемогућено преузимање превода</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="557"/>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="591"/>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="613"/>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="618"/>
-      <source>update</source>
-      <translation>ажурирање</translation>
+        <location filename="../src/DkCore/DkUpdater.cpp" line="398"/>
+        <location filename="../src/DkCore/DkUpdater.cpp" line="432"/>
+        <location filename="../src/DkCore/DkUpdater.cpp" line="454"/>
+        <location filename="../src/DkCore/DkUpdater.cpp" line="459"/>
+        <source>update</source>
+        <translation>ажурирање</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="591"/>
-      <source>Unable to update translation</source>
-      <translation>Онемогућено ажурирање превода</translation>
+        <location filename="../src/DkCore/DkUpdater.cpp" line="432"/>
+        <source>Unable to update translation</source>
+        <translation>Онемогућено ажурирање превода</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="613"/>
-      <source>Translation updated</source>
-      <translation>Превод је ажуриран</translation>
+        <location filename="../src/DkCore/DkUpdater.cpp" line="454"/>
+        <source>Translation updated</source>
+        <translation>Превод је ажуриран</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="618"/>
-      <source>No newer translations found</source>
-      <translation>Нису пронађени новији преводи</translation>
+        <location filename="../src/DkCore/DkUpdater.cpp" line="459"/>
+        <source>No newer translations found</source>
+        <translation>Нису пронађени новији преводи</translation>
     </message>
-  </context>
-  <context>
-    <name>nmc::DkUndoRedo</name>
+</context>
+<context>
+    <name>nmc::DkUnsharpMaskWidget</name>
     <message>
-      <location filename="../src/DkGui/DkManipulationWidgets.cpp" line="1471"/>
-      <source>&amp;Undo</source>
-      <translation>&amp;Откажи</translation>
-    </message>
-    <message>
-      <location filename="../src/DkGui/DkManipulationWidgets.cpp" line="1473"/>
-      <source>&amp;Redo</source>
-      <translation>&amp;Понови</translation>
-    </message>
-  </context>
-  <context>
-    <name>nmc::DkUnsharpDialog</name>
-    <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2826"/>
-      <source>Sharpen Image</source>
-      <translation>Изоштри слику</translation>
+        <location filename="../src/DkGui/DkManipulatorWidgets.cpp" line="297"/>
+        <source>Sigma</source>
+        <translation>Сигма</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2860"/>
-      <source>Sigma</source>
-      <translation>Сигма</translation>
+        <location filename="../src/DkGui/DkManipulatorWidgets.cpp" line="302"/>
+        <source>Amount</source>
+        <translation>Износ</translation>
     </message>
-    <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2865"/>
-      <source>Amount</source>
-      <translation>Износ</translation>
-    </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkUpdateDialog</name>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2045"/>
-      <source>nomacs updater</source>
-      <translation>nomacs ажурирање</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2079"/>
+        <source>nomacs updater</source>
+        <translation>nomacs ажурирање</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2053"/>
-      <source>Install Now</source>
-      <translation>Инсталирај сад</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2087"/>
+        <source>Install Now</source>
+        <translation>Инсталирај сад</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="2054"/>
-      <source>Cancel</source>
-      <translation>Отказано</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="2088"/>
+        <source>Cancel</source>
+        <translation>Отказано</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkUpdater</name>
     <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="395"/>
-      <source>sorry, I could not check for newer versions</source>
-      <translation>извини, не могу проверити за нове верзије</translation>
+        <location filename="../src/DkCore/DkUpdater.cpp" line="240"/>
+        <source>sorry, I could not check for newer versions</source>
+        <translation>извини, не могу проверити за нове верзије</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="395"/>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="415"/>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="418"/>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="426"/>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="496"/>
-      <source>updates</source>
-      <translation>ажурирања</translation>
+        <location filename="../src/DkCore/DkUpdater.cpp" line="240"/>
+        <location filename="../src/DkCore/DkUpdater.cpp" line="260"/>
+        <location filename="../src/DkCore/DkUpdater.cpp" line="263"/>
+        <location filename="../src/DkCore/DkUpdater.cpp" line="271"/>
+        <location filename="../src/DkCore/DkUpdater.cpp" line="341"/>
+        <source>updates</source>
+        <translation>ажурирања</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="407"/>
-      <source>A new version</source>
-      <translation>Нова верзија</translation>
+        <location filename="../src/DkCore/DkUpdater.cpp" line="252"/>
+        <source>A new version</source>
+        <translation>Нова верзија</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="407"/>
-      <source>is available</source>
-      <translation>је доступна</translation>
+        <location filename="../src/DkCore/DkUpdater.cpp" line="252"/>
+        <source>is available</source>
+        <translation>је доступна</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="408"/>
-      <source>Do you want to download and install it now?</source>
-      <translation>Да ли желите да преузмете и инсталирате сада?</translation>
+        <location filename="../src/DkCore/DkUpdater.cpp" line="253"/>
+        <source>Do you want to download and install it now?</source>
+        <translation>Да ли желите да преузмете и инсталирате сада?</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="409"/>
-      <source>For more information see </source>
-      <translation>За више информација погледајте</translation>
+        <location filename="../src/DkCore/DkUpdater.cpp" line="254"/>
+        <source>For more information see </source>
+        <translation>За више информација погледајте </translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="426"/>
-      <source>sorry, unable to download the new version</source>
-      <translation>извини, није могуће преузети нову верзију</translation>
+        <location filename="../src/DkCore/DkUpdater.cpp" line="271"/>
+        <source>sorry, unable to download the new version</source>
+        <translation>извини, није могуће преузети нову верзију</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="496"/>
-      <source>Unable to connect to server ... please try again later</source>
-      <translation>Није могуће повезивање са сервером ... молим пробајте поново касније</translation>
+        <location filename="../src/DkCore/DkUpdater.cpp" line="341"/>
+        <source>Unable to connect to server ... please try again later</source>
+        <translation>Није могуће повезивање са сервером ... молим пробајте поново касније</translation>
     </message>
     <message>
-      <location filename="../src/DkCore/DkUpdater.cpp" line="418"/>
-      <source>nomacs is up-to-date</source>
-      <translation>nomacs је ажуриран</translation>
+        <location filename="../src/DkCore/DkUpdater.cpp" line="263"/>
+        <source>nomacs is up-to-date</source>
+        <translation>nomacs је ажуриран</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkViewPort</name>
     <message>
-      <location filename="../src/DkGui/DkViewPort.cpp" line="226"/>
-      <source>Original Image</source>
-      <translation>Оригинална слика</translation>
+        <location filename="../src/DkGui/DkViewPort.cpp" line="238"/>
+        <source>Original Image</source>
+        <translation>Оригинална слика</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkViewPort.cpp" line="627"/>
-      <source>connected with: </source>
-      <translation>повезан са: </translation>
+        <location filename="../src/DkGui/DkViewPort.cpp" line="651"/>
+        <source>connected with: </source>
+        <translation>повезан са: </translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkViewPort.cpp" line="631"/>
-      <source>disconnected with: </source>
-      <translation>дисконектован са: </translation>
+        <location filename="../src/DkGui/DkViewPort.cpp" line="655"/>
+        <source>disconnected with: </source>
+        <translation>дисконектован са: </translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkViewPort.cpp" line="1283"/>
-      <source>Transparency Pattern Enabled</source>
-      <translation>Провидност омогућена</translation>
+        <location filename="../src/DkGui/DkViewPort.cpp" line="739"/>
+        <source>Busy</source>
+        <translation>Заузет</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkViewPort.cpp" line="1283"/>
-      <source>Transparency Pattern Disabled</source>
-      <translation>Провидност онемогућена</translation>
+        <location filename="../src/DkGui/DkViewPort.cpp" line="1408"/>
+        <source>Transparency Pattern Enabled</source>
+        <translation>Провидност омогућена</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkViewPort.cpp" line="1324"/>
-      <source>Lena</source>
-      <translation>Лена</translation>
+        <location filename="../src/DkGui/DkViewPort.cpp" line="1408"/>
+        <source>Transparency Pattern Disabled</source>
+        <translation>Провидност онемогућена</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkViewPort.cpp" line="1324"/>
-      <source>A remarkable woman</source>
-      <translation>Изузетна жена</translation>
+        <location filename="../src/DkGui/DkViewPort.cpp" line="1449"/>
+        <source>Lena</source>
+        <translation>Лена</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkViewPort.cpp" line="1334"/>
-      <source>you cannot cancel this</source>
-      <translation>не можете отказати ово</translation>
+        <location filename="../src/DkGui/DkViewPort.cpp" line="1449"/>
+        <source>A remarkable woman</source>
+        <translation>Изузетна жена</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkViewPort.cpp" line="1342"/>
-      <source>did you understand the brainteaser?</source>
-      <translation>разумете ли слагалицу?</translation>
+        <location filename="../src/DkGui/DkViewPort.cpp" line="1459"/>
+        <source>you cannot cancel this</source>
+        <translation>не можете отказати ово</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkViewPort.cpp" line="1344"/>
-      <source>%1 is wrong...</source>
-      <translation>%1 је погрешно...</translation>
+        <location filename="../src/DkGui/DkViewPort.cpp" line="1467"/>
+        <source>did you understand the brainteaser?</source>
+        <translation>разумете ли слагалицу?</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkViewPort.cpp" line="1385"/>
-      <location filename="../src/DkGui/DkViewPort.cpp" line="1410"/>
-      <source>Attempted to set NULL image</source>
-      <translation>Покушај да подесиш NULL слику</translation>
+        <location filename="../src/DkGui/DkViewPort.cpp" line="1469"/>
+        <source>%1 is wrong...</source>
+        <translation>%1 је погрешно...</translation>
     </message>
-  </context>
-  <context>
+    <message>
+        <location filename="../src/DkGui/DkViewPort.cpp" line="1510"/>
+        <location filename="../src/DkGui/DkViewPort.cpp" line="1536"/>
+        <source>Attempted to set NULL image</source>
+        <translation>Покушај да подесиш NULL слику</translation>
+    </message>
+</context>
+<context>
     <name>nmc::DkViewPortFrameless</name>
     <message>
-      <location filename="../src/DkGui/DkViewPort.cpp" line="1943"/>
-      <source>Press F10 to exit Frameless view</source>
-      <translation>Притисни Ф10 за излаз са прегледа без оквира</translation>
+        <location filename="../src/DkGui/DkViewPort.cpp" line="2065"/>
+        <source>Press F10 to exit Frameless view</source>
+        <translation>Притисни Ф10 за излаз са прегледа без оквира</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>nmc::DkWelcomeDialog</name>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4188"/>
-      <source>Welcome</source>
-      <translation>Добродошли</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3839"/>
+        <source>Welcome</source>
+        <translation>Добродошли</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4197"/>
-      <source>Welcome to nomacs, please choose your preferred language below.</source>
-      <translation>Добродошли у nomacs, молим изаберите жељени језик испод.</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3848"/>
+        <source>Welcome to nomacs, please choose your preferred language below.</source>
+        <translation>Добродошли у nomacs, молим изаберите жељени језик испод.</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4202"/>
-      <source>&amp;Register File Associations</source>
-      <translation>&amp;Региструј придруживање фајлова</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3853"/>
+        <source>&amp;Register File Associations</source>
+        <translation>&amp;Региструј придруживање фајлова</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4205"/>
-      <source>Set As &amp;Default Viewer</source>
-      <translation>Подеси као &amp;подразумевани прегледач</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3856"/>
+        <source>Set As &amp;Default Viewer</source>
+        <translation>Подеси као &amp;подразумевани прегледач</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4210"/>
-      <source>&amp;OK</source>
-      <translation>&amp;У реду</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3861"/>
+        <source>&amp;OK</source>
+        <translation>&amp;У реду</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4211"/>
-      <source>&amp;Cancel</source>
-      <translation>&amp;Откажи</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3862"/>
+        <source>&amp;Cancel</source>
+        <translation>&amp;Откажи</translation>
     </message>
     <message>
-      <location filename="../src/DkGui/DkDialog.cpp" line="4249"/>
-      <source>Image</source>
-      <translation>Слика</translation>
+        <location filename="../src/DkGui/DkDialog.cpp" line="3900"/>
+        <source>Image</source>
+        <translation>Слика</translation>
     </message>
-  </context>
+</context>
 </TS>


### PR DESCRIPTION
I have updated the translation files for the above mentioned languages.

I'm sorry for not using the Crowdin web-interface. I find using Qt Linguist just easier and more convenient compared to a web-interface when working on bigger translations.