### PR TITLE
The French translation for 'Make' is 'Fabricant'.

### DIFF
--- a/ImageLounge/translations/nomacs_fr.ts
+++ b/ImageLounge/translations/nomacs_fr.ts
@@ -4562,7 +4562,7 @@ Do you want to show them again?</source>
     <message>
       <location filename="../srv/nomacs.git/ImageLounge/src/DkCore/DkSettings.cpp" line="68"/>
       <source>Make</source>
-      <translation>Construire</translation>
+      <translation>Fabricant</translation>
     </message>
     <message>
       <location filename="../srv/nomacs.git/ImageLounge/src/DkCore/DkSettings.cpp" line="69"/>


### PR DESCRIPTION

'Construire' is a verb but it should be a noun. This can be compared with the German version 'Hersteller' which translate to 'Fabricant' as per Google translate (and Collins).


