### PR TITLE
Fix use-after-free in DkMetaDataDock (Debian #1051579)

### DIFF
--- a/ImageLounge/src/DkGui/DkMetaDataWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkMetaDataWidgets.cpp
@@ -440,11 +440,10 @@ void DkMetaDataDock::updateEntries()
     for (int idx = 0; idx < nr; idx++)
         getExpandedItemNames(mProxyModel->index(idx, 0, QModelIndex()), mExpandedNames);
 
-    mModel->deleteLater();
-
     if (!mImgC)
         return;
 
+    mModel->deleteLater();
     mModel = new DkMetaDataModel(this);
     mModel->addMetaData(mImgC->getMetaData());
     mProxyModel->setSourceModel(mModel);


### PR DESCRIPTION
Fixes https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1051579

When metadata dock is enabled, nomacs crashes some time after all tabs are closed. This is due to to use-after-free on the item model.

It seems like the intent of the incorrect code was to prevent a null image from causing an update to the view, so I have corrected as such. If the intent was to empty/reset the view that could be addressed in a separate PR.
