### PR TITLE
Translate exif metadata into human readable text

### DIFF
--- a/ImageLounge/src/DkCore/DkMetaData.cpp
+++ b/ImageLounge/src/DkCore/DkMetaData.cpp
@@ -278,7 +278,7 @@ DkMetaDataT::ExifOrientationState DkMetaDataT::checkExifOrientation() const {
 	if (mExifState != loaded && mExifState != dirty)
 		return or_not_set;
 
-	QString orStr = getNativeExifValue("Exif.Image.Orientation");
+	QString orStr = getNativeExifValue("Exif.Image.Orientation", false);
 
 	if (orStr.isEmpty())
 		return or_not_set;
@@ -360,12 +360,12 @@ QSize DkMetaDataT::getImageSize() const {
 		return size;
 
 	bool ok = false;
-	int width = getNativeExifValue("Exif.Photo.PixelXDimension").toInt(&ok);
+	int width = getNativeExifValue("Exif.Photo.PixelXDimension", false).toInt(&ok);
 
 	if (!ok)
 		return size;
 
-	int height = getNativeExifValue("Exif.Photo.PixelYDimension").toInt(&ok);
+	int height = getNativeExifValue("Exif.Photo.PixelYDimension", false).toInt(&ok);
 
 	if (!ok)
 		return size;
@@ -373,7 +373,7 @@ QSize DkMetaDataT::getImageSize() const {
 	return QSize(width, height);
 }
 
-QString DkMetaDataT::getNativeExifValue(const QString& key) const {
+QString DkMetaDataT::getNativeExifValue(const QString& key, bool humanReadable) const {
 
 	QString info;
 
@@ -400,7 +400,13 @@ QString DkMetaDataT::getNativeExifValue(const QString& key) const {
 
 				//qDebug() << "pos count: " << pos->count();
 				//Exiv2::Value::AutoPtr v = pos->getValue();
-				info = exiv2ToQString(pos->toString());
+				if (humanReadable) {
+					std::stringstream ss;
+					ss << *pos;
+					info = exiv2ToQString(ss.str());
+				} else {
+					info = exiv2ToQString(pos->toString());
+				}
 
 			}
 			else {
@@ -601,7 +607,7 @@ void DkMetaDataT::getAllMetaData(QStringList& keys, QStringList& values) const {
 	for (int idx = 0; idx < exifKeys.size(); idx++) {
 
 		QString cKey = exifKeys.at(idx);
-		QString exifValue = getNativeExifValue(cKey);
+		QString exifValue = getNativeExifValue(cKey, true);
 
 		keys.append(cKey);
 		values.append(exifValue);
@@ -1275,7 +1281,7 @@ void DkMetaDataT::printMetaData() const {
 	QStringList exifKeys = getExifKeys();
 
 	for (int idx = 0; idx < exifKeys.size(); idx++)
-		qDebug() << exifKeys.at(idx) << " is " << getNativeExifValue(exifKeys.at(idx));
+		qDebug() << exifKeys.at(idx) << " is " << getNativeExifValue(exifKeys.at(idx), true);
 
 	qDebug() << "IPTC------------------------------------------------------------------";
 
@@ -1707,10 +1713,10 @@ QString DkMetaDataHelper::getGpsCoordinates(QSharedPointer<DkMetaDataT> metaData
 
 		if (metaData->hasMetaData()) {
 			//metaData = DkImageLoader::imgMetaData;
-			Lat = metaData->getNativeExifValue("Exif.GPSInfo.GPSLatitude");
-			LatRef = metaData->getNativeExifValue("Exif.GPSInfo.GPSLatitudeRef");
-			Lon = metaData->getNativeExifValue("Exif.GPSInfo.GPSLongitude");
-			LonRef = metaData->getNativeExifValue("Exif.GPSInfo.GPSLongitudeRef");
+			Lat = metaData->getNativeExifValue("Exif.GPSInfo.GPSLatitude", false);
+			LatRef = metaData->getNativeExifValue("Exif.GPSInfo.GPSLatitudeRef", false);
+			Lon = metaData->getNativeExifValue("Exif.GPSInfo.GPSLongitude", false);
+			LonRef = metaData->getNativeExifValue("Exif.GPSInfo.GPSLongitudeRef", false);
 			//example url
 			//http://maps.google.com/maps?q=N+48°+8'+31.940001''+E16°+15'+35.009998''
 

--- a/ImageLounge/src/DkCore/DkMetaData.h
+++ b/ImageLounge/src/DkCore/DkMetaData.h
@@ -104,7 +104,7 @@ public:
 	QSize getImageSize() const;
 	QString getDescription() const;
 	QVector2D getResolution() const;
-	QString getNativeExifValue(const QString& key) const;
+	QString getNativeExifValue(const QString& key, bool humanReadable) const;
 	QString getXmpValue(const QString& key) const;
 	QString getExifValue(const QString& key) const;
 	QString getIptcValue(const QString& key) const;

--- a/ImageLounge/src/DkGui/DkMetaDataWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkMetaDataWidgets.cpp
@@ -103,7 +103,7 @@ void DkMetaDataModel::addMetaData(QSharedPointer<DkMetaDataT> metaData) {
 
 		QString lastKey = exifKeys.at(idx).split(".").last();
 		QString translatedKey = DkMetaDataHelper::getInstance().translateKey(lastKey);
-		QString exifValue = metaData->getNativeExifValue(exifKeys.at(idx));
+		QString exifValue = metaData->getNativeExifValue(exifKeys.at(idx), true);
 		exifValue = DkMetaDataHelper::getInstance().resolveSpecialValue(metaData, lastKey, exifValue);
 
 		createItem(exifKeys.at(idx), translatedKey, exifValue);
@@ -904,7 +904,7 @@ void DkMetaDataHUD::updateMetaData(const QSharedPointer<DkMetaDataT> metaData) {
 
 		if (mKeyValues.contains(cKey)) {
 			QString lastKey = cKey.split(".").last();
-			QString exifValue = metaData->getNativeExifValue(exifKeys.at(idx));
+			QString exifValue = metaData->getNativeExifValue(exifKeys.at(idx), true);
 			exifValue = DkMetaDataHelper::getInstance().resolveSpecialValue(metaData, lastKey, exifValue);
 
 			mEntryKeyLabels.append(createKeyLabel(cKey));


### PR DESCRIPTION
exiv2 provides a function to translate raw exif values into a human readable form.
This PR extends getNativeExifValue with the argument "humanReadable" to use human readable strings in the Meta Data Info panel.

For example, this translates Exif->Fujifilm->WhiteBalance from **0** to **Auto**.
