### PR TITLE
Fix cmake with Qt 5.11

### DIFF
--- a/ImageLounge/CMakeLists.txt
+++ b/ImageLounge/CMakeLists.txt
@@ -36,6 +36,8 @@ set(NOMACS_BUILD_DIRECTORY ${CMAKE_BINARY_DIR})
 # include macros needed
 include("cmake/Utils.cmake")
 
+set(QT5_MIN_VERSION 5.2.1)
+
 # different compile options
 option(ENABLE_OPENCV "Compile with Opencv (needed for RAW and TIFF)" ON)
 option(ENABLE_RAW "Compile with raw images support (libraw)" ON)

--- a/ImageLounge/cmake/MacBuildTarget.cmake
+++ b/ImageLounge/cmake/MacBuildTarget.cmake
@@ -66,8 +66,8 @@ add_dependencies(
 	${QUAZIP_DEPENDENCY} 
 	${LIBQPSD_LIBRARY}) 
 
-qt5_use_modules(${BINARY_NAME} 		Widgets Gui Network LinguistTools PrintSupport Concurrent Svg)
-qt5_use_modules(${DLL_CORE_NAME} 	Widgets Gui Network LinguistTools PrintSupport Concurrent Svg)
+qt5_use_modules(${BINARY_NAME} Qt5::Widgets Qt5::Gui Qt5::Network Qt5::PrintSupport Qt5::Concurrent Qt5::Svg)
+qt5_use_modules(${DLL_CORE_NAME} Qt5::Widgets Qt5::Gui Qt5::Network Qt5::PrintSupport Qt5::Concurrent Qt5::Svg)
 
 # core flags
 set_target_properties(${DLL_CORE_NAME} PROPERTIES ARCHIVE_OUTPUT_DIRECTORY_DEBUG ${CMAKE_CURRENT_BINARY_DIR}/libs)

--- a/ImageLounge/cmake/UnixBuildTarget.cmake
+++ b/ImageLounge/cmake/UnixBuildTarget.cmake
@@ -58,8 +58,8 @@ add_dependencies(
 	${QUAZIP_DEPENDENCY}
 	${LIBQPSD_LIBRARY})
 
-qt5_use_modules(${BINARY_NAME} 		Widgets Gui Network LinguistTools PrintSupport Concurrent Svg)
-qt5_use_modules(${DLL_CORE_NAME} 	Widgets Gui Network LinguistTools PrintSupport Concurrent Svg)
+target_link_libraries(${BINARY_NAME} Qt5::Widgets Qt5::Gui Qt5::Network Qt5::PrintSupport Qt5::Concurrent Qt5::Svg)
+target_link_libraries(${DLL_CORE_NAME} Qt5::Widgets Qt5::Gui Qt5::Network Qt5::PrintSupport Qt5::Concurrent Qt5::Svg)
 
 # core flags
 set_target_properties(${DLL_CORE_NAME} PROPERTIES ARCHIVE_OUTPUT_DIRECTORY_DEBUG ${CMAKE_CURRENT_BINARY_DIR}/libs)

--- a/ImageLounge/cmake/Utils.cmake
+++ b/ImageLounge/cmake/Utils.cmake
@@ -17,10 +17,10 @@ macro(NMC_FINDQT)
 	 set(QT_ROOT ${QT_QMAKE_PATH}/)
 	 set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} ${QT_QMAKE_PATH}\\..\\lib\\cmake\\Qt5)
 	 	 
-	 find_package(Qt5 REQUIRED  Core Widgets Network LinguistTools PrintSupport Concurrent Gui Svg)
+	 find_package(Qt5 ${QT5_MIN_VERSION} REQUIRED COMPONENTS Core Widgets Network LinguistTools PrintSupport Concurrent Gui Svg)
 	 
 	if (MSVC)
-		find_package(Qt5 REQUIRED WinExtras)
+		find_package(Qt5 ${QT5_MIN_VERSION} REQUIRED WinExtras)
 	endif()
 	 
 	 if (NOT Qt5_FOUND)

--- a/ImageLounge/cmake/WinBuildTarget.cmake
+++ b/ImageLounge/cmake/WinBuildTarget.cmake
@@ -62,8 +62,8 @@ add_dependencies(
 target_include_directories(${BINARY_NAME} 		PRIVATE ${OpenCV_INCLUDE_DIRS} ${ZLIB_INCLUDE_DIRS})
 target_include_directories(${DLL_CORE_NAME} 	PRIVATE ${OpenCV_INCLUDE_DIRS} ${ZLIB_INCLUDE_DIRS})
 
-qt5_use_modules(${BINARY_NAME} 		Widgets Gui Network LinguistTools PrintSupport Concurrent Svg WinExtras)
-qt5_use_modules(${DLL_CORE_NAME} 	Widgets Gui Network LinguistTools PrintSupport Concurrent Svg WinExtras)
+target_link_libraries(${BINARY_NAME} Qt5::Widgets Qt5::Gui Qt5::Network Qt5::PrintSupport Qt5::Concurrent Qt5::Svg Qt5::WinExtras)
+target_link_libraries(${DLL_CORE_NAME} Qt5::Widgets Qt5::Gui Qt5::Network Qt5::PrintSupport Qt5::Concurrent Qt5::Svg Qt5::WinExtras)
 
 # set(_moc ${CMAKE_CURRENT_BINARY_DIR}/GeneratedFiles)
 file(GLOB NOMACS_AUTOMOC "${CMAKE_BINARY_DIR}/*_automoc.cpp ${CMAKE_BINARY_DIR}/moc_.cpp")


### PR DESCRIPTION
cmake fails due to a change in Qt 5.11 beta3:
```
CMake Error at cmake/UnixBuildTarget.cmake:61 (qt5_use_modules):
  Unknown CMake command "qt5_use_modules".
Call Stack (most recent call first):
  CMakeLists.txt:178 (include)
```

(only tested with Linux)