### PR TITLE
Port to Qt5.15 / Qt6

### DIFF
--- a/ImageLounge/CMakeLists.txt
+++ b/ImageLounge/CMakeLists.txt
@@ -96,6 +96,17 @@ endif()
 
 # find Qt
 NMC_FINDQT()
+if(${QT_VERSION_MAJOR} VERSION_GREATER_EQUAL "6")
+    # Still we a using a tons of deprecated features (silence them for a while)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
+
+	set(ENABLE_QUAZIP OFF)
+	message(STATUS "QuaZip disabled - it's not supported for Qt6")
+
+    # We need these to biuld with Qt6
+    set(CMAKE_CXX_STANDARD 17)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
+endif()
 
 if (NOT ENABLE_QT_DEBUG)
 	message (STATUS "disabling qt debug messages")

--- a/ImageLounge/CMakeLists.txt
+++ b/ImageLounge/CMakeLists.txt
@@ -159,10 +159,10 @@ set(NOMACS_RESOURCES src/nomacs.qrc)
 
 file(GLOB NOMACS_TRANSLATIONS "translations/*.ts")
 
-QT5_ADD_RESOURCES(NOMACS_RCC ${NOMACS_RESOURCES})
+qt_add_resources(NOMACS_RCC ${NOMACS_RESOURCES})
 
 if (${ENABLE_TRANSLATIONS})
-	QT5_ADD_TRANSLATION(NOMACS_QM ${NOMACS_TRANSLATIONS})
+	qt_add_translation(NOMACS_QM ${NOMACS_TRANSLATIONS})
 endif()
 
 if(MSVC)
@@ -254,8 +254,7 @@ set(ignoreMe "${CMAKE_EXPORT_COMPILE_COMMANDS}")
 MESSAGE(STATUS "")
 MESSAGE(STATUS "----------------------------------------------------------------------------------")
 MESSAGE(STATUS " ${PROJECT_NAME} - Image Lounge ${NOMACS_VERSION}  <https://nomacs.org>")
-execute_process(COMMAND ${QT_QMAKE_EXECUTABLE} -query QT_VERSION OUTPUT_VARIABLE qt_version)
-message(STATUS " Qt version: ${qt_version}")
+message(STATUS " Qt version: ${Qt${QT_DEFAULT_MAJOR_VERSION}_VERSION}")
 
 
 IF(OpenCV_FOUND)

--- a/ImageLounge/cmake/MacBuildTarget.cmake
+++ b/ImageLounge/cmake/MacBuildTarget.cmake
@@ -66,8 +66,8 @@ add_dependencies(
 	${QUAZIP_DEPENDENCY} 
 	${LIBQPSD_LIBRARY}) 
 
-target_link_libraries(${BINARY_NAME} Qt5::Widgets Qt5::Gui Qt5::Network Qt5::PrintSupport Qt5::Concurrent Qt5::Svg)
-target_link_libraries(${DLL_CORE_NAME} Qt5::Widgets Qt5::Gui Qt5::Network Qt5::PrintSupport Qt5::Concurrent Qt5::Svg)
+target_link_libraries(${BINARY_NAME} Qt::Widgets Qt::Gui Qt::Network Qt::PrintSupport Qt::Concurrent Qt::Svg)
+target_link_libraries(${DLL_CORE_NAME} Qt::Widgets Qt::Gui Qt::Network Qt::PrintSupport Qt::Concurrent Qt::Svg)
 
 # core flags
 set_target_properties(${DLL_CORE_NAME} PROPERTIES ARCHIVE_OUTPUT_DIRECTORY_DEBUG ${CMAKE_CURRENT_BINARY_DIR}/libs)

--- a/ImageLounge/cmake/UnixBuildTarget.cmake
+++ b/ImageLounge/cmake/UnixBuildTarget.cmake
@@ -58,8 +58,8 @@ add_dependencies(
 	${QUAZIP_DEPENDENCY}
 	${LIBQPSD_LIBRARY})
 
-target_link_libraries(${BINARY_NAME} Qt5::Widgets Qt5::Gui Qt5::Network Qt5::PrintSupport Qt5::Concurrent Qt5::Svg)
-target_link_libraries(${DLL_CORE_NAME} Qt5::Widgets Qt5::Gui Qt5::Network Qt5::PrintSupport Qt5::Concurrent Qt5::Svg)
+target_link_libraries(${BINARY_NAME} Qt::Widgets Qt::Gui Qt::Network Qt::PrintSupport Qt::Concurrent Qt::Svg)
+target_link_libraries(${DLL_CORE_NAME} Qt::Widgets Qt::Gui Qt::Network Qt::PrintSupport Qt::Concurrent Qt::Svg)
 
 # core flags
 set_target_properties(${DLL_CORE_NAME} PROPERTIES ARCHIVE_OUTPUT_DIRECTORY_DEBUG ${CMAKE_CURRENT_BINARY_DIR}/libs)

--- a/ImageLounge/cmake/Utils.cmake
+++ b/ImageLounge/cmake/Utils.cmake
@@ -2,8 +2,11 @@
 macro(NMC_FINDQT)
 	set(CMAKE_AUTOMOC ON)
 	set(CMAKE_AUTORCC OFF)
-	# set(CMAKE_INCLUDE_CURRENT_DIR ON)
- 
+
+	if(CMAKE_VERSION VERSION_LESS "3.7.0")
+		set(CMAKE_INCLUDE_CURRENT_DIR ON)
+	endif()
+
 	if (MSVC)
 		if(NOT QT_QMAKE_EXECUTABLE)
 		find_program(QT_QMAKE_EXECUTABLE NAMES "qmake" "qmake-qt5" "qmake.exe")
@@ -16,18 +19,19 @@ macro(NMC_FINDQT)
 		get_filename_component(QT_QMAKE_PATH ${QT_QMAKE_EXECUTABLE} PATH)
 	 endif()
 
-	 set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} ${QT_QMAKE_PATH}\\..\\lib\\cmake\\Qt5)
-	 	 
-	 find_package(Qt5 ${QT5_MIN_VERSION} REQUIRED COMPONENTS Core Widgets Network LinguistTools PrintSupport Concurrent Gui Svg)
+	if (NOT DEFINED QT_VERSION_MAJOR)
+	   find_package(QT NAMES Qt6 Qt5 REQAUIRED COMPONENTS Core)
+	endif()
+
+	find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Widgets Network LinguistTools PrintSupport Concurrent Gui Svg)
+
+	if (NOT Qt${QT_VERSION_MAJOR}_FOUND)
+		message(FATAL_ERROR "Qt Libraries not found!")
+	endif()
 	 
 	if (MSVC)
 		find_package(Qt5 ${QT5_MIN_VERSION} REQUIRED WinExtras)
 	endif()
-	 
-	 if (NOT Qt5_FOUND)
-		message(FATAL_ERROR "Qt5Widgets not found. Check your QT_QMAKE_EXECUTABLE path and set it to the correct location")
-	 endif()
-	 add_definitions(-DQT5)
 	 
 endmacro(NMC_FINDQT)
 

--- a/ImageLounge/cmake/WinBuildTarget.cmake
+++ b/ImageLounge/cmake/WinBuildTarget.cmake
@@ -55,8 +55,8 @@ add_dependencies(
 target_include_directories(${BINARY_NAME} 		PRIVATE ${OpenCV_INCLUDE_DIRS} ${ZLIB_INCLUDE_DIRS})
 target_include_directories(${DLL_CORE_NAME} 	PRIVATE ${OpenCV_INCLUDE_DIRS} ${ZLIB_INCLUDE_DIRS})
 
-target_link_libraries(${BINARY_NAME} Qt5::Widgets Qt5::Gui Qt5::Network Qt5::PrintSupport Qt5::Concurrent Qt5::Svg Qt5::WinExtras)
-target_link_libraries(${DLL_CORE_NAME} Qt5::Widgets Qt5::Gui Qt5::Network Qt5::PrintSupport Qt5::Concurrent Qt5::Svg Qt5::WinExtras)
+target_link_libraries(${BINARY_NAME} Qt::Widgets Qt::Gui Qt::Network Qt::PrintSupport Qt::Concurrent Qt::Svg Qt::WinExtras)
+target_link_libraries(${DLL_CORE_NAME} Qt::Widgets Qt::Gui Qt::Network Qt::PrintSupport Qt::Concurrent Qt::Svg Qt::WinExtras)
 
 # set(_moc ${CMAKE_CURRENT_BINARY_DIR}/GeneratedFiles)
 file(GLOB NOMACS_AUTOMOC "${CMAKE_BINARY_DIR}/*_automoc.cpp ${CMAKE_BINARY_DIR}/moc_.cpp")

--- a/ImageLounge/src/DkCore/DkBasicLoader.cpp
+++ b/ImageLounge/src/DkCore/DkBasicLoader.cpp
@@ -1865,7 +1865,9 @@ void FileDownloader::fileDownloaded(QNetworkReply *pReply)
     // ok save it
     else {
         connect(&mSaveWatcher, SIGNAL(finished()), this, SLOT(saved()), Qt::UniqueConnection);
-        mSaveWatcher.setFuture(QtConcurrent::run(&nmc::FileDownloader::save, mFilePath, mDownloadedData));
+        mSaveWatcher.setFuture(QtConcurrent::run([&] {
+            return save(mFilePath, mDownloadedData);
+        }));
     }
 }
 

--- a/ImageLounge/src/DkCore/DkDependencyResolver.cpp
+++ b/ImageLounge/src/DkCore/DkDependencyResolver.cpp
@@ -32,6 +32,7 @@
 #include <QDebug>
 #include <QFile>
 #include <QFileInfo>
+#include <QRegularExpression>
 #include <limits>
 #pragma warning(pop) // no warnings from includes - end
 
@@ -80,10 +81,10 @@ bool DkDllDependency::findDependencies()
 QStringList DkDllDependency::filteredDependencies() const
 {
     QStringList fd;
-    QRegExp re(filter());
+    QRegularExpression re(filter());
 
     for (const QString &n : mDependencies) {
-        if (re.exactMatch(n)) {
+        if (re.match(n).hasMatch()) {
             fd << n;
         }
     }

--- a/ImageLounge/src/DkCore/DkImageContainer.cpp
+++ b/ImageLounge/src/DkCore/DkImageContainer.cpp
@@ -762,8 +762,9 @@ void DkImageContainerT::fetchFile()
 
     mFetchingBuffer = true; // saves the threaded call
     connect(&mBufferWatcher, SIGNAL(finished()), this, SLOT(bufferLoaded()), Qt::UniqueConnection);
-
-    mBufferWatcher.setFuture(QtConcurrent::run(this, &nmc::DkImageContainerT::loadFileToBuffer, filePath()));
+    mBufferWatcher.setFuture(QtConcurrent::run([&] {
+        return loadFileToBuffer(filePath());
+    }));
 }
 
 void DkImageContainerT::bufferLoaded()
@@ -802,7 +803,9 @@ void DkImageContainerT::fetchImage()
 
     connect(&mImageWatcher, SIGNAL(finished()), this, SLOT(imageLoaded()), Qt::UniqueConnection);
 
-    mImageWatcher.setFuture(QtConcurrent::run(this, &nmc::DkImageContainerT::loadImageIntern, filePath(), mLoader, mFileBuffer));
+    mImageWatcher.setFuture(QtConcurrent::run([&] {
+        return loadImageIntern(filePath(), mLoader, mFileBuffer);
+    }));
 }
 
 void DkImageContainerT::imageLoaded()
@@ -951,7 +954,9 @@ void DkImageContainerT::saveMetaDataThreaded(const QString &filePath)
         return;
 
     mFileUpdateTimer.stop();
-    QFuture<void> future = QtConcurrent::run(this, &nmc::DkImageContainerT::saveMetaDataIntern, filePath, getLoader(), getFileBuffer());
+    QFuture<void> future = QtConcurrent::run([&, filePath] {
+        return saveMetaDataIntern(filePath, getLoader(), getFileBuffer());
+    });
 }
 
 void DkImageContainerT::saveMetaDataThreaded()
@@ -991,7 +996,9 @@ bool DkImageContainerT::saveImageThreaded(const QString &filePath, const QImage 
     mFileUpdateTimer.stop();
     connect(&mSaveImageWatcher, SIGNAL(finished()), this, SLOT(savingFinished()), Qt::UniqueConnection);
 
-    mSaveImageWatcher.setFuture(QtConcurrent::run(this, &nmc::DkImageContainerT::saveImageIntern, filePath, mLoader, saveImg, compression));
+    mSaveImageWatcher.setFuture(QtConcurrent::run([&, filePath, saveImg, compression] {
+        return saveImageIntern(filePath, mLoader, saveImg, compression);
+    }));
 
     return true;
 }

--- a/ImageLounge/src/DkCore/DkImageLoader.cpp
+++ b/ImageLounge/src/DkCore/DkImageLoader.cpp
@@ -1547,12 +1547,12 @@ bool DkImageLoader::restoreFile(const QString &filePath)
     QFileInfo fInfo(filePath);
     QStringList files = fInfo.dir().entryList();
     QString fileName = fInfo.fileName();
-    QRegExp filePattern(fileName + "[0-9]+");
+    QRegularExpression filePattern(fileName + "[0-9]+");
     QString backupFileName;
 
     // if exif crashed it saved a backup file with the format: filename.png1232
     for (int idx = 0; idx < files.size(); idx++) {
-        if (filePattern.exactMatch(files[idx])) {
+        if (filePattern.match(files[idx]).hasMatch()) {
             backupFileName = files[idx];
             break;
         }

--- a/ImageLounge/src/DkCore/DkImageLoader.cpp
+++ b/ImageLounge/src/DkCore/DkImageLoader.cpp
@@ -315,7 +315,9 @@ void DkImageLoader::sortImagesThreaded(QVector<QSharedPointer<DkImageContainerT>
 
     mSortingIsDirty = false;
     mSortingImages = true;
-    mCreateImageWatcher.setFuture(QtConcurrent::run(this, &nmc::DkImageLoader::sortImages, images));
+    mCreateImageWatcher.setFuture(QtConcurrent::run([&, images] {
+        return sortImages(images);
+    }));
 
     qDebug() << "sorting images threaded...";
 }

--- a/ImageLounge/src/DkCore/DkImageStorage.cpp
+++ b/ImageLounge/src/DkCore/DkImageStorage.cpp
@@ -1535,7 +1535,9 @@ void DkImageStorage::compute()
 
     mComputeState = l_computing;
 
-    mFutureWatcher.setFuture(QtConcurrent::run(this, &nmc::DkImageStorage::computeIntern, mImg, mSize));
+    mFutureWatcher.setFuture(QtConcurrent::run([&] {
+        return computeIntern(mImg, mSize);
+    }));
 }
 
 QImage DkImageStorage::computeIntern(const QImage &src, const QSize &size)

--- a/ImageLounge/src/DkCore/DkMessageBox.cpp
+++ b/ImageLounge/src/DkCore/DkMessageBox.cpp
@@ -32,7 +32,6 @@
 #include <QApplication>
 #include <QCheckBox>
 #include <QDebug>
-#include <QDesktopWidget>
 #include <QDialogButtonBox>
 #include <QGridLayout>
 #include <QGuiApplication>

--- a/ImageLounge/src/DkCore/DkQt5Compat.h
+++ b/ImageLounge/src/DkCore/DkQt5Compat.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <QtGlobal>
+
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#define DkEnterEvent QEvent
+#else
+#define DkEnterEvent QEnterEvent
+#endif

--- a/ImageLounge/src/DkCore/DkThumbs.cpp
+++ b/ImageLounge/src/DkCore/DkThumbs.cpp
@@ -88,7 +88,7 @@ void DkThumbNail::compute(int forceLoad)
  * @return QImage the loaded image. Null if no image
  * could be loaded at all.
  **/
-QImage DkThumbNail::computeIntern(const QString &filePath, const QSharedPointer<QByteArray> ba, int forceLoad, int maxThumbSize)
+QImage DkThumbNail::computeIntern(const QString &filePath, QSharedPointer<QByteArray> ba, int forceLoad, int maxThumbSize)
 {
     DkTimer dt;
     // qDebug() << "[thumb] file: " << filePath;
@@ -197,7 +197,7 @@ QImage DkThumbNail::computeIntern(const QString &filePath, const QSharedPointer<
             if (!ba || ba->isEmpty())
                 metaData.saveMetaData(lFilePath);
             else
-                metaData.saveMetaData(lFilePath, ba);
+                metaData.saveMetaData(ba);
 
             qDebug() << "[thumb] saved to exif data";
         } catch (...) {

--- a/ImageLounge/src/DkCore/DkThumbs.cpp
+++ b/ImageLounge/src/DkCore/DkThumbs.cpp
@@ -312,12 +312,9 @@ bool DkThumbNailT::fetchThumb(int forceLoad /* = false */, QSharedPointer<QByteA
     connect(&mThumbWatcher, SIGNAL(finished()), this, SLOT(thumbLoaded()), Qt::UniqueConnection);
 
     mThumbWatcher.setFuture(QtConcurrent::run(DkThumbsThreadPool::pool(), // load thumbnails on their dedicated pool
-                                              this,
-                                              &nmc::DkThumbNailT::computeCall,
-                                              mFile,
-                                              ba,
-                                              forceLoad,
-                                              mMaxThumbSize));
+                                              [&, ba] {
+                                                  return computeCall(mFile, ba, mForceLoad, mMaxThumbSize);
+                                              }));
 
     return true;
 }

--- a/ImageLounge/src/DkCore/DkTimer.h
+++ b/ImageLounge/src/DkCore/DkTimer.h
@@ -29,8 +29,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <time.h>
 
 #pragma warning(push, 0) // no warnings from includes - begin
+#include <QElapsedTimer>
 #include <QObject>
-#include <QTime>
 #pragma warning(pop) // no warnings from includes - end
 
 #ifndef DllCoreExport
@@ -74,7 +74,7 @@ public:
     void start();
 
 protected:
-    QTime mTimer;
+    QElapsedTimer mTimer;
 };
 
 }

--- a/ImageLounge/src/DkCore/DkUtils.cpp
+++ b/ImageLounge/src/DkCore/DkUtils.cpp
@@ -991,11 +991,11 @@ DkFileNameConverter::DkFileNameConverter(const QString &fileName, const QString 
 QString DkFileNameConverter::getConvertedFileName()
 {
     QString newFileName = mPattern;
-    QRegExp rx("<.*>");
-    rx.setMinimal(true);
+    QRegularExpression rx("<.*>");
+    QRegularExpressionMatch match = rx.match(newFileName);
 
-    while (rx.indexIn(newFileName) != -1) {
-        QString tag = rx.cap();
+    while (match.hasMatch()) {
+        QString tag = match.captured();
         QString res = "";
 
         if (tag.contains("<c:"))
@@ -1007,6 +1007,7 @@ QString DkFileNameConverter::getConvertedFileName()
 
         // replace() replaces all matches - so if two tags are the very same, we save a little computing
         newFileName = newFileName.replace(tag, res);
+        match = rx.match(newFileName);
     }
 
     return newFileName;

--- a/ImageLounge/src/DkCore/DkUtils.cpp
+++ b/ImageLounge/src/DkCore/DkUtils.cpp
@@ -535,8 +535,9 @@ bool DkUtils::exists(const QFileInfo &file, int waitMs)
         // - create a dedicated pool for exists
         // - create a dedicated pool for image loading
         DkThumbsThreadPool::pool(), // hook it to the thumbs pool
-        &DkUtils::checkFile,
-        file);
+        [file] {
+            return DkUtils::checkFile(file);
+        });
 
     for (int idx = 0; idx < waitMs; idx++) {
         if (future.isFinished())

--- a/ImageLounge/src/DkCore/DkUtils.h
+++ b/ImageLounge/src/DkCore/DkUtils.h
@@ -33,7 +33,7 @@
 #pragma warning(push, 0) // no warnings from includes - begin
 #include <QDebug>
 #include <QFileInfo>
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QVector>
 
 #include <QSharedMemory>

--- a/ImageLounge/src/DkGui/DkCentralWidget.cpp
+++ b/ImageLounge/src/DkGui/DkCentralWidget.cpp
@@ -50,7 +50,6 @@
 #pragma warning(push, 0) // no warnings from includes - begin
 #include <QApplication>
 #include <QClipboard>
-#include <QDesktopWidget>
 #include <QDragEnterEvent>
 #include <QFileDialog>
 #include <QIcon>

--- a/ImageLounge/src/DkGui/DkCentralWidget.cpp
+++ b/ImageLounge/src/DkGui/DkCentralWidget.cpp
@@ -505,7 +505,7 @@ void DkCentralWidget::updateLoader(QSharedPointer<DkImageLoader> loader) const
 void DkCentralWidget::paintEvent(QPaintEvent *)
 {
     QStyleOption opt;
-    opt.init(this);
+    opt.initFrom(this);
     QPainter p(this);
     style()->drawPrimitive(QStyle::PE_Widget, &opt, &p, this);
 }

--- a/ImageLounge/src/DkGui/DkDialog.cpp
+++ b/ImageLounge/src/DkGui/DkDialog.cpp
@@ -3262,7 +3262,7 @@ int DkMosaicDialog::computeMosaic(const QString &filter, const QString &suffix, 
                 // update cc
                 ccPtr[maxIdx.x] = (float)maxVal;
 
-                mFilesUsed[maxIdx.y * numPatchesH + maxIdx.x] = thumb.getFilePath(); // replaces additionally the old file
+                mFilesUsed[maxIdx.y * numPatchesH + maxIdx.x] = QFileInfo(thumb.getFilePath()); // replaces additionally the old file
                 iDidNothing = 0;
             } else
                 iDidNothing++;

--- a/ImageLounge/src/DkGui/DkDialog.cpp
+++ b/ImageLounge/src/DkGui/DkDialog.cpp
@@ -53,7 +53,6 @@
 #include <QComboBox>
 #include <QCompleter>
 #include <QDesktopServices>
-#include <QDesktopWidget>
 #include <QDialogButtonBox>
 #include <QFileDialog>
 #include <QFileInfo>

--- a/ImageLounge/src/DkGui/DkDialog.cpp
+++ b/ImageLounge/src/DkGui/DkDialog.cpp
@@ -83,6 +83,7 @@
 #include <QSpinBox>
 #include <QSplashScreen>
 #include <QStandardItemModel>
+#include <QStandardPaths>
 #include <QStringListModel>
 #include <QTableView>
 #include <QTextEdit>

--- a/ImageLounge/src/DkGui/DkDialog.cpp
+++ b/ImageLounge/src/DkGui/DkDialog.cpp
@@ -106,6 +106,10 @@
 
 #pragma warning(pop) // no warnings from includes - end
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#define QPageLayout QPrinter
+#endif
+
 namespace nmc
 {
 
@@ -2195,7 +2199,7 @@ void DkPrintPreviewDialog::pageSetup()
 
     if (pageSetup.exec() == QDialog::Accepted) {
         // update possible orientation changes
-        if (mPreview->orientation() == QPrinter::Portrait) {
+        if (mPreview->orientation() == QPageLayout::Portrait) {
             mPreview->setPortraitOrientation();
         } else {
             mPreview->setLandscapeOrientation();

--- a/ImageLounge/src/DkGui/DkDialog.h
+++ b/ImageLounge/src/DkGui/DkDialog.h
@@ -368,7 +368,7 @@ protected:
     void loadSettings();
     void saveSettings();
     QImage resizeImg(QImage img, bool silent = true);
-    void resizeEvent(QResizeEvent *re);
+    void resizeEvent(QResizeEvent *re) override;
 };
 
 class DkShortcutDelegate : public QItemDelegate

--- a/ImageLounge/src/DkGui/DkMenu.cpp
+++ b/ImageLounge/src/DkGui/DkMenu.cpp
@@ -128,7 +128,7 @@ void DkMenuBar::setTimeToShow(int timeToShow)
     mTimeToShow = timeToShow;
 }
 
-void DkMenuBar::enterEvent(QEvent *event)
+void DkMenuBar::enterEvent(DkEnterEvent *event)
 {
     if (mTimeToShow == -1)
         return;

--- a/ImageLounge/src/DkGui/DkMenu.h
+++ b/ImageLounge/src/DkGui/DkMenu.h
@@ -27,6 +27,8 @@
 
 #pragma once
 
+#include "DkQt5Compat.h"
+
 #pragma warning(push, 0) // no warnings from includes - begin
 #include <QMenuBar>
 #include <QPointer>
@@ -104,7 +106,7 @@ public slots:
     void hideMenu();
 
 protected:
-    void enterEvent(QEvent *event) override;
+    void enterEvent(DkEnterEvent *event) override;
     void leaveEvent(QEvent *event) override;
 
 private:

--- a/ImageLounge/src/DkGui/DkPreferenceWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkPreferenceWidgets.cpp
@@ -1495,8 +1495,10 @@ void DkAdvancedPreference::on_useNative_toggled(bool checked) const
 void DkAdvancedPreference::on_logFolder_clicked() const
 {
     // TODO: add linux/mac os
+#ifdef _WIN32
     QString logPath = QDir::toNativeSeparators(DkUtils::getLogFilePath());
     QProcess::startDetached(QString("explorer /select, \"%1\"").arg(logPath));
+#endif
 }
 
 void DkAdvancedPreference::on_numThreads_valueChanged(int val) const

--- a/ImageLounge/src/DkGui/DkSettingsWidget.cpp
+++ b/ImageLounge/src/DkGui/DkSettingsWidget.cpp
@@ -73,9 +73,7 @@ void DkSettingsWidget::addSettingsGroup(const DkSettingsGroup &group)
 void DkSettingsWidget::clear()
 {
     mProxyModel->invalidate();
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     mSettingsModel->clear();
-#endif
 }
 
 void DkSettingsWidget::changeSetting(QSettings &settings, const QString &key, const QVariant &value, const QStringList &groups)

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -2158,7 +2158,7 @@ void DkRecentDirWidget::mousePressEvent(QMouseEvent *event)
     DkFadeWidget::mousePressEvent(event);
 }
 
-void DkRecentDirWidget::enterEvent(QEvent *event)
+void DkRecentDirWidget::enterEvent(DkEnterEvent *event)
 {
     for (auto b : mButtons)
         b->show();

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.h
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.h
@@ -27,6 +27,8 @@
 
 #pragma once
 
+#include "DkQt5Compat.h"
+
 #pragma warning(push, 0) // no warnings from includes - begin
 #include <QDrag>
 #include <QFileInfo>
@@ -447,7 +449,7 @@ protected:
 
     void createLayout();
     void mousePressEvent(QMouseEvent *event) override;
-    void enterEvent(QEvent *event) override;
+    void enterEvent(DkEnterEvent *event) override;
     void leaveEvent(QEvent *event) override;
 };
 

--- a/ImageLounge/src/DkGui/DkViewPort.cpp
+++ b/ImageLounge/src/DkGui/DkViewPort.cpp
@@ -870,7 +870,9 @@ void DkViewPort::applyManipulator()
     } else
         img = getImage();
 
-    mManipulatorWatcher.setFuture(QtConcurrent::run(mpl.data(), &nmc::DkBaseManipulator::apply, img));
+    mManipulatorWatcher.setFuture(QtConcurrent::run([mpl, img] {
+        return mpl.data()->apply(img);
+    }));
 
     mActiveManipulator = mpl;
 

--- a/ImageLounge/src/DkGui/DkViewPort.cpp
+++ b/ImageLounge/src/DkGui/DkViewPort.cpp
@@ -1259,11 +1259,16 @@ void DkViewPort::mouseMoveEvent(QMouseEvent *event)
 
 void DkViewPort::wheelEvent(QWheelEvent *event)
 {
-    if ((!DkSettingsManager::param().global().zoomOnWheel && event->modifiers() != mCtrlMod)
-        || (DkSettingsManager::param().global().zoomOnWheel
-            && (event->modifiers() & mCtrlMod
-                || (DkSettingsManager::param().global().horZoomSkips && event->orientation() == Qt::Horizontal && !(event->modifiers() & mAltMod))))) {
-        auto delta = event->angleDelta().y();
+    auto ctrlMod = DkSettingsManager::param().global().ctrlMod;
+    if ((!DkSettingsManager::param().global().zoomOnWheel && event->modifiers() != ctrlMod)
+        || (DkSettingsManager::param().global().zoomOnWheel && (event->modifiers() & ctrlMod))) {
+        auto delta = 0;
+
+        if (DkSettingsManager::param().global().horZoomSkips) {
+            delta = event->angleDelta().x();
+        } else {
+            delta = event->angleDelta().y();
+        }
         if (delta < 0)
             loadNextFileFast();
         if (delta > 0)

--- a/ImageLounge/src/DkGui/DkViewPort.cpp
+++ b/ImageLounge/src/DkGui/DkViewPort.cpp
@@ -48,7 +48,6 @@
 #include <QAction>
 #include <QApplication>
 #include <QClipboard>
-#include <QDesktopWidget>
 #include <QDrag>
 #include <QDragLeaveEvent>
 #include <QInputDialog>

--- a/ImageLounge/src/DkGui/DkWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkWidgets.cpp
@@ -1079,7 +1079,7 @@ void DkButton::focusOutEvent(QFocusEvent *)
     mouseOver = false;
 }
 
-void DkButton::enterEvent(QEvent *)
+void DkButton::enterEvent(DkEnterEvent *)
 {
     mouseOver = true;
 }
@@ -1604,7 +1604,7 @@ void DkTransformRect::mouseReleaseEvent(QMouseEvent *event)
     QWidget::mouseReleaseEvent(event);
 }
 
-void DkTransformRect::enterEvent(QEvent *)
+void DkTransformRect::enterEvent(DkEnterEvent *)
 {
     if (rect)
         setCursor(rect->cpCursor(parentIdx));

--- a/ImageLounge/src/DkGui/DkWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkWidgets.cpp
@@ -353,6 +353,9 @@ DkFileSystemModel::DkFileSystemModel(QObject *parent /* = 0 */)
     setRootPath(QDir::rootPath());
     setNameFilters(DkSettingsManager::param().app().fileFilters);
     setReadOnly(false);
+
+    mIconProvider = new QFileIconProvider();
+    setIconProvider(mIconProvider);
 }
 
 // DkSortFileProxyModel --------------------------------------------------------------------

--- a/ImageLounge/src/DkGui/DkWidgets.h
+++ b/ImageLounge/src/DkGui/DkWidgets.h
@@ -95,7 +95,7 @@ protected:
     void paintEvent(QPaintEvent *event) override;
     void focusInEvent(QFocusEvent *event) override;
     void focusOutEvent(QFocusEvent *event) override;
-    void enterEvent(QEvent *event);
+    void enterEvent(QEvent *event) override;
     void leaveEvent(QEvent *event) override;
     QPixmap createSelectedEffect(QPixmap *pm);
 };
@@ -562,7 +562,7 @@ protected:
     void mousePressEvent(QMouseEvent *event) override;
     void mouseMoveEvent(QMouseEvent *event) override;
     void mouseReleaseEvent(QMouseEvent *event) override;
-    void enterEvent(QEvent *event);
+    void enterEvent(QEvent *event) override;
     void init();
 
     DkRotatingRect *rect;

--- a/ImageLounge/src/DkGui/DkWidgets.h
+++ b/ImageLounge/src/DkGui/DkWidgets.h
@@ -27,6 +27,8 @@
 
 #pragma once
 
+#include "DkQt5Compat.h"
+
 #pragma warning(push, 0) // no warnings from includes - begin
 #include <QDockWidget>
 #include <QFileSystemModel>
@@ -95,7 +97,7 @@ protected:
     void paintEvent(QPaintEvent *event) override;
     void focusInEvent(QFocusEvent *event) override;
     void focusOutEvent(QFocusEvent *event) override;
-    void enterEvent(QEvent *event) override;
+    void enterEvent(DkEnterEvent *event) override;
     void leaveEvent(QEvent *event) override;
     QPixmap createSelectedEffect(QPixmap *pm);
 };
@@ -562,7 +564,7 @@ protected:
     void mousePressEvent(QMouseEvent *event) override;
     void mouseMoveEvent(QMouseEvent *event) override;
     void mouseReleaseEvent(QMouseEvent *event) override;
-    void enterEvent(QEvent *event) override;
+    void enterEvent(DkEnterEvent *event) override;
     void init();
 
     DkRotatingRect *rect;

--- a/ImageLounge/src/DkGui/DkWidgets.h
+++ b/ImageLounge/src/DkGui/DkWidgets.h
@@ -31,6 +31,7 @@
 
 #pragma warning(push, 0) // no warnings from includes - begin
 #include <QDockWidget>
+#include <QFileIconProvider>
 #include <QFileSystemModel>
 #include <QFutureWatcher>
 #include <QLineEdit>
@@ -381,6 +382,9 @@ class DkFileSystemModel : public QFileSystemModel
 
 public:
     DkFileSystemModel(QObject *parent = 0);
+
+protected:
+    QFileIconProvider *mIconProvider = nullptr;
 };
 
 class DkSortFileProxyModel : public QSortFilterProxyModel

--- a/ImageLounge/src/main.cpp
+++ b/ImageLounge/src/main.cpp
@@ -28,12 +28,12 @@
 #ifdef Q_OS_WIN
 #include "shlwapi.h"
 #pragma comment(lib, "shlwapi.lib")
-#endif
 
 #if defined(_MSC_BUILD) && !defined(DK_INSTALL) // only final release will be compiled without a CMD
 #pragma comment(linker, "/SUBSYSTEM:CONSOLE")
 #else
 #pragma comment(linker, "/SUBSYSTEM:WINDOWS")
+#endif
 #endif
 
 #ifdef QT_NO_DEBUG_OUTPUT


### PR DESCRIPTION
This a number of commits to:
1) Fix compile warning for Qt5.15
2) Make code compliant with both Qt 5.15 and Qt6 (last 6 commits)

The build script is now looking for any available Qt (with preference to Qt6)

To explicitly enable Qt5 build define:
    QT_VERSION_MAJOR=5