### PR TITLE
Make compilation of libqpsd optional

### DIFF
--- a/ImageLounge/CMakeLists.txt
+++ b/ImageLounge/CMakeLists.txt
@@ -54,6 +54,7 @@ if( ENABLE_CODE_COV AND CMAKE_COMPILER_IS_GNUCXX)
     include("cmake/CodeCoverage.cmake")
     setup_target_for_coverage(${PROJECT_NAME}_coverage tests coverage)
 endif()
+option(ENABLE_PSD "Compile with support for PSD files" ON)
 
 if(APPLE)
 	option(ENABLE_QUAZIP "Compile with QuaZip (allows opening .zip files)" OFF)
@@ -148,8 +149,13 @@ include_directories (
 	${TIFF_CONFIG_DIR}
 	${QUAZIP_INCLUDE_DIRECTORY}
 	# ${ZLIB_INCLUDE_DIRS}
+)
+
+if (ENABLE_PSD)
+include_directories (
 	${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/libqpsd
 )
+endif (ENABLE_PSD)
 
 if (APPLE) # todo: somehow add this to Mac.cmake or MacBuildTarget.cmake
 	SET (NOMACS_SOURCES ${NOMACS_SOURCES} macosx/nomacs.icns)

--- a/ImageLounge/cmake/Unix.cmake
+++ b/ImageLounge/cmake/Unix.cmake
@@ -121,6 +121,8 @@ if(ENABLE_QUAZIP)
 endif(ENABLE_QUAZIP)
 
 # add libqpsd
+if (ENABLE_PSD)
+	add_definitions(-DWITH_LIBQPSD)
 IF(USE_SYSTEM_LIBQPSD)
 	find_package(qpsd REQUIRED)
 	if(NOT QPSD_FOUND)
@@ -130,3 +132,4 @@ ELSE()
 	file(GLOB LIBQPSD_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/libqpsd/*.cpp")
 	file(GLOB LIBQPSD_HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/libqpsd/*.h")
 ENDIF(USE_SYSTEM_LIBQPSD)
+endif (ENABLE_PSD)

--- a/ImageLounge/src/DkCore/DkBasicLoader.cpp
+++ b/ImageLounge/src/DkCore/DkBasicLoader.cpp
@@ -226,12 +226,14 @@ bool DkBasicLoader::loadGeneral(const QString& filePath, QSharedPointer<QByteArr
 		if (imgLoaded) mLoader = qt_loader;
 	}
 
+#ifdef WITH_LIBQPSD
 	// PSD loader
 	if (!imgLoaded) {
 
 		imgLoaded = loadPSDFile(mFile, img, ba);
 		if (imgLoaded) mLoader = psd_loader;
 	}
+#endif
 
 #if QT_VERSION < 0x050000	// >DIR: qt5 ships with webp : ) [23.4.2015 markus]
 	// WEBP loader
@@ -396,6 +398,7 @@ bool DkBasicLoader::loadRawFile(const QString& filePath, QImage& img, QSharedPoi
 }
 
 #ifdef Q_OS_WIN
+#ifdef WITH_LIBQPSD
 bool DkBasicLoader::loadPSDFile(const QString&, QImage&, QSharedPointer<QByteArray>) const {
 #else
 bool DkBasicLoader::loadPSDFile(const QString& filePath, QImage& img, QSharedPointer<QByteArray> ba) const {
@@ -437,6 +440,7 @@ bool DkBasicLoader::loadPSDFile(const QString& filePath, QImage& img, QSharedPoi
 #endif // !Q_OS_WIN
 	return false;
 }
+#endif
 
 void DkBasicLoader::setImage(const QImage & img, const QString & editName, const QString & file) {
 

--- a/ImageLounge/src/DkCore/DkBasicLoader.h
+++ b/ImageLounge/src/DkCore/DkBasicLoader.h
@@ -38,7 +38,9 @@
 //#include "DkImageStorage.h"
 
 #ifndef Q_OS_WIN
+#ifdef WITH_LIBQPSD
 #include "qpsdhandler.h"
+#endif
 #endif
 
 // opencv


### PR DESCRIPTION
Had some problems with compiling libqpsd. Added a cmake compile flag that allows selectively turning its usage off.