### PR TITLE
Chnage default shortcut for next/prev tab on Mac OS

### DIFF
--- a/ImageLounge/src/DkCore/DkActionManager.h
+++ b/ImageLounge/src/DkCore/DkActionManager.h
@@ -399,16 +399,18 @@ public:
 		// view
 		shortcut_new_tab		= Qt::CTRL + Qt::Key_T,
 		shortcut_close_tab		= Qt::CTRL + Qt::Key_W,
-		shortcut_next_tab		= Qt::CTRL + Qt::Key_Tab,
-		shortcut_previous_tab	= Qt::CTRL + Qt::SHIFT + Qt::Key_Tab,
 		shortcut_show_toolbar	= Qt::CTRL + Qt::Key_B,
 		shortcut_show_statusbar	= Qt::CTRL + Qt::Key_I,
 		shortcut_full_screen_ad	= Qt::CTRL + Qt::Key_L,
 		shortcut_show_transfer	= Qt::CTRL + Qt::Key_U,
 #ifdef Q_OS_MAC
+		shortcut_next_tab		= Qt::META + Qt::Key_Tab,
+		shortcut_previous_tab	= Qt::META + Qt::SHIFT + Qt::Key_Tab,
 		shortcut_full_screen_ff	= Qt::CTRL + Qt::Key_F,
 		shortcut_frameless		= Qt::CTRL + Qt::Key_R,
 #else
+		shortcut_next_tab		= Qt::CTRL + Qt::Key_Tab,
+		shortcut_previous_tab	= Qt::CTRL + Qt::SHIFT + Qt::Key_Tab,
 		shortcut_full_screen_ff	= Qt::Key_F11,
 		shortcut_frameless		= Qt::Key_F10,
 #endif

--- a/README.md
+++ b/README.md
@@ -107,7 +107,16 @@ Go to the `nomacs` directory and run cmake to get the Makefiles:
 $ cd nomacs
 $ mkdir build
 $ cd build
+```
+
+For Homebrew on Intel models:
+```console
 $ Qt5_DIR=/usr/local/opt/qt5/ cmake -DQT_QMAKE_EXECUTABLE=/usr/local/opt/qt5/bin ../ImageLounge/.
+```
+
+For Homebrew on Apple Silicon models:
+```console
+$ Qt5_DIR=/opt/homebrew/opt/qt5/ cmake -DQT_QMAKE_EXECUTABLE=/opt/homebrew/opt/qt5/bin ../ImageLounge/.
 ```
 
 Run make:


### PR DESCRIPTION
The default shortcut for `next tab` is `Qt::CTRL + Qt::Key_Tab`, which works fine on Windows and Linux as `Ctrl + Tab`.

However on Mac OS, `Qt::CTRL` corresponds to `Command`, so the shortcut will become `Command + Tab`, which conflicts with the default "Alt + Tab" function systemwide, making the shortcut unusable.

I've changed `Qt::CTRL` into `Qt::META`, which corresponds to `Control` on Mac OS, so the shorcut can work as expected. Same for the shortcut of `previous tab`.

Another change is about homebrew's prefix change on Apple Silicons. On M1 chips, homebrew moved its prefix from `/usr/local/` to `/opt/homebrew`, so the environment variable should be changed in building instructions as well.