### PR TITLE
Make rotation and comment change explicit (*)

### DIFF
--- a/ImageLounge/src/DkCore/DkBasicLoader.h
+++ b/ImageLounge/src/DkCore/DkBasicLoader.h
@@ -99,16 +99,26 @@ protected:
 class DllCoreExport DkEditImage {
 
 public:
-	DkEditImage(const QImage& img = QImage(), const QString& editName = "");
+	DkEditImage();
+	DkEditImage(const QImage& img, const QSharedPointer<DkMetaDataT>& metaData, const QString& editName = "");
+	DkEditImage(const QSharedPointer<DkMetaDataT>& metaData, const QImage& img, const QString& editName = "");
 
 	void setImage(const QImage& img);
-	QImage image() const;
 	QString editName() const;
+	QImage image() const;
+	bool hasImage() const;
+	bool hasMetaData() const;
+	bool hasNewImage() const;
+	bool hasNewMetaData() const;
+	QSharedPointer<DkMetaDataT> metaData() const;
 	int size() const;
 
 protected:
-	QImage mImg;
 	QString mEditName;
+	QImage mImg;
+	bool mNewImg;
+	bool mNewMetaData;
+	QSharedPointer<DkMetaDataT> mMetaData;
 
 };
 
@@ -263,7 +273,11 @@ public:
 	 * @param file assigns the current file name
 	 **/
 	void setImage(const QImage& img, const QString& editName, const QString& file);
+	void pruneEditHistory();
 	void setEditImage(const QImage& img, const QString& editName = "");
+	void setEditMetaData(const QSharedPointer<DkMetaDataT>& metaData, const QImage& img, const QString& editName = "");
+	void setEditMetaData(const QSharedPointer<DkMetaDataT>& metaData, const QString& editName = "");
+	void setEditMetaData(const QString& editName);
 
 	void setTraining(bool training) {
 		training = true;
@@ -277,15 +291,20 @@ public:
 		return mLoader;
 	};
 
-	QSharedPointer<DkMetaDataT> getMetaData() const {
-		return mMetaData;
-	};
+	QSharedPointer<DkMetaDataT> getMetaData() const;
 
 	/**
 	 * Returns the 8-bit image, which is rendered.
 	 * @return QImage an 8bit image
 	 **/
 	QImage image() const;
+	QImage lastImage() const;
+	QImage pixmap() const;
+
+	QSharedPointer<DkMetaDataT> lastMetaDataEdit(bool return_nullptr = true, bool return_orig = false) const;
+
+	bool isImageEdited();
+	bool isMetaDataEdited();
 
 	QString getFile() {
 		return mFile;
@@ -356,6 +375,10 @@ public:
 
 signals:
 	void errorDialogSignal(const QString& msg) const;
+
+	void undoSignal();
+	void redoSignal();
+	void resetMetaDataSignal();
 
 protected:
 	bool loadRohFile(const QString& filePath, QImage& img, QSharedPointer<QByteArray> ba = QSharedPointer<QByteArray>()) const;

--- a/ImageLounge/src/DkCore/DkBasicLoader.h
+++ b/ImageLounge/src/DkCore/DkBasicLoader.h
@@ -306,11 +306,11 @@ public:
 	bool isImageEdited();
 	bool isMetaDataEdited();
 
-	QString getFile() {
+	QString getFile() const {
 		return mFile;
 	};
 
-	bool isDirty() {
+	bool isDirty() const {
 		return mPageIdxDirty;
 	};
 

--- a/ImageLounge/src/DkCore/DkBasicLoader.h
+++ b/ImageLounge/src/DkCore/DkBasicLoader.h
@@ -213,7 +213,7 @@ public:
 	DkBasicLoader(int mode = mode_default);
 
 	~DkBasicLoader() {
-		release(true);
+		release();
 	};
 
 	/**
@@ -324,7 +324,7 @@ public:
 	QSharedPointer<QByteArray> loadFileToBuffer(const QString& filePath) const;
 	bool writeBufferToFile(const QString& fileInfo, const QSharedPointer<QByteArray> ba) const;
 
-	void release(bool clear = false);
+	void release();
 
 
 #ifdef WITH_OPENCV

--- a/ImageLounge/src/DkCore/DkImageContainer.cpp
+++ b/ImageLounge/src/DkCore/DkImageContainer.cpp
@@ -477,10 +477,12 @@ void DkImageContainer::saveMetaData() {
 
 void DkImageContainer::saveMetaDataIntern(const QString& filePath, QSharedPointer<DkBasicLoader> loader, QSharedPointer<QByteArray> fileBuffer) {
 
-	loader->saveMetaData(filePath, fileBuffer);
+	// TODO this shouldn't be used without notifying the user, see issue #799
+	loader->saveMetaData(filePath, fileBuffer); // TODO use with caution
 }
 
-void DkImageContainer::setEdited(bool edited) {
+void DkImageContainer::setEdited(bool edited /* = true */) {
+
 	mEdited = edited;
 }
 
@@ -599,7 +601,11 @@ DkImageContainerT::~DkImageContainerT() {
 	mImageWatcher.blockSignals(true);
 	mImageWatcher.cancel();
 
-	saveMetaData();
+	// This dtor is where saveMetaData() used to be called, which called the "dangerous" overload of saveMetaData(),
+	// which is dangerous because it updates the file. We consider this to be a bug.
+	// The other place where the file was silently updated in the background was the release() routine, called on unload.
+	// All changes should be explicitly committed, including exif notes.
+	// If you think this is wrong, a comment would be appreciated. See issue #799.
 
 	// we have to wait here
 	mSaveMetaDataWatcher.blockSignals(true);

--- a/ImageLounge/src/DkCore/DkImageContainer.cpp
+++ b/ImageLounge/src/DkCore/DkImageContainer.cpp
@@ -313,10 +313,7 @@ QImage DkImageContainer::image() {
 
 QImage DkImageContainer::pixmap() {
 
-	//if (getLoader()->image().isNull() && getLoadState() == not_loaded)
-	//	loadImage();
-
-	return mLoader->pixmap(); //current image as shown in the gui, may differ from saved image
+	return mLoader->pixmap();
 }
 
 QImage DkImageContainer::imageScaledToHeight(int height) {
@@ -643,7 +640,7 @@ DkImageContainerT::~DkImageContainerT() {
 	// which is dangerous because it updates the file. We consider this to be a bug.
 	// The other place where the file was silently updated in the background was the release() routine, called on unload.
 	// All changes should be explicitly committed, including exif notes.
-	// If you think this is wrong, a comment would be appreciated. See issue #799.
+	// See issue #799. [2022, PSE]
 
 	// we have to wait here
 	mSaveMetaDataWatcher.blockSignals(true);

--- a/ImageLounge/src/DkCore/DkImageContainer.h
+++ b/ImageLounge/src/DkCore/DkImageContainer.h
@@ -76,6 +76,7 @@ public:
 	bool operator>= (const DkImageContainer& o) const;
 
 	QImage image();
+	QImage pixmap();
 	QImage imageScaledToHeight(int height);
 	QImage imageScaledToWidth(int width);
 
@@ -114,6 +115,9 @@ public:
 	bool loadImage();
 	void setImage(const QImage& img, const QString& editName);
 	void setImage(const QImage& img, const QString& editName, const QString& filePath);
+	void setMetaData(QSharedPointer<DkMetaDataT> editedMetaData, const QImage& img, const QString& editName);
+	void setMetaData(QSharedPointer<DkMetaDataT> editedMetaData, const QString& editName);
+	void setMetaData(const QString& editName);
 	bool saveImage(const QString& filePath, const QImage saveImg, int compression = -1);
 	bool saveImage(const QString& filePath, int compression = -1);
 	void saveMetaData();
@@ -174,6 +178,7 @@ public:
 	bool loadImageThreaded(bool force = false);
 	bool saveImageThreaded(const QString& filePath, const QImage saveImg, int compression = -1);
 	bool saveImageThreaded(const QString& filePath, int compression = -1);
+	void saveMetaDataThreaded(const QString& filePath);
 	void saveMetaDataThreaded();
 	bool isFileDownloaded() const;
 

--- a/ImageLounge/src/DkCore/DkImageContainer.h
+++ b/ImageLounge/src/DkCore/DkImageContainer.h
@@ -91,7 +91,7 @@ public:
 	bool isFromZip();
 	bool isEdited() const;
 	bool isSelected() const;
-	void setEdited(bool edited);
+	void setEdited(bool edited = true);
 	QString getTitleAttribute() const;
 	float getMemoryUsage() const;
 	float getFileSize() const;

--- a/ImageLounge/src/DkCore/DkImageLoader.cpp
+++ b/ImageLounge/src/DkCore/DkImageLoader.cpp
@@ -1260,6 +1260,8 @@ void DkImageLoader::saveUserFileAs(const QImage& saveImg, bool silent) {
 		//Skip the rest which is only relevant when re-encoding/saving the image
 		return;
 	}
+	//Saving image normally, clear exif rotation flag to prevent double rotation
+	mCurrentImage->getLoader()->getMetaData()->clearOrientation();
 	//Below are the compress/encode routines; at the end of a long call chain (saveIntern internSave Threaded)
 	//saveToBuffer() is responsible for adding the exif data to the image buffer soup
 	//which is then written to the specified file.

--- a/ImageLounge/src/DkCore/DkImageLoader.h
+++ b/ImageLounge/src/DkCore/DkImageLoader.h
@@ -116,6 +116,7 @@ public:
 	bool isEdited() const;
 	int numFiles() const;
 	QImage getImage();
+	QImage getPixmap();
 	bool dirtyTiff();
 
 	QStringList ignoreKeywords() const;

--- a/ImageLounge/src/DkCore/DkImageLoader.h
+++ b/ImageLounge/src/DkCore/DkImageLoader.h
@@ -84,6 +84,7 @@ public:
 	void setImages(QVector<QSharedPointer<DkImageContainerT> > images);
 	QSharedPointer<DkImageContainerT> setImage(const QImage& img, const QString& editName, const QString& editFilePath = QString());
 	QSharedPointer<DkImageContainerT> setImage(QSharedPointer<DkImageContainerT> img);
+	void setImageUpdated();
 	void setCurrentImage(QSharedPointer<DkImageContainerT> newImg);
 	void sort();
 

--- a/ImageLounge/src/DkCore/DkMetaData.cpp
+++ b/ImageLounge/src/DkCore/DkMetaData.cpp
@@ -64,22 +64,14 @@ QSharedPointer<DkMetaDataT> DkMetaDataT::copy() const {
 	metaDataN->mExifState = mExifState;
 
 	if (mExifImg.get() != 0) {
-		mExifImg->io().seek(0, Exiv2::BasicIo::beg);
-		long size = mExifImg->io().size();
-        Exiv2::DataBuf buff = mExifImg->io().read(size);
-		if (buff.pData_[0] != 0) {
-			//Initial copy, read buffered file contents to create new Exiv2::Image via factory
-			Exiv2::Image::AutoPtr exifImgN = Exiv2::ImageFactory::open(buff.pData_, size);
-			metaDataN->mExifImg = exifImgN;
-			metaDataN->mExifImg->readMetadata();
-		} else {
-			//Second copy without file data, alternatively recreate new Exiv2::Image by reading file again
-			metaDataN->readMetaData(mFilePath);
-		}
-
-		metaDataN->mExifImg->setExifData(mExifImg->exifData()); //explicit copy of list<Exifdatum>
-		metaDataN->mExifState = dirty;
 		metaDataN->mFilePath = mFilePath;
+		//Load new Exiv2::Image object
+		int i_type = mExifImg->imageType();
+		metaDataN->mExifImg = Exiv2::ImageFactory::create(i_type);
+		//Copy exif data from old object into new object
+		Exiv2::ExifData data = mExifImg->exifData();
+		metaDataN->mExifImg->setExifData(data); //explicit copy of list<Exifdatum>
+		metaDataN->mExifState = dirty;
 	}
 
 	return metaDataN;

--- a/ImageLounge/src/DkCore/DkMetaData.h
+++ b/ImageLounge/src/DkCore/DkMetaData.h
@@ -86,7 +86,9 @@ class DllCoreExport DkMetaDataT {
 
 public:
 	DkMetaDataT();
-
+	bool isNull();
+	QSharedPointer<DkMetaDataT> copy() const;
+	void update(const QSharedPointer<DkMetaDataT> &other);
 
 	enum ExifOrientationState {
 		or_illegal = -1,
@@ -128,7 +130,7 @@ public:
 	void setRating(int r);
 	bool setDescription(const QString& description);
 	bool setExifValue(QString key, QString taginfo);
-	bool updateImageMetaData(const QImage& img);
+	bool updateImageMetaData(const QImage& img, bool reset_orientation = true);
 	void setThumbnail(QImage thumb);
 	void setQtValues(const QImage& cImg);
 	static QString exiv2ToQString(std::string exifString);
@@ -163,7 +165,7 @@ protected:
 		dirty,
 	};
 
-	Exiv2::Image::AutoPtr mExifImg;
+	Exiv2::Image::AutoPtr mExifImg; //TODO std::unique_ptr<Exiv2::Image> (and all other *::AutoPtr)
 	QString mFilePath;
 	QStringList mQtKeys;
 	QStringList mQtValues;

--- a/ImageLounge/src/DkGui/DkControlWidget.cpp
+++ b/ImageLounge/src/DkGui/DkControlWidget.cpp
@@ -243,7 +243,7 @@ void DkControlWidget::init() {
 	//centerLabel->setText("ich bin richtig...", -1);
 	//bottomLeftLabel->setText("topLeft label...", -1);
 	//spinnerLabel->show();
-	
+
 	show();
 }
 
@@ -282,6 +282,7 @@ void DkControlWidget::connectWidgets() {
 
 	// comment widget
 	connect(mCommentWidget, SIGNAL(showInfoSignal(const QString&)), this, SLOT(setInfo(const QString&)));
+	connect(mCommentWidget, SIGNAL(commentSavedSignal()), mViewport, SLOT(setImageUpdated()));
 
 	// mViewport
 	connect(mViewport, SIGNAL(infoSignal(const QString&)), this, SLOT(setInfo(const QString&)));
@@ -627,7 +628,7 @@ void DkControlWidget::updateImage(QSharedPointer<DkImageContainerT> imgC) {
 	QString dateString = metaData->getExifValue("DateTimeOriginal");
 	mFileInfoLabel->updateInfo(imgC->filePath(), "", dateString, metaData->getRating());
 	mFileInfoLabel->setEdited(imgC->isEdited());
-	mCommentWidget->setMetaData(metaData);
+	mCommentWidget->setMetaData(metaData); // reset
 	updateRating(metaData->getRating());
 
 }

--- a/ImageLounge/src/DkGui/DkControlWidget.cpp
+++ b/ImageLounge/src/DkGui/DkControlWidget.cpp
@@ -282,7 +282,8 @@ void DkControlWidget::connectWidgets() {
 
 	// comment widget
 	connect(mCommentWidget, SIGNAL(showInfoSignal(const QString&)), this, SLOT(setInfo(const QString&)));
-	connect(mCommentWidget, SIGNAL(commentSavedSignal()), mViewport, SLOT(setImageUpdated()));
+	connect(mCommentWidget, SIGNAL(commentSavedSignal()), this, SLOT(setCommentSaved()));
+	connect(this, SIGNAL(imageUpdatedSignal()), mCommentWidget, SLOT(resetComment()));
 
 	// mViewport
 	connect(mViewport, SIGNAL(infoSignal(const QString&)), this, SLOT(setInfo(const QString&)));
@@ -305,6 +306,11 @@ void DkControlWidget::connectWidgets() {
 	connect(am.action(DkActionManager::menu_panel_histogram), SIGNAL(toggled(bool)), this, SLOT(showHistogram(bool)));
 	connect(am.action(DkActionManager::menu_panel_comment), SIGNAL(toggled(bool)), this, SLOT(showCommentWidget(bool)));
 	connect(am.action(DkActionManager::menu_panel_toggle), SIGNAL(toggled(bool)), this, SLOT(toggleHUD(bool)));
+}
+
+void DkControlWidget::setCommentSaved() {
+
+	mViewport->imageContainer()->setMetaData(tr("File comment"));
 }
 
 void DkControlWidget::update() {
@@ -630,6 +636,8 @@ void DkControlWidget::updateImage(QSharedPointer<DkImageContainerT> imgC) {
 	mFileInfoLabel->setEdited(imgC->isEdited());
 	mCommentWidget->setMetaData(metaData); // reset
 	updateRating(metaData->getRating());
+
+	connect(imgC.get(), SIGNAL(imageUpdatedSignal()), this, SIGNAL(imageUpdatedSignal()));
 
 }
 

--- a/ImageLounge/src/DkGui/DkControlWidget.h
+++ b/ImageLounge/src/DkGui/DkControlWidget.h
@@ -148,6 +148,12 @@ public slots:
 
 	void update();
 
+signals:
+	void imageUpdatedSignal();
+
+protected slots:
+	void setCommentSaved();
+
 protected:
 
 	// events

--- a/ImageLounge/src/DkGui/DkMetaDataWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkMetaDataWidgets.cpp
@@ -1262,6 +1262,7 @@ void DkCommentWidget::initComment(const QString& description) {
 void DkCommentWidget::resetComment() {
 
 	//First, reset comment text (triggering changed event, but not edited event)
+	mOldText = mMetaData->getDescription();
 	mCommentLabel->setText(mOldText);
 	mCommentLabel->clearFocus();
 	//Reset internal state (this panel only)
@@ -1282,7 +1283,10 @@ void DkCommentWidget::saveComment() {
 			emit showInfoSignal(tr("Sorry, I cannot save comments for this image format."));
 			return;
 		}
+		initComment(text());
+
 		emit commentSavedSignal();
+		emit commentSavedSignal(tr("File comment"));
 	}
 }
 

--- a/ImageLounge/src/DkGui/DkMetaDataWidgets.h
+++ b/ImageLounge/src/DkGui/DkMetaDataWidgets.h
@@ -248,15 +248,17 @@ public slots:
 	void on_saveButton_clicked();
 	void on_cancelButton_clicked();
 
+	void initComment(const QString& description);
+	void resetComment();
+	void saveComment();
+
 signals:
 	void showInfoSignal(const QString& msg) const;
 	void commentEditedSignal() const;
 	void commentSavedSignal() const;
+	void commentSavedSignal(const QString&) const;
 
 protected:
-	void initComment(const QString& description);
-	void resetComment();
-	void saveComment();
 	void createLayout();
 
 	DkCommentTextEdit* mCommentLabel;

--- a/ImageLounge/src/DkGui/DkMetaDataWidgets.h
+++ b/ImageLounge/src/DkGui/DkMetaDataWidgets.h
@@ -240,6 +240,7 @@ public:
 	~DkCommentWidget() {};
 	
 	void setMetaData(QSharedPointer<DkMetaDataT> metaData);
+	QString text() const;
 
 public slots:
 	void on_CommentLabel_textChanged();
@@ -249,16 +250,18 @@ public slots:
 
 signals:
 	void showInfoSignal(const QString& msg) const;
+	void commentEditedSignal() const;
+	void commentSavedSignal() const;
 
 protected:
-	void setComment(const QString& description);
+	void initComment(const QString& description);
+	void resetComment();
 	void saveComment();
 	void createLayout();
 
 	DkCommentTextEdit* mCommentLabel;
 	QSharedPointer<DkMetaDataT> mMetaData;
-	bool mTextChanged = false;
-	bool mDirty = false;
+	bool mTextEdited = false;
 	QString mOldText;
 };
 

--- a/ImageLounge/src/DkGui/DkViewPort.cpp
+++ b/ImageLounge/src/DkGui/DkViewPort.cpp
@@ -262,6 +262,12 @@ void DkViewPort::updateImage(QSharedPointer<DkImageContainerT> image, bool loade
 	}
 }
 
+void DkViewPort::setImageUpdated() {
+
+	if (!mLoader) return;
+	mLoader->setImageUpdated();
+}
+
 void DkViewPort::loadImage(const QImage& newImg) {
 
 	// delete current information
@@ -1926,13 +1932,14 @@ void DkViewPort::connectLoader(QSharedPointer<DkImageLoader> loader, bool connec
 		return;
 
 	if (connectSignals) {
-		//connect(mLoader.data(), SIGNAL(imageLoadedSignal(QSharedPointer<DkImageContainerT>, bool)), this, SLOT(updateImage(QSharedPointer<DkImageContainerT>, bool)), Qt::UniqueConnection);
-		connect(loader.data(), SIGNAL(imageUpdatedSignal(QSharedPointer<DkImageContainerT>)), this, SLOT(updateImage(QSharedPointer<DkImageContainerT>)), Qt::UniqueConnection);
+		connect(loader.data(), SIGNAL(imageLoadedSignal(QSharedPointer<DkImageContainerT>, bool)), this, SLOT(updateImage(QSharedPointer<DkImageContainerT>, bool)), Qt::UniqueConnection);
+		connect(loader.data(), SIGNAL(imageLoadedSignal(QSharedPointer<DkImageContainerT>)), mController->getMetaDataWidget(), SLOT(updateMetaData(QSharedPointer<DkImageContainerT>)), Qt::UniqueConnection);
+		connect(loader.data(), SIGNAL(imageLoadedSignal(QSharedPointer<DkImageContainerT>)), mController, SLOT(updateImage(QSharedPointer<DkImageContainerT>)), Qt::UniqueConnection);
+
+		connect(loader.data(), SIGNAL(imageUpdatedSignal(QSharedPointer<DkImageContainerT>)), this, SLOT(updateImage(QSharedPointer<DkImageContainerT>)), Qt::UniqueConnection); // update image matrix
 
 		connect(loader.data(), SIGNAL(updateDirSignal(QVector<QSharedPointer<DkImageContainerT> >)), mController->getFilePreview(), SLOT(updateThumbs(QVector<QSharedPointer<DkImageContainerT> >)), Qt::UniqueConnection);
 		connect(loader.data(), SIGNAL(imageUpdatedSignal(QSharedPointer<DkImageContainerT>)), mController->getFilePreview(), SLOT(setFileInfo(QSharedPointer<DkImageContainerT>)), Qt::UniqueConnection);
-		connect(loader.data(), SIGNAL(imageUpdatedSignal(QSharedPointer<DkImageContainerT>)), mController->getMetaDataWidget(), SLOT(updateMetaData(QSharedPointer<DkImageContainerT>)), Qt::UniqueConnection);
-		connect(loader.data(), SIGNAL(imageUpdatedSignal(QSharedPointer<DkImageContainerT>)), mController, SLOT(updateImage(QSharedPointer<DkImageContainerT>)), Qt::UniqueConnection);
 
 		connect(loader.data(), SIGNAL(showInfoSignal(const QString&, int, int)), mController, SLOT(setInfo(const QString&, int, int)), Qt::UniqueConnection);
 
@@ -1943,7 +1950,10 @@ void DkViewPort::connectLoader(QSharedPointer<DkImageLoader> loader, bool connec
 		connect(mController->getScroller(), SIGNAL(valueChanged(int)), loader.data(), SLOT(loadFileAt(int)));
 	}
 	else {
-		//connect(mLoader.data(), SIGNAL(imageLoadedSignal(QSharedPointer<DkImageContainerT>, bool)), this, SLOT(updateImage(QSharedPointer<DkImageContainerT>, bool)), Qt::UniqueConnection);
+		disconnect(loader.data(), SIGNAL(imageLoadedSignal(QSharedPointer<DkImageContainerT>, bool)), this, SLOT(updateImage(QSharedPointer<DkImageContainerT>, bool)));
+		disconnect(loader.data(), SIGNAL(imageLoadedSignal(QSharedPointer<DkImageContainerT>)), mController->getMetaDataWidget(), SLOT(updateMetaData(QSharedPointer<DkImageContainerT>)));
+		disconnect(loader.data(), SIGNAL(imageLoadedSignal(QSharedPointer<DkImageContainerT>)), mController, SLOT(updateImage(QSharedPointer<DkImageContainerT>)));
+
 		disconnect(loader.data(), SIGNAL(imageUpdatedSignal(QSharedPointer<DkImageContainerT>)), this, SLOT(updateImage(QSharedPointer<DkImageContainerT>)));
 
 		disconnect(loader.data(), SIGNAL(updateDirSignal(QVector<QSharedPointer<DkImageContainerT> >)), mController->getFilePreview(), SLOT(updateThumbs(QVector<QSharedPointer<DkImageContainerT> >)));

--- a/ImageLounge/src/DkGui/DkViewPort.cpp
+++ b/ImageLounge/src/DkGui/DkViewPort.cpp
@@ -258,8 +258,10 @@ void DkViewPort::updateImage(QSharedPointer<DkImageContainerT> image, bool loade
 		return;
 
 	if (mLoader->hasImage()) {
-		setImage(mLoader->getImage());
+		setImage(mLoader->getPixmap()); //modified image (for view), may differ from lastImage after rotate
 	}
+
+	emit imageUpdatedSignal();
 }
 
 void DkViewPort::setImageUpdated() {

--- a/ImageLounge/src/DkGui/DkViewPort.h
+++ b/ImageLounge/src/DkGui/DkViewPort.h
@@ -180,6 +180,7 @@ public slots:
 	void manipulatorApplied();
 
 	virtual void updateImage(QSharedPointer<DkImageContainerT> image, bool loaded = true);
+	virtual void setImageUpdated();
 	virtual void loadImage(const QImage& newImg);
 	virtual void loadImage(QSharedPointer<DkImageContainerT> img);
 	virtual void setEditedImage(const QImage& newImg, const QString& editName);

--- a/ImageLounge/src/DkGui/DkViewPort.h
+++ b/ImageLounge/src/DkGui/DkViewPort.h
@@ -122,6 +122,7 @@ signals:
 	void zoomSignal(double zoomLevel) const;
 	void mouseClickSignal(QMouseEvent* event, QPoint imgPos) const;
 	void showProgress(bool show, int time = -1) const;
+	void imageUpdatedSignal() const;
 
 public slots:
 	void fullView() override;


### PR DESCRIPTION
This is a work in progress.

I have removed the auto-save feature/bug, rotating an image is now an explicit change which means the image is marked with an asterisk (*) in the title. See issue #799 for details. Since file comments would've been saved automagically (or reset if you rotate or change the image), I have made that explicit too, so clicking on the save (comment) button now marks the image as edited in the same way.

I also want to add an option to declare rotating and cropping as "minor" changes, the file date would be retained after making a minor change (opt-in obviously). See #804.

Is there anyone left who'd be willing to spare some time to review or test my changes? Comments would be appreciated.
