### PR TITLE
Removed 1px border from frameless windows

### DIFF
--- a/ImageLounge/src/themes/Dark-Theme.css
+++ b/ImageLounge/src/themes/Dark-Theme.css
@@ -194,7 +194,7 @@ QLineEdit#DkWarningEdit[error="true"] {
 }
 
 nmc--DkFolderScrollBar {
-	border: 1px solid #444;
+	border: none;
 }
 
 nmc--DkCentralWidget {

--- a/ImageLounge/src/themes/Dark-Theme.css
+++ b/ImageLounge/src/themes/Dark-Theme.css
@@ -194,11 +194,11 @@ QLineEdit#DkWarningEdit[error="true"] {
 }
 
 nmc--DkFolderScrollBar {
-	border: none;
+	border: 1px solid #444;
 }
 
 nmc--DkCentralWidget {
-	border: 1px solid #444;
+	border: none;
 }
 
 /* DkRecentFiles */


### PR DESCRIPTION
When not maximized, a frameless window will show a thin 1px border.
This solves the issue #318
