### PR TITLE
Enable HiDPI support in Qt and fixup the main view

### DIFF
--- a/ImageLounge/src/DkCore/DkSaveDialog.cpp
+++ b/ImageLounge/src/DkCore/DkSaveDialog.cpp
@@ -404,8 +404,12 @@ void DkCompressDialog::drawPreview()
     } else
         updateFileSizeLabel();
 
-    // previewLabel->setScaledContents(true);
-    QImage img = mNewImg.scaled(mPreviewLabel->size(), Qt::KeepAspectRatio, Qt::FastTransformation);
+    qreal deviceScale = devicePixelRatioF();
+
+    QImage img = mNewImg.scaled(mPreviewLabel->size()*deviceScale, Qt::KeepAspectRatio, Qt::FastTransformation);
+
+    img.setDevicePixelRatio(devicePixelRatioF());
+
     mPreviewLabel->setPixmap(QPixmap::fromImage(img));
 }
 

--- a/ImageLounge/src/DkGui/DkDialog.cpp
+++ b/ImageLounge/src/DkGui/DkDialog.cpp
@@ -1402,8 +1402,14 @@ void DkResizeDialog::drawPreview()
     // TODO: thread here!
     QImage img = resizeImg(newImg);
 
+    qreal deviceScale = devicePixelRatioF();
+
     // TODO: is there a better way of mapping the pixels? (ipl here introduces artifacts that are not in the final image)
-    img = img.scaled(mPreviewLabel->size(), Qt::KeepAspectRatio, Qt::FastTransformation);
+    img = img.scaled(mOrigView->size()*deviceScale, Qt::KeepAspectRatio, Qt::FastTransformation);
+
+    // HiDPI: pixmap inherits this; painter uses it
+    img.setDevicePixelRatio(deviceScale);
+
     mPreviewLabel->setPixmap(QPixmap::fromImage(img));
 }
 

--- a/ImageLounge/src/main.cpp
+++ b/ImageLounge/src/main.cpp
@@ -93,8 +93,6 @@ int main(int argc, char *argv[])
     QCoreApplication::setApplicationName("Image Lounge");
     QCoreApplication::setApplicationVersion(NOMACS_VERSION_STR);
 
-    QApplication::setAttribute(Qt::AA_DisableHighDpiScaling, true);
-
     QApplication app(argc, (char **)argv);
 
 #ifdef Q_OS_LINUX


### PR DESCRIPTION
We want to enable HiDPI in Qt so that the UI is properly scaled for different display resolutions. The following changes are a first step in that direction:

- Do not disable Qt's internal HiDPI scaling; we should be relying on it for everything besides image/thumbnail display.
- Main view adjusts for scaling so 100% is actual pixels
- QT_SCALE_FACTOR works correctly; 100% is still actual pixels
- Dialogs using main view logic also adjusted

Remaining issues:
- old device-scaling/dpi logic can be refactored or removed
- Icons and thumbnail resolution are incorrect
- Plugins must be patched as well (patch forthcoming)
