### PR TITLE
Fix missing icon in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,4 +182,4 @@ docker push diemmarkus/nomacs:latest
 - [GitHub](https://github.com/nomacs)
 - [Matrix chat room](https://matrix.to/#/#nomacs:matrix.org)
 
-[![nomacs-icon](https://nomacs.org/startpage/nomacs.svg)](https://nomacs.org)
+[![nomacs-icon](https://nomacs.org/nomacs.svg)](https://nomacs.org)


### PR DESCRIPTION
Because the URL to the icon has been changed, the link in the README does not work anymore. Point it to the correct URL.

Fixes https://github.com/nomacs/nomacs/issues/1045.
