### PR TITLE
Add missing /usr/local/ include search path for macOS XCode build

### DIFF
--- a/ImageLounge/CMakeLists.txt
+++ b/ImageLounge/CMakeLists.txt
@@ -143,6 +143,7 @@ include_directories (
 if (APPLE) # todo: somehow add this to Mac.cmake or MacBuildTarget.cmake
 	execute_process(COMMAND ${QT_QMAKE_EXECUTABLE} -query QT_INSTALL_HEADERS OUTPUT_VARIABLE qt_install_headers)
 	include_directories (BEFORE ${qt_install_headers})
+	include_directories (BEFORE /usr/local/include)
 	SET (NOMACS_SOURCES ${NOMACS_SOURCES} macosx/nomacs.icns)
 endif (APPLE)
 


### PR DESCRIPTION
Hello, I'd been trying to find a precompiled package or nomacs installer for macOS. All I could find is a ports formula for macPorts. Since I didn't find a Homebrew package, I went to Github and found that your repository has macOS compilation instructions. 

I followed them and was able to get CMake configured, save for minor warnings about quazip and HEIF support being disabled. However, when I would execute `make`, I would get the following:

```
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/xxxx/Developer/Downloads/Github/nomacs/originalbuild
[  1%] Automatic MOC for target nomacsCore
[  1%] Built target nomacsCore_autogen
[  2%] Building CXX object CMakeFiles/nomacsCore.dir/src/DkGui/DkControlWidget.cpp.o
In file included from /Users/xxxx/Developer/Downloads/Github/nomacs/ImageLounge/src/DkGui/DkControlWidget.cpp:32:
In file included from /Users/xxxx/Developer/Downloads/Github/nomacs/ImageLounge/src/DkCore/DkMetaData.h:43:
In file included from /usr/local/Cellar/exiv2/0.27.5_1/include/exiv2/exiv2.hpp:61:
/usr/local/Cellar/exiv2/0.27.5_1/include/exiv2/ssh.hpp:27:10: fatal error: 'libssh/libssh.h' file not found
#include <libssh/libssh.h>
         ^~~~~~~~~~~~~~~~~
1 error generated.
make[2]: *** [CMakeFiles/nomacsCore.dir/src/DkGui/DkControlWidget.cpp.o] Error 1
make[1]: *** [CMakeFiles/nomacsCore.dir/all] Error 2
make: *** [all] Error 2
```

I did some digging around, and I found that Homebrew on x86 macOS links all the packages' private ${pkg}/include directories to /usr/local/include. I then peeked at the CMakeLists file to find out how the Qt5 include paths are prepended to the search path, and did the same for /usr/local/include.  (See the code change, its super simple)

That allowed the compilation to find all the dependency headers. It still spat out some QT warnings about deprecated APIs, but it completed with no issue after that, and I got a nomacs binary. 

Please forgive me if I've missed something about the code of conduct or the contribution guide. I figured that the fix is so simple, I wanted to submit it before I moved on to work and other side projects, haha..

 I haven't quite verified that this CI will pass your travis configuration, but I'm looking into it.  I thought Travis could be configured to automatically compile pull requests, but it's been a long time since I've used travis for CI, so, please bare with me. 

Hopefully this will help other macOS users.  😅

------- 
Please check the following before submitting a *pull request*:

- [x] Fork [nomacs](https://github.com/nomacs/nomacs.git) and create your branch from `master`
- [x] Pull requests are only accepted if they pass [travis](https://travis-ci.org/nomacs/nomacs)

also have a look at our [CONTRIBUTING.md](https://github.com/nomacs/nomacs/blob/master/CONTRIBUTING.md)
