### PR TITLE
Fix language name for zh_tw

### DIFF
--- a/ImageLounge/translations/nomacs_tw_zh.ts
+++ b/ImageLounge/translations/nomacs_tw_zh.ts
@@ -4618,7 +4618,7 @@ Do you want to show them again?</source>
         <location filename="../src/DkCore/DkUtils.cpp" line="368"/>
         <source>English</source>
         <extracomment>this should be the name of the language in which nomacs is translated to</extracomment>
-        <translation>簡體中文</translation>
+        <translation>正體中文</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
Fix language name for zh_tw

As is, the string referrers to zh_cn, which is probably a conversion alias

Please check the following before submitting a *pull request*:

- Fork [nomacs](https://github.com/nomacs/nomacs.git) and create your branch from `master`
- Pull requests are only accepted if they pass [travis](https://travis-ci.org/nomacs/nomacs)

also have a look at our [CONTRIBUTING.md](https://github.com/nomacs/nomacs/blob/master/CONTRIBUTING.md)
