### PR TITLE
Fix build with exiv 0.28

### DIFF
--- a/ImageLounge/src/DkCore/DkMetaData.h
+++ b/ImageLounge/src/DkCore/DkMetaData.h
@@ -155,7 +155,7 @@ public:
     bool setXMPValue(Exiv2::XmpData &xmpData, QString xmpKey, QString xmpValue);
 
 protected:
-    Exiv2::Image::AutoPtr loadSidecar(const QString &filePath) const;
+    std::unique_ptr<Exiv2::Image> loadSidecar(const QString &filePath) const;
 
     enum {
         not_loaded,
@@ -164,7 +164,7 @@ protected:
         dirty,
     };
 
-    Exiv2::Image::AutoPtr mExifImg; // TODO std::unique_ptr<Exiv2::Image> (and all other *::AutoPtr)
+    std::unique_ptr<Exiv2::Image> mExifImg; // TODO std::unique_ptr<Exiv2::Image> (and all other *::AutoPtr)
     QString mFilePath;
     QStringList mQtKeys;
     QStringList mQtValues;


### PR DESCRIPTION
With exiv 0.28 we're getting error such as:

> ImageLounge/src/DkCore/DkMetaData.h:151:23: error: ‘AutoPtr’ in ‘class Exiv2::Image’ does not name a type
>   151 |         Exiv2::Image::AutoPtr loadSidecar(const QString& filePath) const;
>       |                       ^~~~~~~
> ImageLounge/src/DkCore/DkMetaData.h:160:23: error: ‘AutoPtr’ in ‘class Exiv2::Image’ does not name a type
>   160 |         Exiv2::Image::AutoPtr mExifImg;
>       |                       ^~~~~~~

...and so on.

First discovered in Gentoo Linux.

Bug: https://bugs.gentoo.org/906488
