### PR TITLE
Fixes wrong coordinates in crop toolbar (#944)

### DIFF
--- a/ImageLounge/src/DkGui/DkWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkWidgets.cpp
@@ -1831,7 +1831,7 @@ void DkEditableRect::paintEvent(QPaintEvent *event)
 QRect DkEditableRect::rect() const
 {
     QRect r;
-    r.setTopLeft(mRect.getCenter().toPoint());
+    r.setTopLeft(mRect.getTopLeft().toPoint());
     r.setSize(mRect.size());
 
     return r;
@@ -2094,7 +2094,7 @@ void DkEditableRect::setShowInfo(bool showInfo)
 
 void DkEditableRect::setRect(const QRect &rect)
 {
-    mRect.setCenter(rect.topLeft());
+    mRect.setCenter(rect.center());
     mRect.setSize(rect.size());
 
     update();


### PR DESCRIPTION
Bug: With Crop active, after creating/changing the rectangle by dragging, the coordinates displayed in the crop toolbar.

Fixed by: Set top left to top left.