### PR TITLE
Fix segfaults or hangs when sorting

### DIFF
--- a/ImageLounge/src/DkCore/DkImageContainer.h
+++ b/ImageLounge/src/DkCore/DkImageContainer.h
@@ -70,10 +70,6 @@ public:
     DkImageContainer(const QString &filePath);
     virtual ~DkImageContainer();
     bool operator==(const DkImageContainer &ric) const;
-    bool operator<(const DkImageContainer &o) const;
-    bool operator<=(const DkImageContainer &o) const;
-    bool operator>(const DkImageContainer &o) const;
-    bool operator>=(const DkImageContainer &o) const;
 
     QImage image();
     QImage pixmap();
@@ -128,6 +124,14 @@ public:
     void cropImage(const DkRotatingRect &rect, const QColor &col, bool cropToMetadata);
     DkRotatingRect cropRect();
 
+    /**
+     * Get a less-than function based on the global sort mode, suitable for std::sort et al
+     * @note does not incorporate the ascending/descending mode (always ascending),
+     *       to sort descending, reverse the array after sorting.
+     */
+    static std::function<bool(const QSharedPointer<DkImageContainer> &,
+                              const QSharedPointer<DkImageContainer> &)> compareFunc();
+
 protected:
     QSharedPointer<DkBasicLoader> loadImageIntern(const QString &filePath, QSharedPointer<DkBasicLoader> loader, const QSharedPointer<QByteArray> fileBuffer);
     void
@@ -157,9 +161,6 @@ protected:
 private:
     QString mFilePath;
 };
-
-bool imageContainerLessThan(const DkImageContainer &l, const DkImageContainer &r);
-bool imageContainerLessThanPtr(const QSharedPointer<DkImageContainer> l, const QSharedPointer<DkImageContainer> r);
 
 class DllCoreExport DkImageContainerT : public QObject, public DkImageContainer
 {

--- a/ImageLounge/src/DkCore/DkUtils.cpp
+++ b/ImageLounge/src/DkCore/DkUtils.cpp
@@ -302,19 +302,9 @@ bool DkUtils::compDateCreated(const QFileInfo &lhf, const QFileInfo &rhf)
     return lhf.birthTime() < rhf.birthTime();
 }
 
-bool DkUtils::compDateCreatedInv(const QFileInfo &lhf, const QFileInfo &rhf)
-{
-    return !compDateCreated(lhf, rhf);
-}
-
 bool DkUtils::compDateModified(const QFileInfo &lhf, const QFileInfo &rhf)
 {
     return lhf.lastModified() < rhf.lastModified();
-}
-
-bool DkUtils::compDateModifiedInv(const QFileInfo &lhf, const QFileInfo &rhf)
-{
-    return !compDateModified(lhf, rhf);
 }
 
 bool DkUtils::compFilename(const QFileInfo &lhf, const QFileInfo &rhf)
@@ -322,19 +312,9 @@ bool DkUtils::compFilename(const QFileInfo &lhf, const QFileInfo &rhf)
     return compLogicQString(lhf.fileName(), rhf.fileName());
 }
 
-bool DkUtils::compFilenameInv(const QFileInfo &lhf, const QFileInfo &rhf)
-{
-    return !compFilename(lhf, rhf);
-}
-
 bool DkUtils::compFileSize(const QFileInfo &lhf, const QFileInfo &rhf)
 {
     return lhf.size() < rhf.size();
-}
-
-bool DkUtils::compFileSizeInv(const QFileInfo &lhf, const QFileInfo &rhf)
-{
-    return !compFileSize(lhf, rhf);
 }
 
 bool DkUtils::compRandom(const QFileInfo &lhf, const QFileInfo &rhf)

--- a/ImageLounge/src/DkCore/DkUtils.h
+++ b/ImageLounge/src/DkCore/DkUtils.h
@@ -132,19 +132,11 @@ public:
 
     static bool compFilename(const QFileInfo &lhf, const QFileInfo &rhf);
 
-    static bool compFilenameInv(const QFileInfo &lhf, const QFileInfo &rhf);
-
     static bool compFileSize(const QFileInfo &lhf, const QFileInfo &rhf);
-
-    static bool compFileSizeInv(const QFileInfo &lhf, const QFileInfo &rhf);
 
     static bool compDateCreated(const QFileInfo &lhf, const QFileInfo &rhf);
 
-    static bool compDateCreatedInv(const QFileInfo &lhf, const QFileInfo &rhf);
-
     static bool compDateModified(const QFileInfo &lhf, const QFileInfo &rhf);
-
-    static bool compDateModifiedInv(const QFileInfo &lhf, const QFileInfo &rhf);
 
     static bool compRandom(const QFileInfo &lhf, const QFileInfo &rhf);
 


### PR DESCRIPTION
The current version will crash if certain network folders are sorted by created time. This is because network shares do not typically support created/birth time.

Since the birth time is unavailable, the comparison result is always false (this is how Qt compares invalid values). With inversion/ descending, then it is always true and std:sort crashes or hangs. If we want to fix this for now and add future sort features this has to change.

Related: #953 which crashes for this very issue; the "coin flip" happens to come up 0 or 1 for all images being sorted.

I have rewritten DkImageLoader::sort() and refactored. I removed the compare operators since they are unsafe and the old sorting method; some dead code for threaded sorting remains, maybe someone will resurrect it (not theoretically a bad idea).

The new version will prevent this bug from ever occurring by reversing the list after sorting if needed. It should be a little faster since the invariants are pulled out before sorting.
