### PR TITLE
Added file index to the file info label

### DIFF
--- a/ImageLounge/src/DkCore/DkBasicWidgets.h
+++ b/ImageLounge/src/DkCore/DkBasicWidgets.h
@@ -118,6 +118,7 @@ protected:
 	int map(double val) const;
 	double mapInv(int val) const;
 
+	QLabel* mIndexLabel;
 	QLabel* mTitleLabel;
 	QSlider* mSlider;
 	QDoubleSpinBox* mSliderBox;

--- a/ImageLounge/src/DkCore/DkImageContainer.cpp
+++ b/ImageLounge/src/DkCore/DkImageContainer.cpp
@@ -704,6 +704,19 @@ bool DkImageContainerT::loadImageThreaded(bool force) {
 	return true;
 }
 
+void DkImageContainerT::setIdx(int idx, int count) {
+	mIdx = idx;
+	mCount = count;
+}
+
+int DkImageContainerT::getIdx() {
+	return mIdx;
+}
+
+int DkImageContainerT::getCount() {
+	return mCount;
+}
+
 void DkImageContainerT::fetchFile() {
 	
 	if (mFetchingBuffer && getLoadState() == loading_canceled) {

--- a/ImageLounge/src/DkCore/DkImageContainer.h
+++ b/ImageLounge/src/DkCore/DkImageContainer.h
@@ -165,6 +165,9 @@ public:
 	virtual ~DkImageContainerT();
 
 	void fetchFile();
+	void setIdx(int idx, int count);
+	int getIdx();
+	int getCount();
 	void cancel();
 	void clear() override;
 	void receiveUpdates(QObject* obj, bool connectSignals = true);
@@ -232,6 +235,9 @@ protected:
 	bool mDownloaded = false;
 
 	QTimer mFileUpdateTimer;
+
+	int mIdx = -1;
+	int mCount = -1;
 };
 
 }

--- a/ImageLounge/src/DkCore/DkImageLoader.cpp
+++ b/ImageLounge/src/DkCore/DkImageLoader.cpp
@@ -851,8 +851,12 @@ void DkImageLoader::setCurrentImage(QSharedPointer<DkImageContainerT> newImg) {
 
 	mCurrentImage = newImg;
 
-	if (mCurrentImage)
+	if (mCurrentImage){
 		mCurrentImage->receiveUpdates(this);
+
+		int idx = findFileIdx(mCurrentImage->filePath(), mImages);
+		mCurrentImage->setIdx(idx, mImages.count());
+	}
 }
 
 void DkImageLoader::reloadImage() {

--- a/ImageLounge/src/DkGui/DkControlWidget.cpp
+++ b/ImageLounge/src/DkGui/DkControlWidget.cpp
@@ -658,7 +658,7 @@ void DkControlWidget::updateImage(QSharedPointer<DkImageContainerT> imgC) {
 	QSharedPointer<DkMetaDataT> metaData = imgC->getMetaData();
 
 	QString dateString = metaData->getExifValue("DateTimeOriginal");
-	mFileInfoLabel->updateInfo(imgC->filePath(), "", dateString, metaData->getRating());
+	mFileInfoLabel->updateInfo(imgC->filePath(), "", dateString, metaData->getRating(), imgC->getIdx(), imgC->getCount());
 	mFileInfoLabel->setEdited(imgC->isEdited());
 	mCommentWidget->setMetaData(metaData);
 	updateRating(metaData->getRating());

--- a/ImageLounge/src/DkGui/DkManipulatorWidgets.h
+++ b/ImageLounge/src/DkGui/DkManipulatorWidgets.h
@@ -222,6 +222,7 @@ private:
 	QSharedPointer<DkImageContainerT> mImgC;
 	QLabel* mPreview = 0;
 	QLabel* mTitleLabel = 0;
+	QLabel* mIndexLabel = 0;
 	int mMaxPreview = 150;
 };
 

--- a/ImageLounge/src/DkGui/DkWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkWidgets.cpp
@@ -1076,6 +1076,10 @@ DkFileInfoLabel::DkFileInfoLabel(QWidget* parent) : DkFadeLabel(parent) {
 	setObjectName("DkFileInfoLabel");
 	setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Minimum);
 
+	mIndexLabel = new QLabel(this);
+	mIndexLabel->setMouseTracking(true);
+	mIndexLabel->setTextInteractionFlags(Qt::TextSelectableByMouse);
+
 	mTitleLabel = new QLabel(this);
 	mTitleLabel->setMouseTracking(true);
 	mTitleLabel->setTextInteractionFlags(Qt::TextSelectableByMouse);
@@ -1094,6 +1098,7 @@ void DkFileInfoLabel::createLayout() {
 	mLayout = new QBoxLayout(QBoxLayout::TopToBottom, this);
 	mLayout->setSpacing(2);
 
+	mLayout->addWidget(mIndexLabel);
 	mLayout->addWidget(mTitleLabel);
 	mLayout->addWidget(mDateLabel);
 	mLayout->addWidget(mRatingLabel);
@@ -1158,12 +1163,21 @@ DkRatingLabel* DkFileInfoLabel::getRatingLabel() {
 	return mRatingLabel;
 }
 
-void DkFileInfoLabel::updateInfo(const QString& filePath, const QString& attr, const QString& date, const int rating) {
+void DkFileInfoLabel::updateInfo(const QString& filePath, const QString& attr, const QString& date, const int rating, const int idx, const int count) {
 
 	mFilePath = filePath;
 	updateTitle(filePath, attr);
+	updateIndex(idx, count);
 	updateDate(date);
 	updateRating(rating);
+
+	updateWidth();
+}
+
+void DkFileInfoLabel::updateIndex(const int idx, const int count) {
+
+	mIndexLabel->setText(QString::number(idx + 1) + "/" + QString::number(count));
+	mIndexLabel->setAlignment(Qt::AlignRight);
 
 	updateWidth();
 }

--- a/ImageLounge/src/DkGui/DkWidgets.h
+++ b/ImageLounge/src/DkGui/DkWidgets.h
@@ -198,8 +198,9 @@ public:
 	~DkFileInfoLabel() {};
 
 	void createLayout();
-	void updateInfo(const QString& filePath, const QString& attr, const QString& date, const int rating);
+	void updateInfo(const QString& filePath, const QString& attr, const QString& date, const int rating, const int idx, const int count);
 	void updateTitle(const QString& filePath, const QString& attr);
+	void updateIndex(const int idx, const int count);
 	void updateDate(const QString& date = QString());
 	void updateRating(const int rating);
 	void setEdited(bool edited);
@@ -213,6 +214,7 @@ protected:
 
 	QBoxLayout* mLayout;
 	QLabel* mTitleLabel;
+	QLabel* mIndexLabel;
 	QLabel* mDateLabel;
 	DkRatingLabel* mRatingLabel;
 


### PR DESCRIPTION
A feature suggestion. I added an indicator in the file info label that shows the index of the current image over the image count in the current folder.

Like so: 9/103

Aligned to the right, on the first line.

![image](https://user-images.githubusercontent.com/27892962/55689964-60a68d00-5959-11e9-9fdb-6902ee59c33d.png)

Hope it's good enough. Feel free to make suggestions; I might have missed something or there might be some convention I am overlooking.

Regards