### PR TITLE
Fix segfault on thumbnailer #1083 from race condition

### DIFF
--- a/ImageLounge/src/DkCore/DkThumbs.h
+++ b/ImageLounge/src/DkCore/DkThumbs.h
@@ -92,7 +92,7 @@ public:
      **/
     virtual void setImage(const QImage img);
 
-    void removeBlackBorder(QImage &img);
+    static void removeBlackBorder(QImage &img);
 
     /**
      * Returns the thumbnail.
@@ -156,7 +156,7 @@ public:
     };
 
 protected:
-    QImage computeIntern(const QString &file, QSharedPointer<QByteArray> ba, int forceLoad, int maxThumbSize);
+    static QImage computeIntern(const QString &filePath, QSharedPointer<QByteArray> ba, int forceLoad, int maxThumbSize);
 
     QImage mImg;
     QString mFile;
@@ -200,8 +200,6 @@ protected slots:
     void thumbLoaded();
 
 protected:
-    QImage computeCall(const QString &filePath, QSharedPointer<QByteArray> ba, int forceLoad, int maxThumbSize);
-
     QFutureWatcher<QImage> mThumbWatcher;
     bool mFetching;
     int mForceLoad;


### PR DESCRIPTION
DkThumbNail::computeIntern() was being invoked with a QString reference, and was also referencing a member variable. Which made it non-reentrant and led to segfault in Qt string operations.

This is corrected, in addition some refactoring is added to prevent this from happening again.

- All params to lambda are copies (no "&" or "this" is passed)
- computeIntern() is declared static
- computeCall() has been dropped
