### PR TITLE
Remove deprecated Qt functions and Add Sorting by File Size

### DIFF
--- a/ImageLounge/src/DkCore/DkActionManager.cpp
+++ b/ImageLounge/src/DkCore/DkActionManager.cpp
@@ -422,6 +422,7 @@ QMenu *DkActionManager::createSortMenu(QWidget *parent)
 {
     mSortMenu = new QMenu(QObject::tr("S&ort"), parent);
     mSortMenu->addAction(mSortActions[menu_sort_filename]);
+    mSortMenu->addAction(mSortActions[menu_sort_file_size]);
     mSortMenu->addAction(mSortActions[menu_sort_date_created]);
     mSortMenu->addAction(mSortActions[menu_sort_date_modified]);
     mSortMenu->addAction(mSortActions[menu_sort_random]);
@@ -1090,6 +1091,12 @@ void DkActionManager::createActions(QWidget *parent)
     mSortActions[menu_sort_filename]->setStatusTip(QObject::tr("Sort by Filename"));
     mSortActions[menu_sort_filename]->setCheckable(true);
     mSortActions[menu_sort_filename]->setChecked(DkSettingsManager::param().global().sortMode == DkSettings::sort_filename);
+
+    mSortActions[menu_sort_file_size] = new QAction(QObject::tr("by File &Size"), parent);
+    mSortActions[menu_sort_file_size]->setObjectName("menu_sort_file_size");
+    mSortActions[menu_sort_file_size]->setStatusTip(QObject::tr("Sort by File Size"));
+    mSortActions[menu_sort_file_size]->setCheckable(true);
+    mSortActions[menu_sort_file_size]->setChecked(DkSettingsManager::param().global().sortMode == DkSettings::sort_file_size);
 
     mSortActions[menu_sort_date_created] = new QAction(QObject::tr("by Date &Created"), parent);
     mSortActions[menu_sort_date_created]->setObjectName("menu_sort_date_created");

--- a/ImageLounge/src/DkCore/DkActionManager.h
+++ b/ImageLounge/src/DkCore/DkActionManager.h
@@ -144,6 +144,7 @@ public:
     enum SortMenuActions {
 
         menu_sort_filename,
+        menu_sort_file_size,
         menu_sort_date_created,
         menu_sort_date_modified,
         menu_sort_random,

--- a/ImageLounge/src/DkCore/DkImageContainer.cpp
+++ b/ImageLounge/src/DkCore/DkImageContainer.cpp
@@ -582,13 +582,11 @@ bool imageContainerLessThan(const DkImageContainer &l, const DkImageContainer &r
             return DkUtils::wCompLogic(l.getFileNameWStr(), r.getFileNameWStr());
         else
             return !DkUtils::wCompLogic(l.getFileNameWStr(), r.getFileNameWStr());
-        break;
 #else
         if (DkSettingsManager::param().global().sortDir == DkSettings::sort_ascending)
             return DkUtils::compFilename(l.fileInfo(), r.fileInfo());
         else
             return DkUtils::compFilenameInv(l.fileInfo(), r.fileInfo());
-        break;
 #endif
 
     case DkSettings::sort_date_created:
@@ -596,7 +594,12 @@ bool imageContainerLessThan(const DkImageContainer &l, const DkImageContainer &r
             return DkUtils::compDateCreated(l.fileInfo(), r.fileInfo());
         else
             return DkUtils::compDateCreatedInv(l.fileInfo(), r.fileInfo());
-        break;
+
+    case DkSettings::sort_file_size:
+        if (DkSettingsManager::param().global().sortDir == DkSettings::sort_ascending)
+            return DkUtils::compFileSize(l.fileInfo(), r.fileInfo());
+        else
+            return DkUtils::compFileSizeInv(l.fileInfo(), r.fileInfo());
 
     case DkSettings::sort_date_modified:
         if (DkSettingsManager::param().global().sortDir == DkSettings::sort_ascending)

--- a/ImageLounge/src/DkCore/DkImageLoader.cpp
+++ b/ImageLounge/src/DkCore/DkImageLoader.cpp
@@ -361,7 +361,7 @@ void DkImageLoader::createImages(const QFileInfoList &files, bool sort)
     qInfo() << "[DkImageLoader]" << mImages.size() << "containers created in" << dt;
 
     if (sort) {
-        qSort(mImages.begin(), mImages.end(), imageContainerLessThanPtr);
+        std::sort(mImages.begin(), mImages.end(), imageContainerLessThanPtr);
         qInfo() << "[DkImageLoader] after sorting: " << dt;
 
         emit updateDirSignal(mImages);
@@ -376,7 +376,7 @@ void DkImageLoader::createImages(const QFileInfoList &files, bool sort)
 
 QVector<QSharedPointer<DkImageContainerT>> DkImageLoader::sortImages(QVector<QSharedPointer<DkImageContainerT>> images) const
 {
-    qSort(images.begin(), images.end(), imageContainerLessThanPtr);
+    std::sort(images.begin(), images.end(), imageContainerLessThanPtr);
     return images;
 }
 
@@ -1694,7 +1694,7 @@ QStringList DkImageLoader::getFoldersRecursive(const QString &dirPath)
 
     subFolders << dirPath;
 
-    qSort(subFolders.begin(), subFolders.end(), DkUtils::compLogicQString);
+    std::sort(subFolders.begin(), subFolders.end(), DkUtils::compLogicQString);
 
     qDebug() << dirPath << "loaded recursively...";
 
@@ -1999,7 +1999,7 @@ QFileInfoList DkImageLoader::getFilteredFileInfoList(const QString &dirPath, QSt
 
 void DkImageLoader::sort()
 {
-    qSort(mImages.begin(), mImages.end(), imageContainerLessThanPtr);
+    std::sort(mImages.begin(), mImages.end(), imageContainerLessThanPtr);
     emit updateDirSignal(mImages);
 }
 

--- a/ImageLounge/src/DkCore/DkMetaData.cpp
+++ b/ImageLounge/src/DkCore/DkMetaData.cpp
@@ -600,7 +600,7 @@ void DkMetaDataT::getFileMetaData(QStringList &fileKeys, QStringList &fileValues
 
     // date group
     fileKeys.append(QObject::tr("Date") + "." + QObject::tr("Created"));
-    fileValues.append(fileInfo.created().toString(Qt::SystemLocaleDate));
+    fileValues.append(fileInfo.birthTime().toString(Qt::SystemLocaleDate));
 
     fileKeys.append(QObject::tr("Date") + "." + QObject::tr("Last Modified"));
     fileValues.append(fileInfo.lastModified().toString(Qt::SystemLocaleDate));

--- a/ImageLounge/src/DkCore/DkSettings.h
+++ b/ImageLounge/src/DkCore/DkSettings.h
@@ -121,6 +121,7 @@ public:
 
     enum sortMode {
         sort_filename,
+        sort_file_size,
         sort_date_created,
         sort_date_modified,
         sort_random,

--- a/ImageLounge/src/DkCore/DkUtils.cpp
+++ b/ImageLounge/src/DkCore/DkUtils.cpp
@@ -298,7 +298,7 @@ QString DkUtils::getLongestNumber(const QString &str, int startIdx)
 
 bool DkUtils::compDateCreated(const QFileInfo &lhf, const QFileInfo &rhf)
 {
-    return lhf.created() < rhf.created();
+    return lhf.birthTime() < rhf.birthTime();
 }
 
 bool DkUtils::compDateCreatedInv(const QFileInfo &lhf, const QFileInfo &rhf)
@@ -715,7 +715,7 @@ QDateTime DkUtils::convertDate(const QString &date, const QFileInfo &file)
 
         dateCreated = QDateTime(dateV, time);
     } else if (file.exists())
-        dateCreated = file.created();
+        dateCreated = file.birthTime();
 
     return dateCreated;
 }
@@ -735,7 +735,7 @@ QString DkUtils::convertDateString(const QString &date, const QFileInfo &file)
             dateConverted += " " + time.toString(Qt::SystemLocaleShortDate);
         }
     } else if (file.exists()) {
-        QDateTime dateCreated = file.created();
+        QDateTime dateCreated = file.birthTime();
         dateConverted += dateCreated.toString(Qt::SystemLocaleShortDate);
     } else
         dateConverted = "unknown date";

--- a/ImageLounge/src/DkCore/DkUtils.cpp
+++ b/ImageLounge/src/DkCore/DkUtils.cpp
@@ -326,6 +326,16 @@ bool DkUtils::compFilenameInv(const QFileInfo &lhf, const QFileInfo &rhf)
     return !compFilename(lhf, rhf);
 }
 
+bool DkUtils::compFileSize(const QFileInfo &lhf, const QFileInfo &rhf)
+{
+    return lhf.size() < rhf.size();
+}
+
+bool DkUtils::compFileSizeInv(const QFileInfo &lhf, const QFileInfo &rhf)
+{
+    return !compFileSize(lhf, rhf);
+}
+
 bool DkUtils::compRandom(const QFileInfo &, const QFileInfo &)
 {
     return qrand() % 2 != 0;

--- a/ImageLounge/src/DkCore/DkUtils.h
+++ b/ImageLounge/src/DkCore/DkUtils.h
@@ -133,6 +133,10 @@ public:
 
     static bool compFilenameInv(const QFileInfo &lhf, const QFileInfo &rhf);
 
+    static bool compFileSize(const QFileInfo &lhf, const QFileInfo &rhf);
+
+    static bool compFileSizeInv(const QFileInfo &lhf, const QFileInfo &rhf);
+
     static bool compDateCreated(const QFileInfo &lhf, const QFileInfo &rhf);
 
     static bool compDateCreatedInv(const QFileInfo &lhf, const QFileInfo &rhf);

--- a/ImageLounge/src/DkGui/DkNoMacs.cpp
+++ b/ImageLounge/src/DkGui/DkNoMacs.cpp
@@ -283,6 +283,7 @@ void DkNoMacs::createActions()
     connect(am.action(DkActionManager::menu_file_exit), SIGNAL(triggered()), this, SLOT(close()));
 
     connect(am.action(DkActionManager::menu_sort_filename), SIGNAL(triggered(bool)), this, SLOT(changeSorting(bool)));
+    connect(am.action(DkActionManager::menu_sort_file_size), SIGNAL(triggered(bool)), this, SLOT(changeSorting(bool)));
     connect(am.action(DkActionManager::menu_sort_date_created), SIGNAL(triggered(bool)), this, SLOT(changeSorting(bool)));
     connect(am.action(DkActionManager::menu_sort_date_modified), SIGNAL(triggered(bool)), this, SLOT(changeSorting(bool)));
     connect(am.action(DkActionManager::menu_sort_random), SIGNAL(triggered(bool)), this, SLOT(changeSorting(bool)));
@@ -1351,6 +1352,8 @@ void DkNoMacs::changeSorting(bool change)
 
         if (senderName == "menu_sort_filename")
             DkSettingsManager::param().global().sortMode = DkSettings::sort_filename;
+        else if (senderName == "menu_sort_file_size")
+            DkSettingsManager::param().global().sortMode = DkSettings::sort_file_size;
         else if (senderName == "menu_sort_date_created")
             DkSettingsManager::param().global().sortMode = DkSettings::sort_date_created;
         else if (senderName == "menu_sort_date_modified")

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -565,7 +565,7 @@ void DkFilePreview::mouseMoveEvent(QMouseEvent *event)
                     //	fileLabel->setText(thumbs.at(selected).getFile().fileName(), -1);
                     QFileInfo fileInfo(thumb->getFilePath());
                     QString toolTipInfo = tr("Name: ") + fileInfo.fileName() + "\n" + tr("Size: ") + DkUtils::readableByte((float)fileInfo.size()) + "\n"
-                        + tr("Created: ") + fileInfo.created().toString(Qt::SystemLocaleDate);
+                        + tr("Created: ") + fileInfo.birthTime().toString(Qt::SystemLocaleDate);
                     setToolTip(toolTipInfo);
                     setStatusTip(fileInfo.fileName());
                 }
@@ -856,7 +856,7 @@ void DkThumbLabel::setThumb(QSharedPointer<DkThumbNailT> thumb)
     connect(thumb.data(), SIGNAL(thumbLoadedSignal()), this, SLOT(updateLabel()));
     QFileInfo fileInfo(thumb->getFilePath());
     QString toolTipInfo = tr("Name: ") + fileInfo.fileName() + "\n" + tr("Size: ") + DkUtils::readableByte((float)fileInfo.size()) + "\n" + tr("Created: ")
-        + fileInfo.created().toString(Qt::SystemLocaleDate);
+        + fileInfo.birthTime().toString(Qt::SystemLocaleDate);
 
     setToolTip(toolTipInfo);
 


### PR DESCRIPTION
Cleaned up a few compiler warnings by removing various deprecated qt function calls.

Also added feature to sort by file size. (Issue #891)