### PR TITLE
install manual pages in the correct folder on OpenBSD

### DIFF
--- a/ImageLounge/cmake/UnixBuildTarget.cmake
+++ b/ImageLounge/cmake/UnixBuildTarget.cmake
@@ -79,7 +79,11 @@ install(FILES src/img/nomacs.svg DESTINATION share/pixmaps)
 #  translations
 install(FILES ${NOMACS_QM} DESTINATION share/nomacs/translations)
 #  manpage
-install(FILES Readme/nomacs.1 DESTINATION share/man/man1)
+if(${CMAKE_SYSTEM_NAME} MATCHES "OpenBSD")
+    install(FILES Readme/nomacs.1 DESTINATION man/man1)
+else()
+    install(FILES Readme/nomacs.1 DESTINATION share/man/man1)
+endif()
 #  appdata
 install(FILES nomacs.appdata.xml DESTINATION share/metainfo/)
 


### PR DESCRIPTION
Simple fix to install manual pages in the correct folder on OpenBSD