### PR TITLE
Use Exiv2::CommentValue to format Exif.Photo.UserComment metadatum

### DIFF
--- a/ImageLounge/src/DkCore/DkMetaData.cpp
+++ b/ImageLounge/src/DkCore/DkMetaData.cpp
@@ -469,7 +469,9 @@ QString DkMetaDataT::getNativeExifValue(const QString &key, bool humanReadable) 
 
                 // qDebug() << "pos count: " << pos->count();
                 // Exiv2::Value::AutoPtr v = pos->getValue();
-                if (humanReadable) {
+                if (key == QLatin1String("Exif.Photo.UserComment")) {
+                    info = QString::fromStdString(static_cast<const Exiv2::CommentValue &>(pos->value()).comment());
+                } else if (humanReadable) {
                     std::stringstream ss;
                     ss << *pos;
                     info = exiv2ToQString(ss.str());


### PR DESCRIPTION
Converting the UserComment exif metadatum to string will result in its direct/quasi-internal string representation of libexiv2, which may include a `charset=...` prefix with the charset of the value.

Since we want the actual content/value of `UserComment`, and the `Exiv2::Value` held by `Exiv2::Exifdatum` is `Exiv2::CommentValue`, then cast it to call `comment()`. The result is converted to `QString` using `QString::fromStdString()`, which converts std::string as UTF-8 string.

For further details, see also the exiv2 ticket:
https://github.com/Exiv2/exiv2/issues/1258