### PR TITLE
Remove QMetaObject::connectSlotsByName()

### DIFF
--- a/ImageLounge/src/DkCore/DkBasicWidgets.cpp
+++ b/ImageLounge/src/DkCore/DkBasicWidgets.cpp
@@ -358,8 +358,8 @@ void DkColorChooser::init()
     mAccepted = false;
 
     colorDialog = new QColorDialog(this);
-    colorDialog->setObjectName("colorDialog");
     colorDialog->setOption(QColorDialog::ShowAlphaChannel, true);
+    connect(colorDialog, &QColorDialog::accepted, this, &DkColorChooser::onColorDialogAccepted);
 
     QVBoxLayout *vLayout = new QVBoxLayout(this);
     vLayout->setContentsMargins(11, 0, 11, 0);
@@ -367,12 +367,12 @@ void DkColorChooser::init()
     QLabel *colorLabel = new QLabel(mText, this);
     colorButton = new QPushButton("", this);
     colorButton->setFlat(true);
-    colorButton->setObjectName("colorButton");
     colorButton->setAutoDefault(false);
+    connect(colorButton, &QPushButton::clicked, this, &DkColorChooser::onColorButtonClicked);
 
     QPushButton *resetButton = new QPushButton(tr("Reset"), this);
-    resetButton->setObjectName("resetButton");
     resetButton->setAutoDefault(false);
+    connect(resetButton, &QPushButton::clicked, this, &DkColorChooser::onResetButtonClicked);
 
     QWidget *colWidget = new QWidget(this);
     QHBoxLayout *hLayout = new QHBoxLayout(colWidget);
@@ -386,7 +386,6 @@ void DkColorChooser::init()
     vLayout->addWidget(colWidget);
 
     setColor(defaultColor);
-    QMetaObject::connectSlotsByName(this);
 }
 
 bool DkColorChooser::isAccept() const
@@ -420,19 +419,19 @@ QColor DkColorChooser::getColor()
     return colorDialog->currentColor();
 }
 
-void DkColorChooser::on_resetButton_clicked()
+void DkColorChooser::onResetButtonClicked()
 {
     setColor(defaultColor);
     emit resetClicked();
 }
 
-void DkColorChooser::on_colorButton_clicked()
+void DkColorChooser::onColorButtonClicked()
 {
     // incorrect color? - see: https://bugreports.qt.io/browse/QTBUG-42988
     colorDialog->show();
 }
 
-void DkColorChooser::on_colorDialog_accepted()
+void DkColorChooser::onColorDialogAccepted()
 {
     setColor(colorDialog->currentColor());
     mAccepted = true;
@@ -664,7 +663,6 @@ DkColorPicker::DkColorPicker(QWidget *parent)
     : DkWidget(parent)
 {
     createLayout();
-    QMetaObject::connectSlotsByName(this);
 }
 
 void DkColorPicker::createLayout()
@@ -673,7 +671,6 @@ void DkColorPicker::createLayout()
 
     // color pane
     mColorPane = new DkColorPane(this);
-    mColorPane->setObjectName("mColorPane");
     mColorPane->setBaseSize(100, 100);
     mColorPane->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Preferred);
 

--- a/ImageLounge/src/DkCore/DkBasicWidgets.h
+++ b/ImageLounge/src/DkCore/DkBasicWidgets.h
@@ -143,9 +143,9 @@ public:
     void enableAlpha(bool enable = true);
 
 public slots:
-    void on_resetButton_clicked();
-    void on_colorButton_clicked();
-    void on_colorDialog_accepted();
+    void onResetButtonClicked();
+    void onColorButtonClicked();
+    void onColorDialogAccepted();
 
 signals:
     void resetClicked();

--- a/ImageLounge/src/DkCore/DkPluginManager.cpp
+++ b/ImageLounge/src/DkCore/DkPluginManager.cpp
@@ -610,7 +610,6 @@ DkPluginTableWidget::DkPluginTableWidget(QWidget *parent)
     : DkWidget(parent)
 {
     createLayout();
-    QMetaObject::connectSlotsByName(this);
 }
 
 DkPluginTableWidget::~DkPluginTableWidget()

--- a/ImageLounge/src/DkGui/DkBatch.cpp
+++ b/ImageLounge/src/DkGui/DkBatch.cpp
@@ -1203,7 +1203,6 @@ DkProfileSummaryWidget::DkProfileSummaryWidget(QWidget *parent)
 {
     createLayout();
     setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Minimum);
-    QMetaObject::connectSlotsByName(this);
 }
 
 void DkProfileSummaryWidget::setProfile(const QString &profileName, const DkBatchConfig &config)
@@ -1219,17 +1218,17 @@ void DkProfileSummaryWidget::setProfile(const QString &profileName, const DkBatc
     mFunctions->setText(functions);
 }
 
-void DkProfileSummaryWidget::on_deleteButton_clicked()
+void DkProfileSummaryWidget::onDeleteButtonClicked()
 {
     emit deleteCurrentProfile();
 }
 
-void DkProfileSummaryWidget::on_updateButton_clicked()
+void DkProfileSummaryWidget::onUpdateButtonClicked()
 {
     emit updateCurrentProfile();
 }
 
-void DkProfileSummaryWidget::on_exportButton_clicked()
+void DkProfileSummaryWidget::onExportButtonClicked()
 {
     emit exportCurrentProfile();
 }
@@ -1264,19 +1263,16 @@ void DkProfileSummaryWidget::createLayout()
     summaryLayout->addWidget(mFunctions, 4, 2);
 
     QPushButton *updateButton = new QPushButton(DkImage::loadIcon(":/nomacs/img/save.svg"), "", this);
-    updateButton->setObjectName("updateButton");
-    // updateButton->setFlat(true);
     updateButton->setToolTip(tr("Update"));
+    connect(updateButton, &QPushButton::clicked, this, &DkProfileSummaryWidget::onUpdateButtonClicked);
 
     QPushButton *deleteButton = new QPushButton(DkImage::loadIcon(":/nomacs/img/trash.svg"), "", this);
-    deleteButton->setObjectName("deleteButton");
-    // deleteButton->setFlat(true);
     deleteButton->setToolTip(tr("Delete"));
+    connect(deleteButton, &QPushButton::clicked, this, &DkProfileSummaryWidget::onDeleteButtonClicked);
 
     QPushButton *exportButton = new QPushButton(DkImage::loadIcon(":/nomacs/img/export.svg"), "", this);
-    exportButton->setObjectName("exportButton");
-    // exportButton->setFlat(true);
     exportButton->setToolTip(tr("Export"));
+    connect(exportButton, &QPushButton::clicked, this, &DkProfileSummaryWidget::onExportButtonClicked);
 
     QWidget *bw = new QWidget(this);
     QHBoxLayout *bLayout = new QHBoxLayout(bw);
@@ -1296,22 +1292,22 @@ DkProfileWidget::DkProfileWidget(QWidget *parent, Qt::WindowFlags f)
     : DkWidget(parent, f)
 {
     createLayout();
-    QMetaObject::connectSlotsByName(this);
 }
 
 void DkProfileWidget::createLayout()
 {
     mProfileList = new QListWidget(this);
     mProfileList->setObjectName("profileList");
+    connect(mProfileList, &QListWidget::itemSelectionChanged, this, &DkProfileWidget::onProfileListItemSelectionChanged);
 
     mSummary = new DkProfileSummaryWidget(this);
 
     // buttons
     QPushButton *saveButton = new QPushButton(tr("Create New Profile"), this);
-    saveButton->setObjectName("saveButton");
+    connect(saveButton, &QPushButton::clicked, this, &DkProfileWidget::onSaveButtonClicked);
 
     QPushButton *resetButton = new QPushButton(tr("Apply Default"), this);
-    resetButton->setObjectName("resetButton");
+    connect(resetButton, &QPushButton::clicked, this, &DkProfileWidget::onResetButtonClicked);
 
     QWidget *buttonWidget = new QWidget(this);
     QHBoxLayout *bLayout = new QHBoxLayout(buttonWidget);
@@ -1364,7 +1360,7 @@ void DkProfileWidget::profileSaved(const QString &profileName)
         i->setSelected(true);
 }
 
-void DkProfileWidget::on_profileList_itemSelectionChanged()
+void DkProfileWidget::onProfileListItemSelectionChanged()
 {
     changeProfile(currentProfile());
 }
@@ -1422,12 +1418,12 @@ QString DkProfileWidget::currentProfile() const
     return profileName;
 }
 
-void DkProfileWidget::on_saveButton_clicked()
+void DkProfileWidget::onSaveButtonClicked()
 {
     saveProfile();
 }
 
-void DkProfileWidget::on_resetButton_clicked()
+void DkProfileWidget::onResetButtonClicked()
 {
     loadDefaultProfile();
 }

--- a/ImageLounge/src/DkGui/DkBatch.h
+++ b/ImageLounge/src/DkGui/DkBatch.h
@@ -379,9 +379,9 @@ public:
     void setProfile(const QString &name, const DkBatchConfig &config);
 
 public slots:
-    void on_deleteButton_clicked();
-    void on_updateButton_clicked();
-    void on_exportButton_clicked();
+    void onDeleteButtonClicked();
+    void onUpdateButtonClicked();
+    void onExportButtonClicked();
 
 signals:
     void deleteCurrentProfile() const;
@@ -411,9 +411,9 @@ public:
     void profileSaved(const QString &profileName);
 
 public slots:
-    void on_profileList_itemSelectionChanged();
-    void on_saveButton_clicked();
-    void on_resetButton_clicked();
+    void onProfileListItemSelectionChanged();
+    void onSaveButtonClicked();
+    void onResetButtonClicked();
 
     void updateCurrentProfile();
     void deleteCurrentProfile();

--- a/ImageLounge/src/DkGui/DkDialog.h
+++ b/ImageLounge/src/DkGui/DkDialog.h
@@ -212,9 +212,9 @@ public:
     DkAppManagerDialog(DkAppManager *manager = 0, QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags());
 
 public slots:
-    void on_addButton_clicked();
-    void on_deleteButton_clicked();
-    void on_runButton_clicked();
+    void onAddButtonClicked();
+    void onDeleteButtonClicked();
+    void onRunButtonClicked();
     virtual void accept() override;
 
 signals:
@@ -250,10 +250,10 @@ public:
     void setDefaultButton(int defaultButton = find_button);
 
 public slots:
-    void on_searchBar_textChanged(const QString &text);
-    void on_filterButton_pressed();
-    void on_resultListView_doubleClicked(const QModelIndex &modelIndex);
-    void on_resultListView_clicked(const QModelIndex &modelIndex);
+    void onSearchBarTextChanged(const QString &text);
+    void onFilterButtonPressed();
+    void onResultListViewDoubleClicked(const QModelIndex &modelIndex);
+    void onResultListViewClicked(const QModelIndex &modelIndex);
     virtual void accept() override;
 
 signals:
@@ -304,23 +304,23 @@ public:
     bool resample();
 
 protected slots:
-    void on_lockButtonDim_clicked();
-    void on_lockButton_clicked();
+    void onLockButtonDimClicked();
+    void onLockButtonClicked();
 
-    void on_wPixelSpin_valueChanged(double val);
-    void on_hPixelSpin_valueChanged(double val);
+    void onWPixelSpinValueChanged(double val);
+    void onHPixelSpinValueChanged(double val);
 
-    void on_widthSpin_valueChanged(double val);
-    void on_heightSpin_valueChanged(double val);
-    void on_resolutionSpin_valueChanged(double val);
+    void onWidthSpinValueChanged(double val);
+    void onHeightSpinValueChanged(double val);
+    void onResolutionSpinValueChanged(double val);
 
-    void on_sizeBox_currentIndexChanged(int idx);
-    void on_unitBox_currentIndexChanged(int idx);
-    void on_resUnitBox_currentIndexChanged(int idx);
-    void on_resampleBox_currentIndexChanged(int idx);
+    void onSizeBoxCurrentIndexChanged(int idx);
+    void onUnitBoxCurrentIndexChanged(int idx);
+    void onResUnitBoxCurrentIndexChanged(int idx);
+    void onResampleBoxCurrentIndexChanged(int idx);
 
-    void on_resampleCheck_clicked();
-    void on_gammaCorrection_clicked();
+    void onResampleCheckClicked();
+    void onGammaCorrectionClicked();
 
     void drawPreview();
 
@@ -632,9 +632,9 @@ public:
     DkExportTiffDialog(QWidget *parent = 0, Qt::WindowFlags f = Qt::WindowFlags());
 
 public slots:
-    void on_openButton_pressed();
-    void on_saveButton_pressed();
-    void on_fileEdit_textChanged(const QString &filename);
+    void onOpenButtonPressed();
+    void onSaveButtonPressed();
+    void onFileEditTextChanged(const QString &filename);
     void setFile(const QString &filePath);
     void accept() override;
     void reject() override;
@@ -693,16 +693,16 @@ public:
     QImage getImage();
 
 public slots:
-    void on_openButton_pressed();
-    void on_dbButton_pressed();
-    void on_fileEdit_textChanged(const QString &filename);
-    void on_newWidthBox_valueChanged(int i);
-    void on_newHeightBox_valueChanged(int i);
-    void on_numPatchesV_valueChanged(int i);
-    void on_numPatchesH_valueChanged(int i);
-    void on_darkenSlider_valueChanged(int i);
-    void on_lightenSlider_valueChanged(int i);
-    void on_saturationSlider_valueChanged(int i);
+    void onOpenButtonPressed();
+    void onDbButtonPressed();
+    void onFileEditTextChanged(const QString &filename);
+    void onNewWidthBoxValueChanged(int i);
+    void onNewHeightBoxValueChanged(int i);
+    void onNumPatchesVValueChanged(int i);
+    void onNumPatchesHValueChanged(int i);
+    void onDarkenSliderValueChanged(int i);
+    void onLightenSliderValueChanged(int i);
+    void onSaturationSliderValueChanged(int i);
 
     void setFile(const QString &file);
     void compute();
@@ -827,8 +827,8 @@ public:
     QSize size() const;
 
 public slots:
-    void on_width_valueChanged(int val);
-    void on_height_valueChanged(int val);
+    void onWidthValueChanged(int val);
+    void onHeightValueChanged(int val);
 
 private:
     void createLayout();

--- a/ImageLounge/src/DkGui/DkDockWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkDockWidgets.cpp
@@ -44,7 +44,6 @@ DkHistoryDock::DkHistoryDock(const QString &title, QWidget *parent)
 {
     setObjectName("DkHistoryDock");
     createLayout();
-    QMetaObject::connectSlotsByName(this);
 }
 
 void DkHistoryDock::createLayout()
@@ -52,6 +51,7 @@ void DkHistoryDock::createLayout()
     mHistoryList = new QListWidget(this);
     mHistoryList->setObjectName("historyList");
     mHistoryList->setIconSize(QSize(DkSettingsManager::param().effectiveIconSize(), DkSettingsManager::param().effectiveIconSize()));
+    connect(mHistoryList, &QListWidget::itemClicked, this, &DkHistoryDock::onHistoryListItemClicked);
 
     QWidget *contentWidget = new QWidget(this);
     QVBoxLayout *layout = new QVBoxLayout(contentWidget);
@@ -88,7 +88,7 @@ void DkHistoryDock::updateList(QSharedPointer<DkImageContainerT> img)
         mHistoryList->item(hIdx)->setSelected(true);
 }
 
-void DkHistoryDock::on_historyList_itemClicked(QListWidgetItem *item)
+void DkHistoryDock::onHistoryListItemClicked(QListWidgetItem *item)
 {
     if (!mImg)
         return;

--- a/ImageLounge/src/DkGui/DkDockWidgets.h
+++ b/ImageLounge/src/DkGui/DkDockWidgets.h
@@ -61,7 +61,7 @@ public:
 
 public slots:
     void updateImage(QSharedPointer<DkImageContainerT> img);
-    void on_historyList_itemClicked(QListWidgetItem *item);
+    void onHistoryListItemClicked(QListWidgetItem *item);
 
 protected:
     void createLayout();

--- a/ImageLounge/src/DkGui/DkLogWidget.cpp
+++ b/ImageLounge/src/DkGui/DkLogWidget.cpp
@@ -55,7 +55,6 @@ DkLogWidget::DkLogWidget(QWidget *parent)
     connect(msgQueuer.data(), SIGNAL(message(const QString &)), this, SLOT(log(const QString &)), Qt::QueuedConnection);
 
     qInstallMessageHandler(widgetMessageHandler);
-    QMetaObject::connectSlotsByName(this);
 }
 
 void DkLogWidget::log(const QString &msg)
@@ -63,7 +62,7 @@ void DkLogWidget::log(const QString &msg)
     mTextEdit->append(msg);
 }
 
-void DkLogWidget::on_clearButton_pressed()
+void DkLogWidget::onClearButtonPressed()
 {
     mTextEdit->clear();
 }
@@ -75,8 +74,8 @@ void DkLogWidget::createLayout()
 
     QPushButton *clearButton = new QPushButton(this);
     clearButton->setFlat(true);
-    clearButton->setObjectName("clearButton");
     clearButton->setFixedSize(QSize(32, 32));
+    connect(clearButton, &QPushButton::clicked, this, &DkLogWidget::onClearButtonPressed);
 
     QGridLayout *layout = new QGridLayout(this);
     layout->setContentsMargins(0, 0, 0, 0);

--- a/ImageLounge/src/DkGui/DkLogWidget.h
+++ b/ImageLounge/src/DkGui/DkLogWidget.h
@@ -83,7 +83,7 @@ public:
 
 public slots:
     void log(const QString &msg);
-    void on_clearButton_pressed();
+    void onClearButtonPressed();
 
 protected:
     void createLayout();

--- a/ImageLounge/src/DkGui/DkManipulatorWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkManipulatorWidgets.cpp
@@ -42,6 +42,7 @@
 #include <QComboBox>
 #include <QLabel>
 #include <QVBoxLayout>
+#include <QtGlobal>
 #pragma warning(pop)
 
 namespace nmc
@@ -252,7 +253,6 @@ DkTinyPlanetWidget::DkTinyPlanetWidget(QSharedPointer<DkBaseManipulatorExt> mani
     : DkBaseManipulatorWidget(manipulator, parent)
 {
     createLayout();
-    QMetaObject::connectSlotsByName(this);
 
     manipulator->setWidget(this);
 }
@@ -261,20 +261,20 @@ void DkTinyPlanetWidget::createLayout()
 {
     // post processing sliders
     DkSlider *scaleSlider = new DkSlider(tr("Planet Size"), this);
-    scaleSlider->setObjectName("scaleSlider");
     scaleSlider->setMinimum(1);
     scaleSlider->setMaximum(1000);
     scaleSlider->setValue(manipulator()->size());
+    connect(scaleSlider, &DkSlider::valueChanged, this, &DkTinyPlanetWidget::onScaleSliderValueChanged);
 
     DkSlider *angleSlider = new DkSlider(tr("Angle"), this);
-    angleSlider->setObjectName("angleSlider");
     angleSlider->setValue(manipulator()->angle());
     angleSlider->setMinimum(-180);
     angleSlider->setMaximum(179);
+    connect(angleSlider, &DkSlider::valueChanged, this, &DkTinyPlanetWidget::onAngleSliderValueChanged);
 
     QCheckBox *invertBox = new QCheckBox(tr("Invert Planet"), this);
-    invertBox->setObjectName("invertBox");
     invertBox->setChecked(manipulator()->inverted());
+    connect(invertBox, &QCheckBox::toggled, this, &DkTinyPlanetWidget::onInvertBoxToggled);
 
     QVBoxLayout *sliderLayout = new QVBoxLayout(this);
     sliderLayout->addWidget(scaleSlider);
@@ -282,17 +282,17 @@ void DkTinyPlanetWidget::createLayout()
     sliderLayout->addWidget(invertBox);
 }
 
-void DkTinyPlanetWidget::on_scaleSlider_valueChanged(int val)
+void DkTinyPlanetWidget::onScaleSliderValueChanged(int val)
 {
     manipulator()->setSize(val);
 }
 
-void DkTinyPlanetWidget::on_angleSlider_valueChanged(int val)
+void DkTinyPlanetWidget::onAngleSliderValueChanged(int val)
 {
     manipulator()->setAngle(val);
 }
 
-void DkTinyPlanetWidget::on_invertBox_toggled(bool val)
+void DkTinyPlanetWidget::onInvertBoxToggled(bool val)
 {
     manipulator()->setInverted(val);
 }
@@ -307,7 +307,6 @@ DkBlurWidget::DkBlurWidget(QSharedPointer<DkBaseManipulatorExt> manipulator, QWi
     : DkBaseManipulatorWidget(manipulator, parent)
 {
     createLayout();
-    QMetaObject::connectSlotsByName(this);
 
     manipulator->setWidget(this);
 }
@@ -316,15 +315,15 @@ void DkBlurWidget::createLayout()
 {
     // post processing sliders
     DkSlider *sigmaSlider = new DkSlider(tr("Sigma"), this);
-    sigmaSlider->setObjectName("sigmaSlider");
     sigmaSlider->setValue(manipulator()->sigma());
     sigmaSlider->setMaximum(50);
+    connect(sigmaSlider, &DkSlider::valueChanged, this, &DkBlurWidget::onSigmaSliderValueChanged);
 
     QVBoxLayout *sliderLayout = new QVBoxLayout(this);
     sliderLayout->addWidget(sigmaSlider);
 }
 
-void DkBlurWidget::on_sigmaSlider_valueChanged(int val)
+void DkBlurWidget::onSigmaSliderValueChanged(int val)
 {
     manipulator()->setSigma(val);
 }
@@ -339,7 +338,6 @@ DkUnsharpMaskWidget::DkUnsharpMaskWidget(QSharedPointer<DkBaseManipulatorExt> ma
     : DkBaseManipulatorWidget(manipulator, parent)
 {
     createLayout();
-    QMetaObject::connectSlotsByName(this);
 
     manipulator->setWidget(this);
 }
@@ -348,25 +346,24 @@ void DkUnsharpMaskWidget::createLayout()
 {
     // post processing sliders
     DkSlider *sigmaSlider = new DkSlider(tr("Sigma"), this);
-    sigmaSlider->setObjectName("sigmaSlider");
     sigmaSlider->setValue(manipulator()->sigma());
-    // darkenSlider->hide();
+    connect(sigmaSlider, &DkSlider::valueChanged, this, &DkUnsharpMaskWidget::onSigmaSliderValueChanged);
 
     DkSlider *amountSlider = new DkSlider(tr("Amount"), this);
-    amountSlider->setObjectName("amountSlider");
     amountSlider->setValue(manipulator()->amount());
+    connect(amountSlider, &DkSlider::valueChanged, this, &DkUnsharpMaskWidget::onAmountSliderValueChanged);
 
     QVBoxLayout *sliderLayout = new QVBoxLayout(this);
     sliderLayout->addWidget(sigmaSlider);
     sliderLayout->addWidget(amountSlider);
 }
 
-void DkUnsharpMaskWidget::on_sigmaSlider_valueChanged(int val)
+void DkUnsharpMaskWidget::onSigmaSliderValueChanged(int val)
 {
     manipulator()->setSigma(val);
 }
 
-void DkUnsharpMaskWidget::on_amountSlider_valueChanged(int val)
+void DkUnsharpMaskWidget::onAmountSliderValueChanged(int val)
 {
     manipulator()->setAmount(val);
 }
@@ -381,7 +378,6 @@ DkRotateWidget::DkRotateWidget(QSharedPointer<DkBaseManipulatorExt> manipulator,
     : DkBaseManipulatorWidget(manipulator, parent)
 {
     createLayout();
-    QMetaObject::connectSlotsByName(this);
 
     manipulator->setWidget(this);
 }
@@ -394,16 +390,16 @@ QSharedPointer<DkRotateManipulator> DkRotateWidget::manipulator() const
 void DkRotateWidget::createLayout()
 {
     DkSlider *angleSlider = new DkSlider(tr("Angle"), this);
-    angleSlider->setObjectName("angleSlider");
     angleSlider->setValue(manipulator()->angle());
     angleSlider->setMinimum(-180);
     angleSlider->setMaximum(180);
+    connect(angleSlider, &DkSlider::valueChanged, this, &DkRotateWidget::onAngleSliderValueChanged);
 
     QVBoxLayout *sliderLayout = new QVBoxLayout(this);
     sliderLayout->addWidget(angleSlider);
 }
 
-void DkRotateWidget::on_angleSlider_valueChanged(int val)
+void DkRotateWidget::onAngleSliderValueChanged(int val)
 {
     manipulator()->setAngle(val);
 }
@@ -413,7 +409,6 @@ DkResizeWidget::DkResizeWidget(QSharedPointer<DkBaseManipulatorExt> manipulator,
     : DkBaseManipulatorWidget(manipulator, parent)
 {
     createLayout();
-    QMetaObject::connectSlotsByName(this);
 
     manipulator->setWidget(this);
 
@@ -439,14 +434,13 @@ void DkResizeWidget::onObjectNameChanged(const QString &name)
 void DkResizeWidget::createLayout()
 {
     DkDoubleSlider *scaleSlider = new DkDoubleSlider(tr("Scale"), this);
-    scaleSlider->setObjectName("scaleFactorSlider");
     scaleSlider->setMinimum(0.1);
     scaleSlider->setCenterValue(1.0);
     scaleSlider->setMaximum(10);
     scaleSlider->setValue(manipulator()->scaleFactor());
+    connect(scaleSlider, &DkDoubleSlider::valueChanged, this, &DkResizeWidget::onScaleFactorSliderValueChanged);
 
     mIplBox = new QComboBox(this);
-    mIplBox->setObjectName("iplBox");
     mIplBox->setView(new QListView()); // needed for style
     mIplBox->addItem(tr("Nearest Neighbor"), DkImage::ipl_nearest);
     mIplBox->addItem(tr("Area (best for downscaling)"), DkImage::ipl_area);
@@ -454,9 +448,10 @@ void DkResizeWidget::createLayout()
     mIplBox->addItem(tr("Bicubic (4x4 interpolatia)"), DkImage::ipl_cubic);
     mIplBox->addItem(tr("Lanczos (8x8 interpolation)"), DkImage::ipl_lanczos);
     mIplBox->setCurrentIndex(1);
+    connect(mIplBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &DkResizeWidget::onIplBoxCurrentIndexChanged);
 
     QCheckBox *cbGamma = new QCheckBox(tr("Gamma Correction"), this);
-    cbGamma->setObjectName("gammaCorrection");
+    connect(cbGamma, &QCheckBox::toggled, this, &DkResizeWidget::onGammaCorrectionToggled);
 
     QVBoxLayout *sliderLayout = new QVBoxLayout(this);
     sliderLayout->setSpacing(10);
@@ -465,17 +460,17 @@ void DkResizeWidget::createLayout()
     sliderLayout->addWidget(cbGamma);
 }
 
-void DkResizeWidget::on_scaleFactorSlider_valueChanged(double val)
+void DkResizeWidget::onScaleFactorSliderValueChanged(double val)
 {
     manipulator()->setScaleFactor(val);
 }
 
-void DkResizeWidget::on_iplBox_currentIndexChanged(int idx)
+void DkResizeWidget::onIplBoxCurrentIndexChanged(int idx)
 {
     manipulator()->setInterpolation(mIplBox->itemData(idx).toInt());
 }
 
-void DkResizeWidget::on_gammaCorrection_toggled(bool checked)
+void DkResizeWidget::onGammaCorrectionToggled(bool checked)
 {
     manipulator()->setCorrectGamma(checked);
 }
@@ -485,7 +480,6 @@ DkThresholdWidget::DkThresholdWidget(QSharedPointer<DkBaseManipulatorExt> manipu
     : DkBaseManipulatorWidget(manipulator, parent)
 {
     createLayout();
-    QMetaObject::connectSlotsByName(this);
 
     manipulator->setWidget(this);
 }
@@ -495,7 +489,7 @@ QSharedPointer<DkThresholdManipulator> DkThresholdWidget::manipulator() const
     return qSharedPointerDynamicCast<DkThresholdManipulator>(baseManipulator());
 }
 
-void DkThresholdWidget::on_colBox_toggled(bool checked)
+void DkThresholdWidget::onColBoxToggled(bool checked)
 {
     manipulator()->setColor(checked);
 }
@@ -503,21 +497,21 @@ void DkThresholdWidget::on_colBox_toggled(bool checked)
 void DkThresholdWidget::createLayout()
 {
     DkSlider *thrSlider = new DkSlider(tr("Threshold"), this);
-    thrSlider->setObjectName("thrSlider");
     thrSlider->setValue(manipulator()->threshold());
     thrSlider->setMinimum(0);
     thrSlider->setMaximum(255);
     thrSlider->setValue(manipulator()->threshold());
+    connect(thrSlider, &DkSlider::valueChanged, this, &DkThresholdWidget::onThrSliderValueChanged);
 
     QCheckBox *colBox = new QCheckBox(tr("Color"), this);
-    colBox->setObjectName("colBox");
     colBox->setChecked(manipulator()->color());
+    connect(colBox, &QCheckBox::toggled, this, &DkThresholdWidget::onColBoxToggled);
 
     QVBoxLayout *layout = new QVBoxLayout(this);
     layout->addWidget(thrSlider);
     layout->addWidget(colBox);
 }
-void DkThresholdWidget::on_thrSlider_valueChanged(int val)
+void DkThresholdWidget::onThrSliderValueChanged(int val)
 {
     manipulator()->setThreshold(val);
 }
@@ -527,8 +521,6 @@ DkColorWidget::DkColorWidget(QSharedPointer<DkBaseManipulatorExt> manipulator, Q
     : DkBaseManipulatorWidget(manipulator, parent)
 {
     createLayout();
-
-    QMetaObject::connectSlotsByName(this);
 
     manipulator->setWidget(this);
     setMinimumHeight(150);
@@ -542,14 +534,14 @@ QSharedPointer<DkColorManipulator> DkColorWidget::manipulator() const
 void DkColorWidget::createLayout()
 {
     DkColorPicker *cp = new DkColorPicker(this);
-    cp->setObjectName("colPicker");
+    connect(cp, &DkColorPicker::colorSelected, this, &DkColorWidget::onColPickerColorSelected);
 
     QVBoxLayout *l = new QVBoxLayout(this);
     l->setContentsMargins(0, 0, 0, 0);
     l->addWidget(cp);
 }
 
-void DkColorWidget::on_colPicker_colorSelected(const QColor &col)
+void DkColorWidget::onColPickerColorSelected(const QColor &col)
 {
     manipulator()->setColor(col);
 }
@@ -559,7 +551,6 @@ DkHueWidget::DkHueWidget(QSharedPointer<DkBaseManipulatorExt> manipulator, QWidg
     : DkBaseManipulatorWidget(manipulator, parent)
 {
     createLayout();
-    QMetaObject::connectSlotsByName(this);
 
     manipulator->setWidget(this);
 }
@@ -572,25 +563,25 @@ QSharedPointer<DkHueManipulator> DkHueWidget::manipulator() const
 void DkHueWidget::createLayout()
 {
     DkSlider *hueSlider = new DkSlider(tr("Hue"), this);
-    hueSlider->setObjectName("hueSlider");
     hueSlider->getSlider()->setObjectName("DkHueSlider");
     hueSlider->setValue(manipulator()->hue());
     hueSlider->setMinimum(-180);
     hueSlider->setMaximum(180);
+    connect(hueSlider, &DkSlider::valueChanged, this, &DkHueWidget::onHueSliderValueChanged);
 
     DkSlider *satSlider = new DkSlider(tr("Saturation"), this);
-    satSlider->setObjectName("satSlider");
     satSlider->getSlider()->setObjectName("DkSaturationSlider");
     satSlider->setValue(manipulator()->saturation());
     satSlider->setMinimum(-100);
     satSlider->setMaximum(100);
+    connect(satSlider, &DkSlider::valueChanged, this, &DkHueWidget::onSatSliderValueChanged);
 
     DkSlider *brightnessSlider = new DkSlider(tr("Brightness"), this);
-    brightnessSlider->setObjectName("brightnessSlider");
     brightnessSlider->getSlider()->setObjectName("DkBrightnessSlider");
     brightnessSlider->setValue(manipulator()->hue());
     brightnessSlider->setMinimum(-100);
     brightnessSlider->setMaximum(100);
+    connect(brightnessSlider, &DkSlider::valueChanged, this, &DkHueWidget::onBrightnessSliderValueChanged);
 
     QVBoxLayout *sliderLayout = new QVBoxLayout(this);
     sliderLayout->addWidget(hueSlider);
@@ -598,17 +589,17 @@ void DkHueWidget::createLayout()
     sliderLayout->addWidget(brightnessSlider);
 }
 
-void DkHueWidget::on_hueSlider_valueChanged(int val)
+void DkHueWidget::onHueSliderValueChanged(int val)
 {
     manipulator()->setHue(val);
 }
 
-void DkHueWidget::on_satSlider_valueChanged(int val)
+void DkHueWidget::onSatSliderValueChanged(int val)
 {
     manipulator()->setSaturation(val);
 }
 
-void DkHueWidget::on_brightnessSlider_valueChanged(int val)
+void DkHueWidget::onBrightnessSliderValueChanged(int val)
 {
     manipulator()->setValue(val);
 }
@@ -618,7 +609,6 @@ DkExposureWidget::DkExposureWidget(QSharedPointer<DkBaseManipulatorExt> manipula
     : DkBaseManipulatorWidget(manipulator, parent)
 {
     createLayout();
-    QMetaObject::connectSlotsByName(this);
 
     manipulator->setWidget(this);
 }
@@ -631,27 +621,27 @@ QSharedPointer<DkExposureManipulator> DkExposureWidget::manipulator() const
 void DkExposureWidget::createLayout()
 {
     DkDoubleSlider *exposureSlider = new DkDoubleSlider(tr("Exposure"), this);
-    exposureSlider->setObjectName("exposureSlider");
     exposureSlider->setMinimum(-3);
     exposureSlider->setMaximum(3);
     exposureSlider->setTickInterval(0.0005);
     exposureSlider->setValue(manipulator()->exposure());
+    connect(exposureSlider, &DkDoubleSlider::valueChanged, this, &DkExposureWidget::onExposureSliderValueChanged);
 
     DkDoubleSlider *offsetSlider = new DkDoubleSlider(tr("Offset"), this);
-    offsetSlider->setObjectName("offsetSlider");
     offsetSlider->setMinimum(-0.5);
     offsetSlider->setMaximum(0.5);
     offsetSlider->setTickInterval(0.001);
     offsetSlider->setValue(manipulator()->offset());
+    connect(offsetSlider, &DkDoubleSlider::valueChanged, this, &DkExposureWidget::onOffsetSliderValueChanged);
 
     DkDoubleSlider *gammaSlider = new DkDoubleSlider(tr("Gamma"), this);
-    gammaSlider->setObjectName("gammaSlider");
     gammaSlider->setMinimum(0);
     gammaSlider->setCenterValue(1);
     gammaSlider->setMaximum(10);
     gammaSlider->setTickInterval(0.001);
     gammaSlider->setSliderInverted(true);
     gammaSlider->setValue(manipulator()->gamma());
+    connect(gammaSlider, &DkDoubleSlider::valueChanged, this, &DkExposureWidget::onGammaSliderValueChanged);
 
     QVBoxLayout *sliderLayout = new QVBoxLayout(this);
     sliderLayout->addWidget(exposureSlider);
@@ -659,7 +649,7 @@ void DkExposureWidget::createLayout()
     sliderLayout->addWidget(gammaSlider);
 }
 
-void DkExposureWidget::on_exposureSlider_valueChanged(double val)
+void DkExposureWidget::onExposureSliderValueChanged(double val)
 {
     double tv = val * val;
     if (val < 0)
@@ -667,12 +657,12 @@ void DkExposureWidget::on_exposureSlider_valueChanged(double val)
     manipulator()->setExposure(tv);
 }
 
-void DkExposureWidget::on_offsetSlider_valueChanged(double val)
+void DkExposureWidget::onOffsetSliderValueChanged(double val)
 {
     manipulator()->setOffset(val);
 }
 
-void DkExposureWidget::on_gammaSlider_valueChanged(double val)
+void DkExposureWidget::onGammaSliderValueChanged(double val)
 {
     manipulator()->setGamma(val);
 }

--- a/ImageLounge/src/DkGui/DkManipulatorWidgets.h
+++ b/ImageLounge/src/DkGui/DkManipulatorWidgets.h
@@ -76,9 +76,9 @@ public:
     QSharedPointer<DkTinyPlanetManipulator> manipulator() const;
 
 public slots:
-    void on_scaleSlider_valueChanged(int val);
-    void on_angleSlider_valueChanged(int val);
-    void on_invertBox_toggled(bool val);
+    void onScaleSliderValueChanged(int val);
+    void onAngleSliderValueChanged(int val);
+    void onInvertBoxToggled(bool val);
 
 private:
     void createLayout();
@@ -94,7 +94,7 @@ public:
     QSharedPointer<DkBlurManipulator> manipulator() const;
 
 public slots:
-    void on_sigmaSlider_valueChanged(int val);
+    void onSigmaSliderValueChanged(int val);
 
 private:
     void createLayout();
@@ -110,8 +110,8 @@ public:
     QSharedPointer<DkUnsharpMaskManipulator> manipulator() const;
 
 public slots:
-    void on_sigmaSlider_valueChanged(int val);
-    void on_amountSlider_valueChanged(int val);
+    void onSigmaSliderValueChanged(int val);
+    void onAmountSliderValueChanged(int val);
 
 private:
     void createLayout();
@@ -127,7 +127,7 @@ public:
     QSharedPointer<DkRotateManipulator> manipulator() const;
 
 public slots:
-    void on_angleSlider_valueChanged(int val);
+    void onAngleSliderValueChanged(int val);
 
 private:
     void createLayout();
@@ -143,9 +143,9 @@ public:
     QSharedPointer<DkResizeManipulator> manipulator() const;
 
 public slots:
-    void on_scaleFactorSlider_valueChanged(double val);
-    void on_iplBox_currentIndexChanged(int idx);
-    void on_gammaCorrection_toggled(bool checked);
+    void onScaleFactorSliderValueChanged(double val);
+    void onIplBoxCurrentIndexChanged(int idx);
+    void onGammaCorrectionToggled(bool checked);
     void onObjectNameChanged(const QString &name);
 
 private:
@@ -164,8 +164,8 @@ public:
     QSharedPointer<DkThresholdManipulator> manipulator() const;
 
 public slots:
-    void on_thrSlider_valueChanged(int val);
-    void on_colBox_toggled(bool checked);
+    void onThrSliderValueChanged(int val);
+    void onColBoxToggled(bool checked);
 
 private:
     void createLayout();
@@ -181,9 +181,9 @@ public:
     QSharedPointer<DkHueManipulator> manipulator() const;
 
 public slots:
-    void on_hueSlider_valueChanged(int val);
-    void on_satSlider_valueChanged(int val);
-    void on_brightnessSlider_valueChanged(int val);
+    void onHueSliderValueChanged(int val);
+    void onSatSliderValueChanged(int val);
+    void onBrightnessSliderValueChanged(int val);
 
 private:
     void createLayout();
@@ -199,7 +199,7 @@ public:
     QSharedPointer<DkColorManipulator> manipulator() const;
 
 public slots:
-    void on_colPicker_colorSelected(const QColor &col);
+    void onColPickerColorSelected(const QColor &col);
 
 private:
     void createLayout();
@@ -215,9 +215,9 @@ public:
     QSharedPointer<DkExposureManipulator> manipulator() const;
 
 public slots:
-    void on_exposureSlider_valueChanged(double val);
-    void on_offsetSlider_valueChanged(double val);
-    void on_gammaSlider_valueChanged(double val);
+    void onExposureSliderValueChanged(double val);
+    void onOffsetSliderValueChanged(double val);
+    void onGammaSliderValueChanged(double val);
 
 private:
     void createLayout();

--- a/ImageLounge/src/DkGui/DkMetaDataWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkMetaDataWidgets.cpp
@@ -342,8 +342,6 @@ DkMetaDataDock::DkMetaDataDock(const QString &title, QWidget *parent /* = 0 */, 
 
     createLayout();
     readSettings();
-
-    QMetaObject::connectSlotsByName(this);
 }
 
 DkMetaDataDock::~DkMetaDataDock()
@@ -389,9 +387,9 @@ void DkMetaDataDock::readSettings()
 void DkMetaDataDock::createLayout()
 {
     mFilterEdit = new QLineEdit(this);
-    mFilterEdit->setObjectName("filter");
     mFilterEdit->setPlaceholderText(tr("Filter"));
     mFilterEdit->setFocusPolicy(Qt::ClickFocus);
+    connect(mFilterEdit, &QLineEdit::textChanged, this, &DkMetaDataDock::onFilterTextChanged);
 
     // create our beautiful shortcut view
     mModel = new DkMetaDataModel(this);
@@ -426,7 +424,7 @@ void DkMetaDataDock::createLayout()
     setWidget(widget);
 }
 
-void DkMetaDataDock::on_filter_textChanged(const QString &filterText)
+void DkMetaDataDock::onFilterTextChanged(const QString &filterText)
 {
     if (!filterText.isEmpty())
         mTreeView->expandAll();
@@ -1165,7 +1163,6 @@ DkCommentWidget::DkCommentWidget(QWidget *parent /* = 0 */, Qt::WindowFlags /* =
 {
     setMaximumSize(220, 150);
     createLayout();
-    QMetaObject::connectSlotsByName(this);
 }
 
 void DkCommentWidget::createLayout()
@@ -1184,24 +1181,25 @@ void DkCommentWidget::createLayout()
         + QString("QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical {height: 0;}");
 
     mCommentLabel = new DkCommentTextEdit(this);
-    mCommentLabel->setObjectName("CommentLabel");
     mCommentLabel->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
     mCommentLabel->setStyleSheet(scrollbarStyle + mCommentLabel->styleSheet());
     mCommentLabel->setToolTip(tr("Enter your notes here. They will be saved to the image metadata."));
+    connect(mCommentLabel, &DkCommentTextEdit::textChanged, this, &DkCommentWidget::onCommentLabelTextChanged);
+    connect(mCommentLabel, &DkCommentTextEdit::focusLost, this, &DkCommentWidget::onCommentLabelFocusLost);
 
     QPushButton *saveButton = new QPushButton(this);
-    saveButton->setObjectName("saveButton");
     saveButton->setFlat(true);
     saveButton->setIcon(DkImage::loadIcon(":/nomacs/img/save.svg", QSize(), DkSettingsManager::param().display().hudFgdColor));
     saveButton->setToolTip(tr("Save Note (CTRL + ENTER)"));
     saveButton->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_Return));
+    connect(saveButton, &QPushButton::clicked, this, &DkCommentWidget::onSaveButtonClicked);
 
     QPushButton *cancelButton = new QPushButton(this);
-    cancelButton->setObjectName("cancelButton");
     cancelButton->setFlat(true);
     cancelButton->setIcon(DkImage::loadIcon(":/nomacs/img/trash.svg", QSize(), DkSettingsManager::param().display().hudFgdColor));
     cancelButton->setToolTip(tr("Discard Changes (ESC)"));
     cancelButton->setShortcut(QKeySequence(Qt::Key_Escape));
+    connect(cancelButton, &QPushButton::clicked, this, &DkCommentWidget::onCancelButtonClicked);
 
     QWidget *titleWidget = new QWidget(this);
     QHBoxLayout *titleLayout = new QHBoxLayout(titleWidget);
@@ -1264,25 +1262,25 @@ void DkCommentWidget::saveComment()
     }
 }
 
-void DkCommentWidget::on_CommentLabel_textChanged()
+void DkCommentWidget::onCommentLabelTextChanged()
 {
     mTextEdited = text() != mOldText;
     if (mTextEdited)
         emit commentEditedSignal();
 }
 
-void DkCommentWidget::on_CommentLabel_focusLost()
+void DkCommentWidget::onCommentLabelFocusLost()
 {
     // We don't want to do anything when changing focus
 }
 
-void DkCommentWidget::on_saveButton_clicked()
+void DkCommentWidget::onSaveButtonClicked()
 {
     saveComment();
     mCommentLabel->clearFocus();
 }
 
-void DkCommentWidget::on_cancelButton_clicked()
+void DkCommentWidget::onCancelButtonClicked()
 {
     resetComment();
 }

--- a/ImageLounge/src/DkGui/DkMetaDataWidgets.h
+++ b/ImageLounge/src/DkGui/DkMetaDataWidgets.h
@@ -106,7 +106,7 @@ public:
 public slots:
     void setImage(QSharedPointer<DkImageContainerT> imgC);
     void thumbLoaded(bool loaded);
-    void on_filter_textChanged(const QString &filterText);
+    void onFilterTextChanged(const QString &filterText);
 
 protected:
     void createLayout();
@@ -252,10 +252,10 @@ public:
     QString text() const;
 
 public slots:
-    void on_CommentLabel_textChanged();
-    void on_CommentLabel_focusLost();
-    void on_saveButton_clicked();
-    void on_cancelButton_clicked();
+    void onCommentLabelTextChanged();
+    void onCommentLabelFocusLost();
+    void onSaveButtonClicked();
+    void onCancelButtonClicked();
 
     void initComment(const QString &description);
     void resetComment();

--- a/ImageLounge/src/DkGui/DkPreferenceWidgets.h
+++ b/ImageLounge/src/DkGui/DkPreferenceWidgets.h
@@ -145,30 +145,30 @@ public:
     DkGeneralPreference(QWidget *parent = 0);
 
 public slots:
-    void on_themeBox_currentIndexChanged(const QString &text) const;
-    void on_showRecentFiles_toggled(bool checked) const;
-    void on_logRecentFiles_toggled(bool checked) const;
-    void on_checkOpenDuplicates_toggled(bool checked) const;
-    void on_extendedTabs_toggled(bool checked) const;
-    void on_closeOnEsc_toggled(bool checked) const;
-    void on_closeOnMiddleMouse_toggled(bool checked) const;
-    void on_zoomOnWheel_toggled(bool checked) const;
-    void on_horZoomSkips_toggled(bool checked) const;
-    void on_doubleClickForFullscreen_toggled(bool checked) const;
-    void on_showBgImage_toggled(bool checked) const;
-    void on_checkForUpdates_toggled(bool checked) const;
-    void on_switchModifier_toggled(bool checked) const;
-    void on_loopImages_toggled(bool checked) const;
-    void on_defaultSettings_clicked();
-    void on_importSettings_clicked();
-    void on_exportSettings_clicked();
-    void on_languageCombo_currentIndexChanged(int index) const;
+    void onThemeBoxCurrentTextChanged(const QString &text) const;
+    void onShowRecentFilesToggled(bool checked) const;
+    void onLogRecentFilesToggled(bool checked) const;
+    void onCheckOpenDuplicatesToggled(bool checked) const;
+    void onExtendedTabsToggled(bool checked) const;
+    void onCloseOnEscToggled(bool checked) const;
+    void onCloseOnMiddleMouseToggled(bool checked) const;
+    void onZoomOnWheelToggled(bool checked) const;
+    void onHorZoomSkipsToggled(bool checked) const;
+    void onDoubleClickForFullscreenToggled(bool checked) const;
+    void onShowBgImageToggled(bool checked) const;
+    void onCheckForUpdatesToggled(bool checked) const;
+    void onSwitchModifierToggled(bool checked) const;
+    void onLoopImagesToggled(bool checked) const;
+    void onDefaultSettingsClicked();
+    void onImportSettingsClicked();
+    void onExportSettingsClicked();
+    void onLanguageComboCurrentIndexChanged(int index) const;
     void showRestartLabel() const;
 
-    void on_backgroundColor_accepted() const;
-    void on_backgroundColor_resetClicked() const;
-    void on_iconColor_accepted() const;
-    void on_iconColor_resetClicked() const;
+    void onBackgroundColorAccepted() const;
+    void onBackgroundColorResetClicked() const;
+    void onIconColorAccepted() const;
+    void onIconColorResetClicked() const;
 
 signals:
     void infoSignal(const QString &msg) const;
@@ -188,23 +188,23 @@ public:
     DkDisplayPreference(QWidget *parent = 0);
 
 public slots:
-    void on_interpolationBox_valueChanged(int value) const;
-    void on_iconSizeBox_valueChanged(int value) const;
-    void on_fadeImageBox_valueChanged(double value) const;
-    void on_displayTimeBox_valueChanged(double value) const;
-    void on_showPlayer_toggled(bool checked) const;
-    void on_keepZoom_buttonClicked(int buttonId) const;
-    void on_invertZoom_toggled(bool checked) const;
-    void on_hQAntiAliasing_toggled(bool checked) const;
-    void on_zoomToFit_toggled(bool checked) const;
-    void on_transition_currentIndexChanged(int index) const;
-    void on_alwaysAnimate_toggled(bool checked) const;
-    void on_showCrop_toggled(bool checked) const;
-    void on_showScrollBars_toggled(bool checked) const;
-    void on_useZoomLevels_toggled(bool checked) const;
-    void on_showNavigation_toggled(bool checked) const;
-    void on_zoomLevels_editingFinished() const;
-    void on_zoomLevelsDefault_clicked() const;
+    void onInterpolationBoxValueChanged(int value) const;
+    void onIconSizeBoxValueChanged(int value) const;
+    void onFadeImageBoxValueChanged(double value) const;
+    void onDisplayTimeBoxValueChanged(double value) const;
+    void onShowPlayerToggled(bool checked) const;
+    void onKeepZoomButtonClicked(int buttonId) const;
+    void onInvertZoomToggled(bool checked) const;
+    void onHQAntiAliasingToggled(bool checked) const;
+    void onZoomToFitToggled(bool checked) const;
+    void onTransitionCurrentIndexChanged(int index) const;
+    void onAlwaysAnimateToggled(bool checked) const;
+    void onShowCropToggled(bool checked) const;
+    void onShowScrollBarsToggled(bool checked) const;
+    void onUseZoomLevelsToggled(bool checked) const;
+    void onShowNavigationToggled(bool checked) const;
+    void onZoomLevelsEditingFinished() const;
+    void onZoomLevelsDefaultClicked() const;
 
 signals:
     void infoSignal(const QString &msg) const;
@@ -225,12 +225,12 @@ public:
     DkFilePreference(QWidget *parent = 0);
 
 public slots:
-    void on_dirChooser_directoryChanged(const QString &dirPath) const;
-    void on_loadGroup_buttonClicked(int buttonId) const;
-    void on_skipBox_valueChanged(int value) const;
-    void on_cacheBox_valueChanged(int value) const;
-    void on_historyBox_valueChanged(int value) const;
-    void on_saveGroup_buttonClicked(int buttonId) const;
+    void onDirChooserDirectoryChanged(const QString &dirPath) const;
+    void onLoadGroupButtonClicked(int buttonId) const;
+    void onSkipBoxValueChanged(int value) const;
+    void onCacheBoxValueChanged(int value) const;
+    void onHistoryBoxValueChanged(int value) const;
+    void onSaveGroupButtonClicked(int buttonId) const;
 
 signals:
     void infoSignal(const QString &msg) const;
@@ -248,9 +248,9 @@ public:
     DkFileAssociationsPreference(QWidget *parent = 0);
     virtual ~DkFileAssociationsPreference();
 public slots:
-    void on_fileModel_itemChanged(QStandardItem *);
-    void on_openDefault_clicked() const;
-    void on_associateFiles_clicked();
+    void onFileModelItemChanged(QStandardItem *);
+    void onOpenDefaultClicked() const;
+    void onAssociateFilesClicked();
 
 signals:
     void infoSignal(const QString &msg) const;
@@ -275,15 +275,15 @@ public:
     DkAdvancedPreference(QWidget *parent = 0);
 
 public slots:
-    void on_loadRaw_buttonClicked(int buttonId) const;
-    void on_filterRaw_toggled(bool checked) const;
-    void on_saveDeleted_toggled(bool checked) const;
-    void on_ignoreExif_toggled(bool checked) const;
-    void on_saveExif_toggled(bool checked) const;
-    void on_useLog_toggled(bool checked) const;
-    void on_useNative_toggled(bool checked) const;
-    void on_logFolder_clicked() const;
-    void on_numThreads_valueChanged(int val) const;
+    void onLoadRawButtonClicked(int buttonId) const;
+    void onFilterRawToggled(bool checked) const;
+    void onSaveDeletedToggled(bool checked) const;
+    void onIgnoreExifToggled(bool checked) const;
+    void onSaveExifToggled(bool checked) const;
+    void onUseLogToggled(bool checked) const;
+    void onUseNativeToggled(bool checked) const;
+    void onLogFolderClicked() const;
+    void onNumThreadsValueChanged(int val) const;
 
 signals:
     void infoSignal(const QString &msg) const;

--- a/ImageLounge/src/DkGui/DkSettingsWidget.cpp
+++ b/ImageLounge/src/DkGui/DkSettingsWidget.cpp
@@ -46,8 +46,6 @@ DkSettingsWidget::DkSettingsWidget(QWidget *parent)
     : DkWidget(parent)
 {
     createLayout();
-
-    QMetaObject::connectSlotsByName(this);
 }
 
 void DkSettingsWidget::setSettingsPath(const QString &settingsPath, const QString &parentName)
@@ -108,17 +106,17 @@ void DkSettingsWidget::removeSetting(QSettings &settings, const QString &key, co
         settings.endGroup();
 }
 
-void DkSettingsWidget::on_SettingsModel_settingChanged(const QString &key, const QVariant &value, const QStringList &groups)
+void DkSettingsWidget::onSettingsModelSettingChanged(const QString &key, const QVariant &value, const QStringList &groups)
 {
     emit changeSettingSignal(key, value, groups);
 }
 
-void DkSettingsWidget::on_SettingsModel_settingRemoved(const QString &key, const QStringList &groups)
+void DkSettingsWidget::onSettingsModelSettingRemoved(const QString &key, const QStringList &groups)
 {
     emit removeSettingSignal(key, groups);
 }
 
-void DkSettingsWidget::on_removeRows_triggered()
+void DkSettingsWidget::onRemoveRowsTriggered()
 {
     QModelIndexList selList = mTreeView->selectionModel()->selectedRows();
     for (const QModelIndex index : selList) {
@@ -130,12 +128,13 @@ void DkSettingsWidget::on_removeRows_triggered()
 void DkSettingsWidget::createLayout()
 {
     mSettingsFilter = new QLineEdit(this);
-    mSettingsFilter->setObjectName("Filter");
     mSettingsFilter->setPlaceholderText(tr("Filter Settings"));
+    connect(mSettingsFilter, &QLineEdit::textChanged, this, &DkSettingsWidget::onFilterTextChanged);
 
     // create our beautiful shortcut view
     mSettingsModel = new DkSettingsModel(this);
-    mSettingsModel->setObjectName("SettingsModel");
+    connect(mSettingsModel, &DkSettingsModel::settingChanged, this, &DkSettingsWidget::onSettingsModelSettingChanged);
+    connect(mSettingsModel, &DkSettingsModel::settingRemoved, this, &DkSettingsWidget::onSettingsModelSettingRemoved);
 
     mProxyModel = new DkSettingsProxyModel(this);
     mProxyModel->setSourceModel(mSettingsModel);
@@ -158,9 +157,9 @@ void DkSettingsWidget::createLayout()
     mTreeView->setContextMenuPolicy(Qt::ActionsContextMenu);
 
     QAction *removeAction = new QAction(tr("Delete"), contextMenu);
-    removeAction->setObjectName("removeRows");
     removeAction->setShortcut(QKeySequence::Delete);
     mTreeView->addAction(removeAction);
+    connect(removeAction, &QAction::triggered, this, &DkSettingsWidget::onRemoveRowsTriggered);
 }
 
 void DkSettingsWidget::filter(const QString &filterText)
@@ -177,7 +176,7 @@ void DkSettingsWidget::expandAll()
     mTreeView->expandAll();
 }
 
-void DkSettingsWidget::on_Filter_textChanged(const QString &filterText)
+void DkSettingsWidget::onFilterTextChanged(const QString &filterText)
 {
     filter(filterText);
 }

--- a/ImageLounge/src/DkGui/DkSettingsWidget.h
+++ b/ImageLounge/src/DkGui/DkSettingsWidget.h
@@ -163,11 +163,10 @@ signals:
     void removeSettingSignal(const QString &key, const QStringList &groups);
 
 public slots:
-    // void focusFilter();
-    void on_Filter_textChanged(const QString &text);
-    void on_SettingsModel_settingChanged(const QString &key, const QVariant &value, const QStringList &groups);
-    void on_SettingsModel_settingRemoved(const QString &key, const QStringList &groups);
-    void on_removeRows_triggered();
+    void onFilterTextChanged(const QString &text);
+    void onSettingsModelSettingChanged(const QString &key, const QVariant &value, const QStringList &groups);
+    void onSettingsModelSettingRemoved(const QString &key, const QStringList &groups);
+    void onRemoveRowsTriggered();
 
 protected:
     void createLayout();

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -1760,6 +1760,7 @@ void DkThumbsView::fetchThumbs()
 DkThumbScrollWidget::DkThumbScrollWidget(QWidget *parent /* = 0 */, Qt::WindowFlags flags /* = 0 */)
     : DkFadeWidget(parent, flags)
 {
+    // TODO: is this name required elsewhere?
     setObjectName("DkThumbScrollWidget");
     setContentsMargins(0, 0, 0, 0);
 
@@ -1780,8 +1781,6 @@ DkThumbScrollWidget::DkThumbScrollWidget(QWidget *parent /* = 0 */, Qt::WindowFl
     setLayout(layout);
 
     enableSelectionActions();
-
-    QMetaObject::connectSlotsByName(this);
 }
 
 void DkThumbScrollWidget::createToolbar()
@@ -1847,8 +1846,8 @@ void DkThumbScrollWidget::createActions()
 
     // add a shortcut to open the selected image
     QAction *loadFile = new QAction(tr("Open Image"), this);
-    loadFile->setObjectName("loadFile");
     loadFile->setShortcut(Qt::Key_Return);
+    connect(loadFile, &QAction::triggered, this, &DkThumbScrollWidget::onLoadFileTriggered);
 
     addAction(loadFile);
 }
@@ -1882,7 +1881,7 @@ void DkThumbScrollWidget::batchPrint() const
     printPreviewDialog->deleteLater();
 }
 
-void DkThumbScrollWidget::on_loadFile_triggered()
+void DkThumbScrollWidget::onLoadFileTriggered()
 {
     auto selected = mThumbsScene->selectedItems();
 
@@ -2055,7 +2054,6 @@ DkRecentDirWidget::DkRecentDirWidget(const DkRecentDir &rde, QWidget *parent)
     mRecentDir = rde;
 
     createLayout();
-    QMetaObject::connectSlotsByName(this);
 }
 
 void DkRecentDirWidget::createLayout()
@@ -2072,6 +2070,7 @@ void DkRecentDirWidget::createLayout()
     mButtons[button_load_dir]->setObjectName("load_dir");
     mButtons[button_load_dir]->setFlat(true);
     mButtons[button_load_dir]->hide();
+    connect(mButtons[button_load_dir], &QPushButton::clicked, this, &DkRecentDirWidget::onLoadDirClicked);
 
     QIcon pIcon;
     pIcon.addPixmap(DkImage::loadIcon(":/nomacs/img/pin-checked.svg"), QIcon::Normal, QIcon::On);
@@ -2084,12 +2083,14 @@ void DkRecentDirWidget::createLayout()
     mButtons[button_pin]->setChecked(mRecentDir.isPinned());
     mButtons[button_pin]->setFlat(true);
     mButtons[button_pin]->hide();
+    connect(mButtons[button_pin], &QPushButton::clicked, this, &DkRecentDirWidget::onPinClicked);
 
     mButtons[button_remove] = new QPushButton(DkImage::loadIcon(":/nomacs/img/close.svg"), "", this);
     mButtons[button_remove]->setToolTip(tr("Remove this directory"));
     mButtons[button_remove]->setObjectName("remove");
     mButtons[button_remove]->setFlat(true);
     mButtons[button_remove]->hide();
+    connect(mButtons[button_remove], &QPushButton::clicked, this, &DkRecentDirWidget::onRemoveClicked);
 
     QVector<DkThumbPreviewLabel *> tls;
 
@@ -2128,7 +2129,7 @@ void DkRecentDirWidget::createLayout()
     setStatusTip(mRecentDir.dirPath());
 }
 
-void DkRecentDirWidget::on_pin_clicked(bool checked)
+void DkRecentDirWidget::onPinClicked(bool checked)
 {
     if (checked) {
         DkSettingsManager::param().global().pinnedFiles << mRecentDir.filePaths();
@@ -2138,13 +2139,13 @@ void DkRecentDirWidget::on_pin_clicked(bool checked)
     }
 }
 
-void DkRecentDirWidget::on_remove_clicked()
+void DkRecentDirWidget::onRemoveClicked()
 {
     mRecentDir.remove();
     emit removeSignal();
 }
 
-void DkRecentDirWidget::on_load_dir_clicked()
+void DkRecentDirWidget::onLoadDirClicked()
 {
     emit loadDirSignal(mRecentDir.dirPath());
 }

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.h
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.h
@@ -338,7 +338,7 @@ public slots:
     void setFilterFocus() const;
     void batchProcessFiles() const;
     void batchPrint() const;
-    void on_loadFile_triggered();
+    void onLoadFileTriggered();
 
 signals:
     void updateDirSignal(const QString &dir);
@@ -429,9 +429,9 @@ signals:
     void removeSignal();
 
 public slots:
-    void on_pin_clicked(bool checked);
-    void on_remove_clicked();
-    void on_load_dir_clicked();
+    void onPinClicked(bool checked);
+    void onRemoveClicked();
+    void onLoadDirClicked();
 
 protected:
     DkRecentDir mRecentDir;

--- a/ImageLounge/src/DkGui/DkToolbars.cpp
+++ b/ImageLounge/src/DkGui/DkToolbars.cpp
@@ -939,9 +939,8 @@ void DkCropToolBar::createLayout()
 
     mVerValBox = new QDoubleSpinBox(this);
     mVerValBox->setSpecialValueText("  ");
-    // FIXME: the following is wrong
-    mHorValBox->setToolTip(tr("Vertical Constraint"));
-    mHorValBox->setStatusTip(mHorValBox->toolTip());
+    mVerValBox->setToolTip(tr("Vertical Constraint"));
+    mVerValBox->setStatusTip(mVerValBox->toolTip());
     connect(mVerValBox, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, &DkCropToolBar::onVerValBoxValueChanged);
 
     mAngleBox = new QDoubleSpinBox(this);

--- a/ImageLounge/src/DkGui/DkToolbars.h
+++ b/ImageLounge/src/DkGui/DkToolbars.h
@@ -272,18 +272,18 @@ public:
 public slots:
     void setAspectRatio(const QPointF &aRatio);
     void setRect(const QRect &r);
-    void on_cropAction_triggered();
-    void on_cancelAction_triggered();
-    void on_swapAction_triggered();
-    void on_ratioBox_currentIndexChanged(const QString &text);
-    void on_guideBox_currentIndexChanged(int idx);
-    void on_horValBox_valueChanged(double val);
-    void on_verValBox_valueChanged(double val);
-    void on_angleBox_valueChanged(double val);
-    void on_bgColButton_clicked();
-    void on_panAction_toggled(bool checked);
-    void on_invertAction_toggled(bool checked);
-    void on_infoAction_toggled(bool checked);
+    void onCropActionTriggered();
+    void onCancelActionTriggered();
+    void onSwapActionTriggered();
+    void onRatioBoxCurrentIndexChanged(const QString &text);
+    void onGuideBoxCurrentIndexChanged(int idx);
+    void onHorValBoxValueChanged(double val);
+    void onVerValBoxValueChanged(double val);
+    void onAngleBoxValueChanged(double val);
+    void onBgColButtonClicked();
+    void onPanActionToggled(bool checked);
+    void onInvertActionToggled(bool checked);
+    void onInfoActionToggled(bool checked);
     void angleChanged(double val);
     virtual void setVisible(bool visible) override;
 

--- a/ImageLounge/src/DkGui/DkWidgets.h
+++ b/ImageLounge/src/DkGui/DkWidgets.h
@@ -533,8 +533,8 @@ public slots:
     virtual void setVisible(bool visible, bool autoHide = false);
 
     void updateZoom(double zoomLevel);
-    void on_sbZoom_valueChanged(double zoomLevel);
-    void on_slZoom_valueChanged(int zoomLevel);
+    void onSbZoomValueChanged(double zoomLevel);
+    void onSlZoomValueChanged(int zoomLevel);
 
 protected:
     void createLayout();
@@ -714,7 +714,7 @@ public:
     void setPainted(bool isPainted);
 
 public slots:
-    void on_toggleStats_triggered(bool show);
+    void onToggleStatsTriggered(bool show);
 
 protected:
     virtual void mousePressEvent(QMouseEvent *event) override;
@@ -810,7 +810,7 @@ public:
     DkDirectoryChooser(const QString &dirPath = "", QWidget *parent = 0);
 
 public slots:
-    void on_dirButton_clicked();
+    void onDirButtonClicked();
 
 signals:
     void directoryChanged(const QString &dirPath) const;


### PR DESCRIPTION

Issues have been found when migrating from Qt5 to Qt6 due to overloaded signals were separated into different names. These were unnoticed because nomacs use `QMetaObject::connectSlotsByName()` to simplify many signal slot connections, which only warns in runtime. See https://github.com/nomacs/nomacs/issues/1093

 Remove all the `QMetaObject::connectSlotsByName()` calls and manually    connect the signals to make things explicit and allow compile time check    of the signatures, so similar problems can be catched early in the    future. The slots are renamed so that they do not follow Qt connectSlotsB    rules anymore. Any signature changes in the signals from Qt5 to Qt6 were    fixed to pass compiler.

Closes https://github.com/nomacs/nomacs/issues/1093
Fixes https://github.com/nomacs/nomacs/issues/1062
Fixes https://github.com/nomacs/nomacs/issues/1076