### PR TITLE
Loop zip archives if browse filter is disabled (#475)

### DIFF
--- a/ImageLounge/src/DkCore/DkImageLoader.cpp
+++ b/ImageLounge/src/DkCore/DkImageLoader.cpp
@@ -525,7 +525,11 @@ QSharedPointer<DkImageContainerT> DkImageLoader::getSkippedImage(int skipIdx, bo
     }
 
 #ifdef WITH_QUAZIP
-    if (mCurrentImage && (newFileIdx < 0 || newFileIdx >= mImages.size()) && mCurrentImage->isFromZip() && mCurrentImage->getZipData()) {
+    // zips only loop if browse filter is disabled; otherwise we could not break out of a zip
+    bool loopZip = DkSettingsManager::param().global().loop && !DkSettingsManager::param().app().browseFilters.contains("*.zip");
+
+    if (mCurrentImage && (newFileIdx < 0 || newFileIdx >= mImages.size()) &&
+        mCurrentImage->isFromZip() && mCurrentImage->getZipData() && !loopZip) {
         // load the zip again and go on from there
         setCurrentImage(QSharedPointer<DkImageContainerT>(new DkImageContainerT(mCurrentImage->getZipData()->getZipFilePath())));
 


### PR DESCRIPTION
Fixes #475. To summarize the issue, if looping is enabled, instead of looping the zip, the next sibling in the parent would appear. This is counterintuitive because we expect zips to behave like directories. In addition, there is no combination of settings that will allow zips to loop.

This patch allows zips to loop but only if browsing for zips is disabled - preserving the old functionality. There should not be a separate checkbox for looping zips because zips are expected to behave like directories.