### PR TITLE
Enable animation for .avif extension

### DIFF
--- a/ImageLounge/src/DkCore/DkImageContainer.cpp
+++ b/ImageLounge/src/DkCore/DkImageContainer.cpp
@@ -384,7 +384,7 @@ bool DkImageContainer::hasImage() const {
 bool DkImageContainer::hasMovie() const {
 
 	QString newSuffix = QFileInfo(filePath()).suffix();
-	return newSuffix.contains(QRegExp("(avifs|gif|mng|webp)", Qt::CaseInsensitive)) != 0;
+	return newSuffix.contains(QRegExp("(avif|gif|mng|webp)", Qt::CaseInsensitive)) != 0;
 }
 
 bool DkImageContainer::hasSvg() const {


### PR DESCRIPTION
New AVIF specification draft indicate that ".avif" files can be animated too.
In the past, animated AVIF sequences had ".avifs" extension.

This patch enables animation for .avif extension while keep it enabled for older .avifs files.

Problem was reported in https://github.com/nomacs/nomacs/issues/582