### PR TITLE
Fix mouse wheel behavior

### DIFF
--- a/ImageLounge/src/DkGui/DkDialog.cpp
+++ b/ImageLounge/src/DkGui/DkDialog.cpp
@@ -2268,15 +2268,16 @@ void DkPrintPreviewWidget::fitImages()
 
 void DkPrintPreviewWidget::wheelEvent(QWheelEvent *event)
 {
-    if (event->modifiers() != Qt::AltModifier) {
+    auto delta = event->angleDelta().y();
+
+    if ((event->modifiers() != Qt::AltModifier) || (delta == 0)) {
         QPrintPreviewWidget::wheelEvent(event);
         return;
     }
 
-    qreal delta = event->angleDelta().y();
     if (DkSettingsManager::param().display().invertZoom)
         delta *= -1;
-    if (event->angleDelta().y() > 0)
+    if (delta > 0)
         zoomIn();
     else
         zoomOut();

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -626,9 +626,10 @@ void DkFilePreview::mouseReleaseEvent(QMouseEvent *event)
 
 void DkFilePreview::wheelEvent(QWheelEvent *event)
 {
+    auto delta = event->angleDelta().y();
     if (event->modifiers() == Qt::CTRL && windowPosition != pos_dock_hor && windowPosition != pos_dock_ver) {
         int newSize = DkSettingsManager::param().display().thumbSize;
-        newSize += qRound(event->angleDelta().y() * 0.05f);
+        newSize += qRound(delta * 0.05f);
 
         // make sure it is even
         if (qRound(newSize * 0.5f) != newSize * 0.5f)
@@ -643,8 +644,8 @@ void DkFilePreview::wheelEvent(QWheelEvent *event)
             DkSettingsManager::param().display().thumbSize = newSize;
             update();
         }
-    } else {
-        int fc = (event->angleDelta().y() > 0) ? -1 : 1;
+    } else if (delta != 0) {
+        int fc = (delta > 0) ? -1 : 1;
 
         if (!DkSettingsManager::param().resources().waitForLastImg) {
             currentFileIdx += fc;

--- a/ImageLounge/src/DkGui/DkViewPort.cpp
+++ b/ImageLounge/src/DkGui/DkViewPort.cpp
@@ -1262,10 +1262,9 @@ void DkViewPort::wheelEvent(QWheelEvent *event)
         || (DkSettingsManager::param().global().zoomOnWheel
             && (event->modifiers() & mCtrlMod
                 || (DkSettingsManager::param().global().horZoomSkips && event->orientation() == Qt::Horizontal && !(event->modifiers() & mAltMod))))) {
-        if (event->angleDelta().y() < 0)
-            loadNextFileFast();
-        else
-            loadPrevFileFast();
+        auto delta = event->angleDelta().y();
+        if (delta < 0) loadNextFileFast();
+        if (delta > 0) loadPrevFileFast();
     } else
         DkBaseViewPort::wheelEvent(event);
 


### PR DESCRIPTION
angleDelta() can return 0 for some platforms
https://doc.qt.io/qt-5/qwheelevent.html#angleDelta

The patch fix scrolling behaviour considering only positive and negative wheel movement

Tested: Linux Qt5.15

Please check the following before submitting a *pull request*:

- Fork [nomacs](https://github.com/nomacs/nomacs.git) and create your branch from `master`
- Pull requests are only accepted if they pass [travis](https://travis-ci.org/nomacs/nomacs)

also have a look at our [CONTRIBUTING.md](https://github.com/nomacs/nomacs/blob/master/CONTRIBUTING.md)
