### PR TITLE
desktop entry: only accept a single file as an argument

### DIFF
--- a/ImageLounge/xgd-data/org.nomacs.ImageLounge.desktop
+++ b/ImageLounge/xgd-data/org.nomacs.ImageLounge.desktop
@@ -2,7 +2,7 @@
 Name=nomacs
 GenericName=Image Viewer
 Comment=nomacs is a free, open source image viewer.
-Exec=nomacs %F
+Exec=nomacs %f
 Terminal=false
 Icon=org.nomacs.ImageLounge
 Type=Application


### PR DESCRIPTION
nomacs doesn't support multiple files as an argument when launched. So the proper way according to the [desktop entry specification](https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s07.html) is to have `Exec=nomacs %f` instead of `Exec=nomacs %F` in the desktop entry file.

This fixes the following issue:

* Without this patch: selecting multiple files in a file manager and opening them with nomacs only shows the first file, while the others are ignored.
* With this patch: selecting multiple files in a file manager and opening them with nomacs will open one nomacs window for each file.