### PR TITLE
Fix status bar displaying wrong zoom

### DIFF
--- a/ImageLounge/src/DkGui/DkViewPort.cpp
+++ b/ImageLounge/src/DkGui/DkViewPort.cpp
@@ -509,6 +509,7 @@ void DkViewPort::resetView()
     controlImagePosition();
 
     emit zoomSignal(mWorldMatrix.m11() * mImgMatrix.m11() * 100);
+    DkStatusBarManager::instance().setMessage(QString::number(qRound(mWorldMatrix.m11() * mImgMatrix.m11() * 100)) + "%", DkStatusBar::status_zoom_info);
     tcpSynchronize();
 }
 


### PR DESCRIPTION
Fixes https://github.com/nomacs/nomacs/issues/1068.

There are two branches in `DkViewPort::zoom()` that changes the zoom but does not call `DkStatusBarManager::setMessage()`, so the status bar is not updated in some cases.

Add the call in the common function to fix this.


