### PR TITLE
Let the user choose the root directory of the file explorer

### DIFF
--- a/ImageLounge/src/DkGui/DkBaseWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkBaseWidgets.cpp
@@ -354,6 +354,41 @@ DkLabelBg::DkLabelBg(QWidget* parent, const QString& text) : DkLabel(parent, tex
 	setObjectName("DkLabelBg");
 }
 
+// DkElidedLabel --------------------------------------------------------------------
+DkElidedLabel::DkElidedLabel(QWidget *parent, const QString &text)
+	: QLabel("", parent) {
+	setText(text);
+	setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Minimum);
+}
+
+void DkElidedLabel::setText(QString text) {
+	content = text;
+	updateElision();
+}
+
+void DkElidedLabel::resizeEvent(QResizeEvent *event) {
+	updateElision();
+	QLabel::resizeEvent(event);
+}
+
+void DkElidedLabel::updateElision() {
+	QFontMetrics metrix(font());
+	QString clippedText = metrix.elidedText(content, Qt::ElideRight, width());
+	QLabel::setText(clippedText);
+}
+
+QSize DkElidedLabel::minimumSizeHint() {
+	return QSize(0, QLabel::minimumSizeHint().height());
+}
+
+QSize DkElidedLabel::minimumSize() {
+	return QSize(0, QLabel::minimumSize().height());
+}
+
+int DkElidedLabel::minimumWidth() {
+	return 0;
+}
+
 // DkFadeLabel --------------------------------------------------------------------
 DkFadeLabel::DkFadeLabel(QWidget* parent, const QString& text) : DkLabel(parent, text) {
 	init();

--- a/ImageLounge/src/DkGui/DkBaseWidgets.h
+++ b/ImageLounge/src/DkGui/DkBaseWidgets.h
@@ -167,6 +167,26 @@ protected:
 	virtual void updateStyleSheet();
 };
 
+class DllCoreExport DkElidedLabel : public QLabel {
+	Q_OBJECT
+
+public:
+	DkElidedLabel(QWidget *parent = 0, const QString &text = QString());
+
+	void setText(QString text);
+	QString text() const { return content; }
+	QSize minimumSizeHint();
+	QSize minimumSize();
+	int minimumWidth();
+
+protected:
+	void resizeEvent(QResizeEvent *event);
+
+private:
+	void updateElision();
+	QString content;
+};
+
 class DkLabelBg : public DkLabel {
 	Q_OBJECT
 

--- a/ImageLounge/src/DkGui/DkWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkWidgets.cpp
@@ -457,6 +457,12 @@ void DkExplorer::setCurrentPath(const QString& filePath) {
 	fileTree->setCurrentIndex(sortModel->mapFromSource(fileModel->index(filePath)));
 }
 
+void DkExplorer::setRootPath(const QString &root) {
+
+	fileTree->setRootIndex(sortModel->mapFromSource(fileModel->index(root)));
+	fileModel->setRootPath(root);
+}
+
 void DkExplorer::fileClicked(const QModelIndex &index) const {
 
 	QFileInfo cFile = fileModel->fileInfo(sortModel->mapToSource(index));

--- a/ImageLounge/src/DkGui/DkWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkWidgets.cpp
@@ -620,7 +620,7 @@ void DkExplorer::readSettings() {
 
 	mLoadSelected = settings.value("LoadSelected", mLoadSelected).toBool();
 	fileModel->setReadOnly(settings.value("ReadOnly", true).toBool());
-	setRootPath(settings.value("RootPath", QDir::rootPath()).toString());
+	setRootPath(settings.value("RootPath", QDir::homePath()).toString());
 	settings.endGroup();
 }
 

--- a/ImageLounge/src/DkGui/DkWidgets.h
+++ b/ImageLounge/src/DkGui/DkWidgets.h
@@ -367,6 +367,7 @@ public:
 public slots:
 	void setCurrentImage(QSharedPointer<DkImageContainerT> img);
 	void setCurrentPath(const QString& filePath);
+	void browseClicked();
 	void setRootPath(const QString &root);
 	void fileClicked(const QModelIndex &index) const;
 	void showColumn(bool show);
@@ -386,9 +387,14 @@ protected:
 	void writeSettings();
 	void readSettings();
 
+	QString rootPath;
+	QPushButton* rootPathBrowseButton;
+	DkElidedLabel* rootPathLabel;
+
 	DkFileSystemModel* fileModel;
 	DkSortFileProxyModel* sortModel;
 	QTreeView* fileTree;
+
 	QVector<QAction*> columnActions;
 	bool mLoadSelected = false;
 };

--- a/ImageLounge/src/DkGui/DkWidgets.h
+++ b/ImageLounge/src/DkGui/DkWidgets.h
@@ -367,6 +367,7 @@ public:
 public slots:
 	void setCurrentImage(QSharedPointer<DkImageContainerT> img);
 	void setCurrentPath(const QString& filePath);
+	void setRootPath(const QString &root);
 	void fileClicked(const QModelIndex &index) const;
 	void showColumn(bool show);
 	void setEditable(bool editable);


### PR DESCRIPTION
The problem I had with the file explorer was that the root of it was at / (on unix-likes) so you would need to go a lot of levels down until you get to your images and then you would need to scroll left/right in the explorer which was cumbersome.

So my proposed solution is to let the user choose the root directory, the default is / on unix likes and whatever qt thinks the root of the filesystem is in windows, perhaps it might be better to change to ~ on unix-likes and My documents or something in windows.

Example:
![2020-04-14-041632_254x211_scrot](https://user-images.githubusercontent.com/5717604/79152680-95b8ab80-7e07-11ea-89c8-c979d3eb7012.png)

Tested only on linux, thought it should work elsewhere as well.
