### PR TITLE
Fix broken zip thumbnails

### DIFF
--- a/ImageLounge/src/DkCore/DkThumbs.cpp
+++ b/ImageLounge/src/DkCore/DkThumbs.cpp
@@ -301,7 +301,7 @@ bool DkThumbNailT::fetchThumb(int forceLoad /* = false */, QSharedPointer<QByteA
 
     // check if we can load the file
     // though if it might seem over engineered: it is much faster cascading it here
-    if (!DkUtils::hasValidSuffix(getFilePath()) && !QFileInfo(getFilePath()).suffix().isEmpty() && !DkUtils::isValid(QFileInfo(getFilePath())))
+    if (!DkUtils::hasValidSuffix(getFilePath()) && !DkUtils::isValid(QFileInfo(getFilePath())))
         return false;
 
     // we have to do our own bool here

--- a/ImageLounge/src/DkCore/DkUtils.cpp
+++ b/ImageLounge/src/DkCore/DkUtils.cpp
@@ -662,12 +662,14 @@ bool DkUtils::isSavable(const QString &fileName)
 
 bool DkUtils::hasValidSuffix(const QString &fileName)
 {
-    for (int idx = 0; idx < DkSettingsManager::param().app().fileFilters.size(); idx++) {
-        QRegularExpression exp = QRegularExpression(QRegularExpression::wildcardToRegularExpression(DkSettingsManager::param().app().fileFilters.at(idx)),
-                                                    QRegularExpression::CaseInsensitiveOption);
-        if (exp.match(fileName).hasMatch())
+    const QString fileSuffix = fileName.mid(fileName.lastIndexOf('.')).toLower(); // .jpg
+    if (fileSuffix.isEmpty())
+        return false;
+
+    const QStringList &filters = DkSettingsManager::param().app().fileFilters; // [*.jpg, ...]
+    for (const QString &filter : filters)
+        if (filter.endsWith(fileSuffix))
             return true;
-    }
 
     return false;
 }


### PR DESCRIPTION
This fixes the bug where zip thumbnails do not load at all. This is due to failing the test DkUtils::hasValidSuffix(). With globs, QRE uses file path matching for the "*" part of the glob -- "the transformation is targeting file path globbing, which means in particular that path separators receive special treatment". Since the zip paths are  encoded to something bizarre, QRE used this way won't accept them.

Well that's the backstory, but I think it should be rewritten so I'm submitting a simplified version that should do the job. I believe it will because the globbing patterns are normalized to be "*.something", always lowercase and nothing else. Now if they had other globbing foo in them this patch would not work for those cases.

I also reviewed all usages of hasValidSuffix() and found one spot that could be refactored.