### PR TITLE
Fix build with GCC9

### DIFF
--- a/ImageLounge/src/DkCore/DkMetaData.cpp
+++ b/ImageLounge/src/DkCore/DkMetaData.cpp
@@ -42,6 +42,8 @@
 #include <QApplication>
 #pragma warning(pop)		// no warnings from includes - end
 
+#include <iostream>
+
 namespace nmc {
 
 // DkMetaDataT --------------------------------------------------------------------

--- a/ImageLounge/src/DkGui/DkNoMacs.cpp
+++ b/ImageLounge/src/DkGui/DkNoMacs.cpp
@@ -99,6 +99,8 @@
 
 #include <assert.h>
 
+#include <iostream>
+
 namespace nmc {
 
 DkNomacsOSXEventFilter::DkNomacsOSXEventFilter(QObject *parent) : QObject(parent) {


### PR DESCRIPTION
This is needed due to some `cout` usage.