### PR TITLE
Fix incorrect crop tooltip when rotating

### DIFF
--- a/ImageLounge/src/DkGui/DkWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkWidgets.cpp
@@ -2002,7 +2002,11 @@ void DkEditableRect::mouseMoveEvent(QMouseEvent *event)
             tl = mRtform.map(mRect.getTopLeft()).toPoint();
             info += "x: ";
         } else {
-            tl = mRtform.map(mRect.getCenter()).toPoint();
+            // Because we rotate around the center, there's no need to do rotation.
+            // However, we need to check whether the center is tranlated.
+            // Not sure why, but the tranlation is stored in mRtform in the above.
+            const QTransform transform{1, 0, 0, 1, mRtform.dx(), mRtform.dy()};
+            tl = transform.map(mRect.getCenter()).toPoint();
             info += "center x: ";
         }
         info += QString::number(tl.x()) + ", y: ";


### PR DESCRIPTION
Fixes https://github.com/nomacs/nomacs/issues/1071

The tooltip of the crop tool displays the center coordinates of the crop rectangle when it is rotated, however, the displayed value changes when we rotate around the center.

The value is incorrect because the center is not properly translated before applying the rotation transform, which rotates around the origin. This patch calculates the coordinates to be displayed considering only the translation because rotation around the center should not change its position.
