### PR TITLE
Add:On Linux system support open image in the Trash

### DIFF
--- a/ImageLounge/src/DkCore/DkUtils.cpp
+++ b/ImageLounge/src/DkCore/DkUtils.cpp
@@ -62,7 +62,6 @@
 #include <QUrl>
 #include <QtConcurrentRun>
 #include <qmath.h>
-#include <QMessageBox>
 
 #include <QSystemSemaphore>
 #pragma warning(pop) // no warnings from includes - end

--- a/ImageLounge/src/DkCore/DkUtils.cpp
+++ b/ImageLounge/src/DkCore/DkUtils.cpp
@@ -871,70 +871,68 @@ bool DkUtils::moveToTrash(const QString &filePath)
     return file.moveToTrash();
 }
 
-QString DkUtils::openFromTrash(const QString &filePath) {
-    QString realPath=filePath;
+QString DkUtils::openFromTrash(const QString &filePath)
+{
+    QString realPath = filePath;
     if (!filePath.isEmpty()) {
-
 #if defined Q_OS_LINUX and not defined(Q_OS_OPENBSD)
         if (realPath.startsWith("trash:///")) {
             // for gnome or other desktop enverment, not include ked.
             // some file name contains \, so , don't convert url in the first.
             // Gnome parmars is trash:///%5Cmnt%5C843c89b8-7899-44bb-ae9e-0efbecb5c66a%5C.Trash-1000%5Cfiles%5Cdad%255Cdad/%5C%5C%5CN-US7989247628_UHD.jpg
-            QString tempFilePath=realPath.remove(0,QString("trash:///").length());
-            int i=tempFilePath.lastIndexOf("/");
-            if(i<=0){
+            QString tempFilePath = realPath.remove(0, QString("trash:///").length());
+            int i = tempFilePath.lastIndexOf("/");
+            if (i <= 0) {
                 // for file in trash but no in folder;
-                QString path= QUrl::fromPercentEncoding(tempFilePath.toUtf8()).replace("\\",QDir::separator());
-                QString lurl = QUrl::fromPercentEncoding( path.toUtf8());
+                QString path = QUrl::fromPercentEncoding(tempFilePath.toUtf8()).replace("\\", QDir::separator());
+                QString lurl = QUrl::fromPercentEncoding(path.toUtf8());
                 // this can't work
-                realPath=QDir::toNativeSeparators(lurl);
-            } else{
+                realPath = QDir::toNativeSeparators(lurl);
+            } else {
                 QFileInfo fileInfo(tempFilePath); // Create QFileInfo
                 QString fileName = fileInfo.fileName(); // get file name
-                QString path= QUrl::fromPercentEncoding(fileInfo.path().toUtf8());
-                if(path.startsWith("\\")){
-                  path.replace("\\",QDir::separator());
+                QString path = QUrl::fromPercentEncoding(fileInfo.path().toUtf8());
+                if (path.startsWith("\\")) {
+                    path.replace("\\", QDir::separator());
                 }
-                QString lurl = QUrl::fromPercentEncoding( (path+"/"+ fileName).toUtf8());
+                QString lurl = QUrl::fromPercentEncoding((path + "/" + fileName).toUtf8());
                 // this can't work
-                realPath=QDir::toNativeSeparators(lurl);
+                realPath = QDir::toNativeSeparators(lurl);
             }
             if (!(realPath.startsWith("/"))) {
                 realPath = QDir::homePath() + "/.local/share/Trash/files/" + realPath;
             }
 
-        } else if (QFileInfo(realPath).isSymLink()){
-
-			// for kde Plasma need use kde component, and need add KDE to Categories
-			// this method not kde Plasma method
+        } else if (QFileInfo(realPath).isSymLink()) {
+            // for kde Plasma need use kde component, and need add KDE to Categories
+            // this method not kde Plasma method
             // /run/user/1000/kio-fuse-KXucgr/trash/home/user/.local/share/Trash/files/UHD.jpg
-            QString splitWord="trash";
+            QString splitWord = "trash";
             QString path = QFileInfo(realPath).symLinkTarget();
-			if(!QFile(path).exists()){
-                int m= path.indexOf(splitWord)+splitWord.length();
-                QString tempPath=path.mid(m);
-				if(QFile(realPath).exists()){
-                    realPath=tempPath;
-				}
-			}
-        } else if(!QFile(realPath).exists()){
-
-			// for kde Plasma when delete folder
-			// this method not kde Plasma method
+            if (!QFile(path).exists()) {
+                int m = path.indexOf(splitWord) + splitWord.length();
+                QString tempPath = path.mid(m);
+                if (QFile(realPath).exists()) {
+                    realPath = tempPath;
+                }
+            }
+        } else if (!QFile(realPath).exists()) {
+            // for kde Plasma when delete folder
+            // this method not kde Plasma method
             // /run/user/1000/kio-fuse-KXucgr/trash/0-2\2/1\1.jpg
-            QString splitWord="trash";
-            int m= filePath.indexOf(splitWord)+splitWord.length();
-            QString trashParent=filePath.mid(0,m);
-            QString tempPath=filePath.mid(m+1);
-            QString symFilePath=tempPath.mid(0,tempPath.indexOf("/"));
+            QString splitWord = "trash";
+            int m = filePath.indexOf(splitWord) + splitWord.length();
+            QString trashParent = filePath.mid(0, m);
+            QString tempPath = filePath.mid(m + 1);
+            QString symFilePath = tempPath.mid(0, tempPath.indexOf("/"));
             // get the symlink
-            QString path = QFileInfo(trashParent+"/"+symFilePath).symLinkTarget().mid(m)+tempPath.mid(tempPath.indexOf("/"));
-            if(QFile(path).exists()){
-                realPath=path;
-			}
-		}
+            QString path = QFileInfo(trashParent + "/" + symFilePath).symLinkTarget().mid(m) + tempPath.mid(tempPath.indexOf("/"));
+            if (QFile(path).exists()) {
+                realPath = path;
+            }
+        }
 #endif
-	}
+    }
     return realPath;
 }
 

--- a/ImageLounge/src/DkCore/DkUtils.h
+++ b/ImageLounge/src/DkCore/DkUtils.h
@@ -198,6 +198,7 @@ public:
     static QString readableByte(float bytes);
     static QStringList filterStringList(const QString &query, const QStringList &list);
     static bool moveToTrash(const QString &filePath);
+    static QString openFromTrash(const QString &filePath);
     static QList<QUrl> findUrlsInTextNewline(QString text);
 
 #ifdef WITH_OPENCV

--- a/ImageLounge/src/main.cpp
+++ b/ImageLounge/src/main.cpp
@@ -272,6 +272,9 @@ int main(int argc, char *argv[])
         QString filePath = parser.positionalArguments()[0].trimmed();
 
         if (!filePath.isEmpty()) {
+#if defined Q_OS_LINUX and not defined(Q_OS_OPENBSD)
+            filePath=nmc::DkUtils::openFromTrash(filePath);
+#endif
             w->loadFile(QFileInfo(filePath).absoluteFilePath()); // update folder + be silent
             loading = true;
         }

--- a/ImageLounge/xgd-data/org.nomacs.ImageLounge.desktop
+++ b/ImageLounge/xgd-data/org.nomacs.ImageLounge.desktop
@@ -2,7 +2,7 @@
 Name=nomacs
 GenericName=Image Viewer
 Comment=nomacs is a free, open source image viewer.
-Exec=nomacs %f
+Exec=nomacs %u
 Terminal=false
 Icon=org.nomacs.ImageLounge
 Type=Application


### PR DESCRIPTION
Add a feature on Linux system to support open image in the Trash. Support KDE, gnome, lxde-gtk3, xfce4. 

Please check the following before submitting a *pull request*:

- Fork [nomacs](https://github.com/nomacs/nomacs.git) and create your branch from `master` [checked]
- Pull requests are only accepted if they pass [travis](https://travis-ci.org/nomacs/nomacs)  [checked]

also have a look at our [CONTRIBUTING.md](https://github.com/nomacs/nomacs/blob/master/CONTRIBUTING.md)
