### PR TITLE
Fix segfault in history dock when last tab is closed

### DIFF
--- a/ImageLounge/src/DkGui/DkDockWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkDockWidgets.cpp
@@ -63,16 +63,18 @@ void DkHistoryDock::createLayout()
 void DkHistoryDock::updateImage(QSharedPointer<DkImageContainerT> img)
 {
     updateList(img);
-    mImg = img;
+    mImg = img; // null if tab has no image
 }
 
 void DkHistoryDock::updateList(QSharedPointer<DkImageContainerT> img)
 {
+    mHistoryList->clear();
+    if (!img)
+        return;
+
     QVector<DkEditImage> *history = img->getLoader()->history();
     int hIdx = img->getLoader()->historyIndex();
     QVector<QListWidgetItem *> editItems;
-
-    mHistoryList->clear();
 
     for (int idx = 0; idx < history->size(); idx++) {
         const DkEditImage &eImg = history->at(idx);


### PR DESCRIPTION
If the last tab is closed or we switch to a tab with no image (settings) we will crash due to receiving a null image from imageUpdatedSignal(). Passing of null seems to be expected behavior as it indicates to the widget there is no longer any image present.

This adds the null check where needed. We must clear the history since restoring history of a detached image, while possible seems incorrect when "ask to save changes" prompt should take care of this.
