### PR TITLE
Fix infinite loop when scanning subfolder

### DIFF
--- a/ImageLounge/src/DkCore/DkImageLoader.h
+++ b/ImageLounge/src/DkCore/DkImageLoader.h
@@ -76,7 +76,7 @@ public:
     QFileInfoList getFilteredFileInfoList(const QString &dirPath,
                                           QStringList ignoreKeywords = QStringList(),
                                           QStringList keywords = QStringList(),
-                                          QString folderKeywords = QString());
+                                          QString folderKeywords = QString()) const;
 
     void rotateImage(double angle);
     QSharedPointer<DkImageContainerT> getCurrentImage() const;
@@ -97,7 +97,7 @@ public:
     void lastFile();
     void clearPath();
     void loadLastDir();
-    QSharedPointer<DkImageContainerT> getSkippedImage(int skipIdx, bool searchFile = true, bool recursive = false);
+    QSharedPointer<DkImageContainerT> getSkippedImage(int skipIdx, bool recursive = false, int currFileIdx=0);
 
     QString getDirPath() const;
     QString getSavePath() const;
@@ -184,8 +184,7 @@ public slots:
 protected:
     // functions
     void updateCacher(QSharedPointer<DkImageContainerT> imgC);
-    int getNextFolderIdx(int folderIdx);
-    int getPrevFolderIdx(int folderIdx);
+    int getSubFolderIdx(int fromIdx, bool forward) const;
     void updateHistory();
     void sortImagesThreaded(QVector<QSharedPointer<DkImageContainerT>> images);
     void createImages(const QFileInfoList &files, bool sort = true);
@@ -206,7 +205,6 @@ protected:
     QSharedPointer<DkImageContainerT> mCurrentImage;
     QSharedPointer<DkImageContainerT> mLastImageLoaded;
     bool mFolderUpdated = false;
-    int mTmpFileIdx = 0;
     bool mSortingImages = false;
     bool mSortingIsDirty = false;
     QFutureWatcher<QVector<QSharedPointer<DkImageContainerT>>> mCreateImageWatcher;


### PR DESCRIPTION
With subfolder scanning enabled, if you have a folder structure where each subfolder contains exactly one loadable file then trying to skip backward/negative by 1 causes an infinite loop. Besides that corner case, the sequencing is incorrect in general, often skipping over the files.

This was a hard one to figure out. I added a lot of comments to the code and refactored and renamed a few things to help understand whats happening. I am attaching some test files I used to validate the feature.

There are still issues with zip files which should be simpler to address with future changes I have planned.

I went through the issue tracker and didn't find anything relating to this. Most are concerned with lack of recursion on the thumbnail pane  or filters.

[subfolders-bug.zip](https://github.com/user-attachments/files/15779160/subfolders-bug.zip)
