### PR TITLE
Explicitly include <iostream>

### DIFF
--- a/ImageLounge/src/DkCore/DkMath.h
+++ b/ImageLounge/src/DkCore/DkMath.h
@@ -33,6 +33,7 @@
 #include <QPolygonF>
 #include <cmath>
 #include <float.h>
+#include <iostream>
 #pragma warning(pop) // no warnings from includes - end
 
 #ifdef QT_NO_DEBUG_OUTPUT


### PR DESCRIPTION
It is needed for `std::ostream` and the like; explicitly including it fixes the build when the OpenCV support is disabled.