### PR TITLE
Middle mouse click to close the program

### DIFF
--- a/ImageLounge/src/DkCore/DkSettings.cpp
+++ b/ImageLounge/src/DkCore/DkSettings.cpp
@@ -365,6 +365,7 @@ void DkSettings::load(QSettings &settings, bool defaults)
 
     app_p.hideAllPanels = settings.value("hideAllPanels", app_p.hideAllPanels).toBool();
     app_p.closeOnEsc = settings.value("closeOnEsc", app_p.closeOnEsc).toBool();
+    app_p.closeOnMiddleMouse = settings.value("closeOnMiddleMouse", app_p.closeOnMiddleMouse).toBool();
     app_p.showRecentFiles = settings.value("showRecentFiles", app_p.showRecentFiles).toBool();
     app_p.useLogFile = settings.value("useLogFile", app_p.useLogFile).toBool();
     app_p.defaultJpgQuality = settings.value("defaultJpgQuality", app_p.defaultJpgQuality).toInt();
@@ -580,6 +581,8 @@ void DkSettings::save(QSettings &settings, bool force)
         settings.setValue("advancedSettings", app_p.advancedSettings);
     if (force || app_p.closeOnEsc != app_d.closeOnEsc)
         settings.setValue("closeOnEsc", app_p.closeOnEsc);
+    if (force || app_p.closeOnMiddleMouse != app_d.closeOnMiddleMouse)
+        settings.setValue("closeOnMiddleMouse", app_p.closeOnMiddleMouse);
     if (force || app_p.showRecentFiles != app_d.showRecentFiles)
         settings.setValue("showRecentFiles", app_p.showRecentFiles);
     if (force || app_p.useLogFile != app_d.useLogFile)
@@ -818,6 +821,7 @@ void DkSettings::setToDefaultSettings()
     app_p.showLogDock = QBitArray(mode_end, false);
     app_p.advancedSettings = false;
     app_p.closeOnEsc = false;
+    app_p.closeOnMiddleMouse = false;
     app_p.hideAllPanels = false;
     app_p.showRecentFiles = true;
     app_p.browseFilters = QStringList();

--- a/ImageLounge/src/DkCore/DkSettings.h
+++ b/ImageLounge/src/DkCore/DkSettings.h
@@ -193,6 +193,7 @@ public:
         bool privateMode;
         bool advancedSettings;
         bool closeOnEsc;
+        bool closeOnMiddleMouse;
         bool hideAllPanels;
 
         int defaultJpgQuality;

--- a/ImageLounge/src/DkGui/DkPreferenceWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkPreferenceWidgets.cpp
@@ -409,6 +409,11 @@ void DkGeneralPreference::createLayout()
     cbCloseOnEsc->setToolTip(tr("Close nomacs if ESC is pressed."));
     cbCloseOnEsc->setChecked(DkSettingsManager::param().app().closeOnEsc);
 
+    QCheckBox *cbCloseOnMiddleMouse = new QCheckBox(tr("Close on Middle Mouse Button"), this);
+    cbCloseOnMiddleMouse->setObjectName("closeOnMiddleMouse");
+    cbCloseOnMiddleMouse->setToolTip(tr("Close nomacs if the Middle Mouse Button is pressed over the image."));
+    cbCloseOnMiddleMouse->setChecked(DkSettingsManager::param().app().closeOnMiddleMouse);
+
     QCheckBox *cbCheckForUpdates = new QCheckBox(tr("Check For Updates"), this);
     cbCheckForUpdates->setObjectName("checkForUpdates");
     cbCheckForUpdates->setToolTip(tr("Check for updates on start-up."));
@@ -426,6 +431,7 @@ void DkGeneralPreference::createLayout()
     generalGroup->addWidget(cbDoubleClickForFullscreen);
     generalGroup->addWidget(cbSwitchModifier);
     generalGroup->addWidget(cbCloseOnEsc);
+    generalGroup->addWidget(cbCloseOnMiddleMouse);
     generalGroup->addWidget(cbCheckForUpdates);
     generalGroup->addWidget(cbShowBgImage);
 
@@ -527,6 +533,12 @@ void DkGeneralPreference::on_closeOnEsc_toggled(bool checked) const
 {
     if (DkSettingsManager::param().app().closeOnEsc != checked)
         DkSettingsManager::param().app().closeOnEsc = checked;
+}
+
+void DkGeneralPreference::on_closeOnMiddleMouse_toggled(bool checked) const
+{
+    if (DkSettingsManager::param().app().closeOnMiddleMouse != checked)
+        DkSettingsManager::param().app().closeOnMiddleMouse = checked;
 }
 
 void DkGeneralPreference::on_zoomOnWheel_toggled(bool checked) const

--- a/ImageLounge/src/DkGui/DkPreferenceWidgets.h
+++ b/ImageLounge/src/DkGui/DkPreferenceWidgets.h
@@ -151,6 +151,7 @@ public slots:
     void on_checkOpenDuplicates_toggled(bool checked) const;
     void on_extendedTabs_toggled(bool checked) const;
     void on_closeOnEsc_toggled(bool checked) const;
+    void on_closeOnMiddleMouse_toggled(bool checked) const;
     void on_zoomOnWheel_toggled(bool checked) const;
     void on_horZoomSkips_toggled(bool checked) const;
     void on_doubleClickForFullscreen_toggled(bool checked) const;

--- a/ImageLounge/src/DkGui/DkViewPort.cpp
+++ b/ImageLounge/src/DkGui/DkViewPort.cpp
@@ -1152,6 +1152,9 @@ void DkViewPort::mousePressEvent(QMouseEvent *event)
         mRepeatZoomTimer->start();
     }
 
+    if (DkSettingsManager::param().app().closeOnMiddleMouse && event->buttons() == Qt::MiddleButton)
+        DkUtils::getMainWindow()->close();
+
     // ok, start panning
     if (mWorldMatrix.m11() > 1 && !imageInside() && event->buttons() == Qt::LeftButton) {
         setCursor(Qt::ClosedHandCursor);


### PR DESCRIPTION
Adds functionality to close nomacs by pressing the middle mouse button in the image viewport.
The feature is disabled by default and has to be activated in the options just like "Close on ESC".