### PR TITLE
Add FreeBSD support

### DIFF
--- a/ImageLounge/3rdparty/drif/drif_image.h
+++ b/ImageLounge/3rdparty/drif/drif_image.h
@@ -26,7 +26,7 @@
 #include <stdint.h>
 #include <stdio.h>
 
-#if defined(Q_OS_MAC) || defined(Q_OS_OPENBSD)
+#if defined(Q_OS_MAC) || defined(Q_OS_OPENBSD) || defined(Q_OS_FREEBSD)
 #include <stdlib.h>
 #else 
 #include <malloc.h>


### PR DESCRIPTION
Add FreeBSD to the list of operating systems that need stdlib.h
instead of malloc.h.