### PR TITLE
Fix Qt5 include on macOS

### DIFF
--- a/ImageLounge/CMakeLists.txt
+++ b/ImageLounge/CMakeLists.txt
@@ -142,6 +142,8 @@ include_directories (
 )
 
 if (APPLE) # todo: somehow add this to Mac.cmake or MacBuildTarget.cmake
+	execute_process(COMMAND ${QT_QMAKE_EXECUTABLE} -query QT_INSTALL_HEADERS OUTPUT_VARIABLE qt_install_headers)
+	include_directories (BEFORE ${qt_install_headers})
 	SET (NOMACS_SOURCES ${NOMACS_SOURCES} macosx/nomacs.icns)
 endif (APPLE)
 


### PR DESCRIPTION
This fixes Qt5 includes on macOS after Homebrews current is Qt6