### PR TITLE
Remove text based connections

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -50,7 +50,8 @@ jobs:
           ninja -j3
 
   check:
-    runs-on: ubuntu-latest
+    # Need to use newer clang-format
+    runs-on: ubuntu-24.04
     if: github.event_name == 'pull_request'
     steps:
       - name: PR commits + 1
@@ -67,11 +68,10 @@ jobs:
           git fetch origin ${{ github.event.pull_request.base.sha }}
 
       - name: Install dependencies
-        # Need to use version above 15 to have non-zero return code
         run: |
-          sudo apt-get install -y clang-format-15
+          sudo apt-get install -y clang-format
 
       - name: Check clang-format
         run: |
           cd ${GITHUB_WORKSPACE}
-          git clang-format-15 --diff ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} 
+          git clang-format --diff ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} 2>&1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,3 +67,6 @@ private:
   QAction* action = 0;
 };
 ```
+
+- Avoid using `SIGNAL` and `SLOT` macros in favor of function pointers.
+  They enable compile time check of the signal and slot names and signature.

--- a/ImageLounge/src/DkCore/DkActionManager.cpp
+++ b/ImageLounge/src/DkCore/DkActionManager.cpp
@@ -81,7 +81,7 @@ DkAppManager::DkAppManager(QWidget *parent)
 
     for (int idx = 0; idx < mApps.size(); idx++) {
         assignIcon(mApps.at(idx));
-        connect(mApps.at(idx), SIGNAL(triggered()), this, SLOT(openTriggered()));
+        connect(mApps.at(idx), &QAction::triggered, this, &DkAppManager::openTriggered);
     }
 }
 
@@ -159,7 +159,7 @@ QAction *DkAppManager::createAction(const QString &filePath)
     QAction *newApp = new QAction(file.baseName(), parent());
     newApp->setToolTip(QDir::fromNativeSeparators(file.filePath()));
     assignIcon(newApp);
-    connect(newApp, SIGNAL(triggered()), this, SLOT(openTriggered()));
+    connect(newApp, &QAction::triggered, this, &DkAppManager::openTriggered);
 
     return newApp;
 }

--- a/ImageLounge/src/DkCore/DkBaseViewPort.cpp
+++ b/ImageLounge/src/DkCore/DkBaseViewPort.cpp
@@ -40,6 +40,7 @@
 #include <QShortcut>
 #include <QSvgRenderer>
 #include <QTimer>
+#include <QtGlobal>
 
 // gestures
 #include <QSwipeGesture>
@@ -69,8 +70,8 @@ DkBaseViewPort::DkBaseViewPort(QWidget *parent)
 
     mZoomTimer = new QTimer(this);
     mZoomTimer->setSingleShot(true);
-    connect(mZoomTimer, SIGNAL(timeout()), this, SLOT(stopBlockZooming()));
-    connect(&mImgStorage, SIGNAL(imageUpdated()), this, SLOT(update()));
+    connect(mZoomTimer, &QTimer::timeout, this, &DkBaseViewPort::stopBlockZooming);
+    connect(&mImgStorage, &DkImageStorage::imageUpdated, this, QOverload<>::of(&DkBaseViewPort::update));
 
     mPattern.setTexture(QPixmap(":/nomacs/img/tp-pattern.png"));
 
@@ -89,17 +90,17 @@ DkBaseViewPort::DkBaseViewPort(QWidget *parent)
 
     // connect pan actions
     const DkActionManager &am = DkActionManager::instance();
-    connect(am.action(DkActionManager::sc_pan_left), SIGNAL(triggered()), this, SLOT(panLeft()));
-    connect(am.action(DkActionManager::sc_pan_right), SIGNAL(triggered()), this, SLOT(panRight()));
-    connect(am.action(DkActionManager::sc_pan_up), SIGNAL(triggered()), this, SLOT(panUp()));
-    connect(am.action(DkActionManager::sc_pan_down), SIGNAL(triggered()), this, SLOT(panDown()));
+    connect(am.action(DkActionManager::sc_pan_left), &QAction::triggered, this, &DkBaseViewPort::panLeft);
+    connect(am.action(DkActionManager::sc_pan_right), &QAction::triggered, this, &DkBaseViewPort::panRight);
+    connect(am.action(DkActionManager::sc_pan_up), &QAction::triggered, this, &DkBaseViewPort::panUp);
+    connect(am.action(DkActionManager::sc_pan_down), &QAction::triggered, this, &DkBaseViewPort::panDown);
 
-    connect(verticalScrollBar(), SIGNAL(valueChanged(int)), this, SLOT(scrollVertically(int)));
-    connect(horizontalScrollBar(), SIGNAL(valueChanged(int)), this, SLOT(scrollHorizontally(int)));
+    connect(verticalScrollBar(), &QScrollBar::valueChanged, this, &DkBaseViewPort::scrollVertically);
+    connect(horizontalScrollBar(), &QScrollBar::valueChanged, this, &DkBaseViewPort::scrollHorizontally);
 
     mHideCursorTimer = new QTimer(this);
     mHideCursorTimer->setInterval(1000);
-    connect(mHideCursorTimer, SIGNAL(timeout()), this, SLOT(hideCursor()));
+    connect(mHideCursorTimer, &QTimer::timeout, this, &DkBaseViewPort::hideCursor);
 }
 
 DkBaseViewPort::~DkBaseViewPort()

--- a/ImageLounge/src/DkCore/DkBasicLoader.cpp
+++ b/ImageLounge/src/DkCore/DkBasicLoader.cpp
@@ -1809,7 +1809,7 @@ FileDownloader::FileDownloader(const QUrl &imageUrl, const QString &filePath, QO
         mWebCtrl.setProxy(listOfProxies[0]);
     }
 
-    connect(&mWebCtrl, SIGNAL(finished(QNetworkReply *)), SLOT(fileDownloaded(QNetworkReply *)));
+    connect(&mWebCtrl, &QNetworkAccessManager::finished, this, &FileDownloader::fileDownloaded);
 
     downloadFile(imageUrl);
 }
@@ -1870,7 +1870,7 @@ void FileDownloader::fileDownloaded(QNetworkReply *pReply)
     }
     // ok save it
     else {
-        connect(&mSaveWatcher, SIGNAL(finished()), this, SLOT(saved()), Qt::UniqueConnection);
+        connect(&mSaveWatcher, &QFutureWatcherBase::finished, this, &FileDownloader::saved, Qt::UniqueConnection);
         mSaveWatcher.setFuture(QtConcurrent::run([&] {
             return save(mFilePath, mDownloadedData);
         }));

--- a/ImageLounge/src/DkCore/DkBasicWidgets.cpp
+++ b/ImageLounge/src/DkCore/DkBasicWidgets.cpp
@@ -45,6 +45,7 @@ related links:
 #include <QSpinBox>
 #include <QVBoxLayout>
 #include <QWidgetAction>
+#include <QtGlobal>
 #pragma warning(pop)
 
 namespace nmc
@@ -107,8 +108,8 @@ void DkSlider::createLayout()
     layout->addWidget(dummyBounds);
 
     // connect
-    connect(slider, SIGNAL(valueChanged(int)), this, SLOT(setValue(int)));
-    connect(sliderBox, SIGNAL(valueChanged(int)), this, SLOT(setValue(int)));
+    connect(slider, &QSlider::valueChanged, this, &DkSlider::setValue);
+    connect(sliderBox, QOverload<int>::of(&QSpinBox::valueChanged), this, &DkSlider::setValue);
 }
 
 QSlider *DkSlider::getSlider() const
@@ -199,8 +200,8 @@ void DkDoubleSlider::createLayout()
     layout->addWidget(mSlider);
 
     // connect
-    connect(mSlider, SIGNAL(valueChanged(int)), this, SLOT(setIntValue(int)));
-    connect(mSliderBox, SIGNAL(valueChanged(double)), this, SLOT(setValue(double)));
+    connect(mSlider, &QSlider::valueChanged, this, &DkDoubleSlider::setIntValue);
+    connect(mSliderBox, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, &DkDoubleSlider::setValue);
 }
 
 int DkDoubleSlider::map(double val) const
@@ -454,7 +455,7 @@ void DkColorEdit::createLayout()
         mColBoxes[idx] = new QSpinBox(this);
         mColBoxes[idx]->setMinimum(0);
         mColBoxes[idx]->setMaximum(255);
-        connect(mColBoxes[idx], SIGNAL(valueChanged(int)), this, SLOT(colorChanged()));
+        connect(mColBoxes[idx], QOverload<int>::of(&QSpinBox::valueChanged), this, &DkColorEdit::colorChanged);
     }
 
     mColBoxes[r]->setPrefix("R: ");
@@ -462,8 +463,8 @@ void DkColorEdit::createLayout()
     mColBoxes[b]->setPrefix("B: ");
 
     mColHash = new QLineEdit(this);
-    connect(mColHash, SIGNAL(textEdited(const QString &)), this, SLOT(hashChanged(const QString &)));
-    connect(mColHash, SIGNAL(editingFinished()), this, SLOT(hashEditFinished()));
+    connect(mColHash, &QLineEdit::textEdited, this, &DkColorEdit::hashChanged);
+    connect(mColHash, &QLineEdit::editingFinished, this, &DkColorEdit::hashEditFinished);
 
     QGridLayout *gl = new QGridLayout(this);
     gl->addWidget(mColBoxes[r], 1, 1);
@@ -697,10 +698,12 @@ void DkColorPicker::createLayout()
     hb->addWidget(mColorPreview, 1, 0);
     hb->addWidget(mMenu, 1, 1);
 
-    connect(hueSlider, SIGNAL(valueChanged(int)), mColorPane, SLOT(setHue(int)));
-    connect(mColorPane, SIGNAL(colorSelected(const QColor &)), this, SIGNAL(colorSelected(const QColor &)));
-    connect(mColorPane, SIGNAL(colorSelected(const QColor &)), this, SLOT(setColor(const QColor &)));
-    connect(mMenu, SIGNAL(clicked()), this, SLOT(showMenu()));
+    connect(hueSlider, &QSlider::valueChanged, mColorPane, &DkColorPane::setHue);
+    connect(mColorPane, &DkColorPane::colorSelected, this, &DkColorPicker::colorSelected);
+    connect(mColorPane, &DkColorPane::colorSelected, this, &DkColorPicker::setColor);
+    connect(mMenu, &QPushButton::clicked, this, [this]() {
+        showMenu();
+    });
 
     setColor(mColorPane->color());
 }
@@ -710,8 +713,8 @@ void DkColorPicker::showMenu(const QPoint &pos)
     if (!mContextMenu) {
         mContextMenu = new QMenu(this);
         mColorEdit = new DkColorEdit(color(), this);
-        connect(mColorEdit, SIGNAL(newColor(const QColor &)), this, SLOT(setColor(const QColor &)));
-        connect(mColorEdit, SIGNAL(newColor(const QColor &)), mColorPane, SLOT(setColor(const QColor &)));
+        connect(mColorEdit, &DkColorEdit::newColor, this, &DkColorPicker::setColor);
+        connect(mColorEdit, &DkColorEdit::newColor, mColorPane, &DkColorPane::setColor);
 
         QWidgetAction *a = new QWidgetAction(this);
         a->setDefaultWidget(mColorEdit);
@@ -812,7 +815,7 @@ void DkRectWidget::createLayout()
         sp->setSuffix(tr(" px"));
         sp->setMinimum(0);
         sp->setMaximum(100000);
-        connect(sp, SIGNAL(valueChanged(int)), this, SLOT(updateRect()));
+        connect(sp, QOverload<int>::of(&QSpinBox::valueChanged), this, &DkRectWidget::updateRect);
     }
 
     QHBoxLayout *cropLayout = new QHBoxLayout(this);

--- a/ImageLounge/src/DkCore/DkImageContainer.cpp
+++ b/ImageLounge/src/DkCore/DkImageContainer.cpp
@@ -873,23 +873,12 @@ void DkImageContainerT::cancel()
     mLoadState = loading_canceled;
 }
 
-void DkImageContainerT::receiveUpdates(QObject *obj, bool connectSignals /* = true */)
+void DkImageContainerT::receiveUpdates(bool connectSignals)
 {
-    // TODO: I cannot change these now because QObject is used here
     // !selected - do not connect twice
     if (connectSignals && !mSelected) {
-        connect(this, SIGNAL(errorDialogSignal(const QString &)), obj, SLOT(errorDialog(const QString &)), Qt::UniqueConnection);
-        connect(this, SIGNAL(fileLoadedSignal(bool)), obj, SLOT(imageLoaded(bool)), Qt::UniqueConnection);
-        connect(this, SIGNAL(showInfoSignal(const QString &, int, int)), obj, SIGNAL(showInfoSignal(const QString &, int, int)), Qt::UniqueConnection);
-        connect(this, SIGNAL(fileSavedSignal(const QString &, bool, bool)), obj, SLOT(imageSaved(const QString &, bool, bool)), Qt::UniqueConnection);
-        connect(this, SIGNAL(imageUpdatedSignal()), obj, SLOT(currentImageUpdated()), Qt::UniqueConnection);
         mFileUpdateTimer.start();
     } else if (!connectSignals) {
-        disconnect(this, SIGNAL(errorDialogSignal(const QString &)), obj, SLOT(errorDialog(const QString &)));
-        disconnect(this, SIGNAL(fileLoadedSignal(bool)), obj, SLOT(imageLoaded(bool)));
-        disconnect(this, SIGNAL(showInfoSignal(const QString &, int, int)), obj, SIGNAL(showInfoSignal(const QString &, int, int)));
-        disconnect(this, SIGNAL(fileSavedSignal(const QString &, bool, bool)), obj, SLOT(imageSaved(const QString &, bool, bool)));
-        disconnect(this, SIGNAL(imageUpdatedSignal()), obj, SLOT(currentImageUpdated()));
         mFileUpdateTimer.stop();
     }
 

--- a/ImageLounge/src/DkCore/DkImageContainer.h
+++ b/ImageLounge/src/DkCore/DkImageContainer.h
@@ -172,7 +172,7 @@ public:
     void fetchFile();
     void cancel();
     void clear() override;
-    void receiveUpdates(QObject *obj, bool connectSignals = true);
+    void receiveUpdates(bool connectSignals);
     void downloadFile(const QUrl &url);
 
     bool loadImageThreaded(bool force = false);

--- a/ImageLounge/src/DkCore/DkImageLoader.cpp
+++ b/ImageLounge/src/DkCore/DkImageLoader.cpp
@@ -308,6 +308,11 @@ bool DkImageLoader::loadDir(const QString &newDirPath, bool scanRecursive)
     return true;
 }
 
+void DkImageLoader::loadDirRecursive(const QString &newDirPath)
+{
+    this->loadDir(newDirPath, true);
+}
+
 void DkImageLoader::sortImagesThreaded(QVector<QSharedPointer<DkImageContainerT>> images)
 {
     if (mSortingImages) {

--- a/ImageLounge/src/DkCore/DkImageLoader.cpp
+++ b/ImageLounge/src/DkCore/DkImageLoader.cpp
@@ -116,21 +116,23 @@ DkImageLoader::DkImageLoader(const QString &filePath)
     qRegisterMetaType<QFileInfo>("QFileInfo");
 
     mDirWatcher = new QFileSystemWatcher(this);
-    connect(mDirWatcher, SIGNAL(directoryChanged(QString)), this, SLOT(directoryChanged(QString)));
+    connect(mDirWatcher, &QFileSystemWatcher::directoryChanged, this, &DkImageLoader::directoryChanged);
 
     mSortingIsDirty = false;
     mSortingImages = false;
 
-    connect(&mCreateImageWatcher, SIGNAL(finished()), this, SLOT(imagesSorted()));
+    connect(&mCreateImageWatcher, &QFutureWatcher<QVector<QSharedPointer<DkImageContainerT>>>::finished, this, &DkImageLoader::imagesSorted);
 
     mDelayedUpdateTimer.setSingleShot(true);
-    connect(&mDelayedUpdateTimer, SIGNAL(timeout()), this, SLOT(directoryChanged()));
+    connect(&mDelayedUpdateTimer, &QTimer::timeout, this, [this]() {
+        directoryChanged();
+    });
 
-    connect(DkActionManager::instance().action(DkActionManager::menu_file_save_copy), SIGNAL(triggered()), this, SLOT(copyUserFile()));
-    connect(DkActionManager::instance().action(DkActionManager::menu_edit_undo), SIGNAL(triggered()), this, SLOT(undo()));
-    connect(DkActionManager::instance().action(DkActionManager::menu_edit_redo), SIGNAL(triggered()), this, SLOT(redo()));
-    connect(DkActionManager::instance().action(DkActionManager::menu_view_gps_map), SIGNAL(triggered()), this, SLOT(showOnMap()));
-    connect(DkActionManager::instance().action(DkActionManager::sc_delete_silent), SIGNAL(triggered()), this, SLOT(deleteFile()), Qt::UniqueConnection);
+    connect(DkActionManager::instance().action(DkActionManager::menu_file_save_copy), &QAction::triggered, this, &DkImageLoader::copyUserFile);
+    connect(DkActionManager::instance().action(DkActionManager::menu_edit_undo), &QAction::triggered, this, &DkImageLoader::undo);
+    connect(DkActionManager::instance().action(DkActionManager::menu_edit_redo), &QAction::triggered, this, &DkImageLoader::redo);
+    connect(DkActionManager::instance().action(DkActionManager::menu_view_gps_map), &QAction::triggered, this, &DkImageLoader::showOnMap);
+    connect(DkActionManager::instance().action(DkActionManager::sc_delete_silent), &QAction::triggered, this, &DkImageLoader::deleteFile, Qt::UniqueConnection);
 
     // saveDir = DkSettingsManager::param().global().lastSaveDir;	// loading save dir is obsolete ?!
 

--- a/ImageLounge/src/DkCore/DkImageLoader.h
+++ b/ImageLounge/src/DkCore/DkImageLoader.h
@@ -189,6 +189,7 @@ protected:
     void sortImagesThreaded(QVector<QSharedPointer<DkImageContainerT>> images);
     void createImages(const QFileInfoList &files, bool sort = true);
     QVector<QSharedPointer<DkImageContainerT>> sortImages(QVector<QSharedPointer<DkImageContainerT>> images) const;
+    void receiveUpdates(bool connectSignals);
 
     QStringList mIgnoreKeywords;
     QStringList mKeywords;

--- a/ImageLounge/src/DkCore/DkImageLoader.h
+++ b/ImageLounge/src/DkCore/DkImageLoader.h
@@ -169,6 +169,7 @@ public slots:
     QString getFolderFilter();
     QStringList getFolderFilters();
     bool loadDir(const QString &newDirPath, bool scanRecursive = true);
+    void loadDirRecursive(const QString &newDirPath);
     void errorDialog(const QString &msg) const;
     void loadFileAt(int idx);
 

--- a/ImageLounge/src/DkCore/DkImageStorage.cpp
+++ b/ImageLounge/src/DkCore/DkImageStorage.cpp
@@ -1455,12 +1455,12 @@ DkImageStorage::DkImageStorage(const QImage &img)
 
     init();
 
-    connect(mWaitTimer, SIGNAL(timeout()), this, SLOT(compute()), Qt::UniqueConnection);
-    connect(&mFutureWatcher, SIGNAL(finished()), this, SLOT(imageComputed()), Qt::UniqueConnection);
+    connect(mWaitTimer, &QTimer::timeout, this, &DkImageStorage::compute, Qt::UniqueConnection);
+    connect(&mFutureWatcher, &QFutureWatcher<QImage>::finished, this, &DkImageStorage::imageComputed, Qt::UniqueConnection);
     connect(DkActionManager::instance().action(DkActionManager::menu_view_anti_aliasing),
-            SIGNAL(toggled(bool)),
+            &QAction::toggled,
             this,
-            SLOT(antiAliasingChanged(bool)),
+            &DkImageStorage::antiAliasingChanged,
             Qt::UniqueConnection);
 }
 

--- a/ImageLounge/src/DkCore/DkMessageBox.cpp
+++ b/ImageLounge/src/DkCore/DkMessageBox.cpp
@@ -106,7 +106,7 @@ void DkMessageBox::createLayout(const QMessageBox::Icon &userIcon, const QString
     buttonBox = new QDialogButtonBox;
     buttonBox->setObjectName(QLatin1String("buttonBox"));
     buttonBox->setCenterButtons(style()->styleHint(QStyle::SH_MessageBox_CenterButtons, 0, this) != 0);
-    QObject::connect(buttonBox, SIGNAL(clicked(QAbstractButton *)), this, SLOT(buttonClicked(QAbstractButton *)));
+    QObject::connect(buttonBox, &QDialogButtonBox::clicked, this, &DkMessageBox::buttonClicked);
 
     buttonBox->setStandardButtons(QDialogButtonBox::StandardButtons(int(buttons)));
 

--- a/ImageLounge/src/DkCore/DkPluginManager.h
+++ b/ImageLounge/src/DkCore/DkPluginManager.h
@@ -372,7 +372,7 @@ class DkDescriptionEdit : public QTextEdit
 public:
     DkDescriptionEdit(QAbstractTableModel *data, QSortFilterProxyModel *proxy, QItemSelectionModel *selection, QWidget *parent = 0);
 
-protected slots:
+public slots:
     void dataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight);
     void selectionChanged(const QItemSelection &selected, const QItemSelection &deselected);
 
@@ -392,7 +392,7 @@ class DkDescriptionImage : public QLabel
 public:
     DkDescriptionImage(QAbstractTableModel *data, QSortFilterProxyModel *proxy, QItemSelectionModel *selection, QWidget *parent = 0);
 
-protected slots:
+public slots:
     void dataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight);
     void selectionChanged(const QItemSelection &selected, const QItemSelection &deselected);
 

--- a/ImageLounge/src/DkCore/DkProcess.cpp
+++ b/ImageLounge/src/DkCore/DkProcess.cpp
@@ -1064,8 +1064,8 @@ DkBatchProcessing::DkBatchProcessing(const DkBatchConfig &config, QWidget *paren
 {
     mBatchConfig = config;
 
-    connect(&mBatchWatcher, SIGNAL(progressValueChanged(int)), this, SIGNAL(progressValueChanged(int)));
-    connect(&mBatchWatcher, SIGNAL(finished()), this, SIGNAL(finished()));
+    connect(&mBatchWatcher, &QFutureWatcher<void>::progressValueChanged, this, &DkBatchProcessing::progressValueChanged);
+    connect(&mBatchWatcher, &QFutureWatcher<void>::finished, this, &DkBatchProcessing::finished);
 }
 
 void DkBatchProcessing::init()

--- a/ImageLounge/src/DkCore/DkSaveDialog.cpp
+++ b/ImageLounge/src/DkCore/DkSaveDialog.cpp
@@ -81,8 +81,8 @@ void DkTifDialog::init()
     QDialogButtonBox *buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, Qt::Horizontal, this);
     buttons->button(QDialogButtonBox::Ok)->setText(tr("&OK"));
     buttons->button(QDialogButtonBox::Cancel)->setText(tr("&Cancel"));
-    connect(buttons, SIGNAL(accepted()), this, SLOT(accept()));
-    connect(buttons, SIGNAL(rejected()), this, SLOT(reject()));
+    connect(buttons, &QDialogButtonBox::accepted, this, &DkTifDialog::accept);
+    connect(buttons, &QDialogButtonBox::rejected, this, &DkTifDialog::reject);
 
     layout()->addWidget(buttonWidget);
     layout()->addWidget(buttons);
@@ -231,7 +231,7 @@ void DkCompressDialog::createLayout()
     mOrigView = new DkBaseViewPort(this);
     mOrigView->setForceFastRendering(true);
     mOrigView->setPanControl(QPointF(0.0f, 0.0f));
-    connect(mOrigView, SIGNAL(imageUpdated()), this, SLOT(drawPreview()));
+    connect(mOrigView, &DkBaseViewPort::imageUpdated, this, &DkCompressDialog::drawPreview);
 
     //// maybe we should report this:
     //// if a stylesheet (with border) is set, the var
@@ -249,7 +249,7 @@ void DkCompressDialog::createLayout()
     mSizeCombo->addItem(tr("Medium (1024 x 786)"), 1024);
     mSizeCombo->addItem(tr("Large  (1920 x 1080)"), 1920);
     mSizeCombo->addItem(tr("Original Size"), -1);
-    connect(mSizeCombo, SIGNAL(currentIndexChanged(int)), this, SLOT(changeSizeWeb(int)));
+    connect(mSizeCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &DkCompressDialog::changeSizeWeb);
 
     // compression quality is set in ::init()
     mCompressionCombo = new QComboBox(this);
@@ -259,11 +259,11 @@ void DkCompressDialog::createLayout()
     mCompressionCombo->addItem(tr("Low Quality"));
     mCompressionCombo->addItem(tr("Bad Quality"));
     mCompressionCombo->setCurrentIndex(1);
-    connect(mCompressionCombo, SIGNAL(currentIndexChanged(int)), this, SLOT(drawPreview()));
+    connect(mCompressionCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &DkCompressDialog::drawPreview);
 
     // lossless
     mCbLossless = new QCheckBox(tr("Lossless Compression"), this);
-    connect(mCbLossless, SIGNAL(toggled(bool)), this, SLOT(losslessCompression(bool)));
+    connect(mCbLossless, &QCheckBox::toggled, this, &DkCompressDialog::losslessCompression);
 
     mPreviewSizeLabel = new QLabel();
     mPreviewSizeLabel->setAlignment(Qt::AlignRight);
@@ -272,7 +272,7 @@ void DkCompressDialog::createLayout()
     mColChooser = new DkColorChooser(mBgCol, tr("Background Color"), this);
     mColChooser->setVisible(mHasAlpha);
     mColChooser->enableAlpha(false);
-    connect(mColChooser, SIGNAL(accepted()), this, SLOT(newBgCol()));
+    connect(mColChooser, &DkColorChooser::accepted, this, &DkCompressDialog::newBgCol);
 
     QWidget *previewWidget = new QWidget(this);
     QGridLayout *previewLayout = new QGridLayout(previewWidget);
@@ -296,8 +296,8 @@ void DkCompressDialog::createLayout()
     buttons->button(QDialogButtonBox::Cancel)->setAutoDefault(false);
     buttons->button(QDialogButtonBox::Ok)->setAutoDefault(true);
     buttons->button(QDialogButtonBox::Ok)->setText(tr("&OK"));
-    connect(buttons, SIGNAL(accepted()), this, SLOT(accept()));
-    connect(buttons, SIGNAL(rejected()), this, SLOT(reject()));
+    connect(buttons, &QDialogButtonBox::accepted, this, &DkCompressDialog::accept);
+    connect(buttons, &QDialogButtonBox::rejected, this, &DkCompressDialog::reject);
 
     QVBoxLayout *layout = new QVBoxLayout(this);
     layout->addWidget(previewWidget);

--- a/ImageLounge/src/DkCore/DkThumbs.cpp
+++ b/ImageLounge/src/DkCore/DkThumbs.cpp
@@ -311,7 +311,7 @@ bool DkThumbNailT::fetchThumb(int forceLoad /* = false */, QSharedPointer<QByteA
     mFetching = true;
     mForceLoad = forceLoad;
 
-    connect(&mThumbWatcher, SIGNAL(finished()), this, SLOT(thumbLoaded()), Qt::UniqueConnection);
+    connect(&mThumbWatcher, &QFutureWatcherBase::finished, this, &DkThumbNailT::thumbLoaded, Qt::UniqueConnection);
 
     // add work to the thread pool
     // note: arguments to lambda must be thread-safe or copies (no "&", "this") to prevent race conditions

--- a/ImageLounge/src/DkCore/DkUpdater.cpp
+++ b/ImageLounge/src/DkCore/DkUpdater.cpp
@@ -153,7 +153,7 @@ DkUpdater::DkUpdater(QObject *parent)
     silent = true;
     mCookie = new QNetworkCookieJar(this);
     mAccessManagerSetup.setCookieJar(mCookie);
-    connect(&mAccessManagerSetup, SIGNAL(finished(QNetworkReply *)), this, SLOT(downloadFinishedSlot(QNetworkReply *)));
+    connect(&mAccessManagerSetup, &QNetworkAccessManager::finished, this, &DkUpdater::downloadFinishedSlot);
     mUpdateAborted = false;
 }
 
@@ -196,9 +196,9 @@ void DkUpdater::checkForUpdates()
     }
 
     qDebug() << "checking for updates";
-    connect(&mAccessManagerVersion, SIGNAL(finished(QNetworkReply *)), this, SLOT(replyFinished(QNetworkReply *)));
+    connect(&mAccessManagerVersion, &QNetworkAccessManager::finished, this, &DkUpdater::replyFinished);
     mReply = mAccessManagerVersion.get(QNetworkRequest(url));
-    connect(mReply, SIGNAL(error(QNetworkReply::NetworkError)), this, SLOT(replyError(QNetworkReply::NetworkError)));
+    connect(mReply, &QNetworkReply::errorOccurred, this, &DkUpdater::replyError);
 }
 
 void DkUpdater::replyFinished(QNetworkReply *reply)
@@ -287,7 +287,7 @@ void DkUpdater::startDownload(QUrl downloadUrl)
     QNetworkRequest req(downloadUrl);
     req.setRawHeader("User-Agent", "Auto-Updater");
     mReply = mAccessManagerSetup.get(req);
-    connect(mReply, SIGNAL(downloadProgress(qint64, qint64)), this, SLOT(updateDownloadProgress(qint64, qint64)));
+    connect(mReply, &QNetworkReply::downloadProgress, this, &DkUpdater::updateDownloadProgress);
 }
 
 void DkUpdater::downloadFinishedSlot(QNetworkReply *data)
@@ -361,7 +361,7 @@ DkTranslationUpdater::DkTranslationUpdater(bool silent, QObject *parent)
     : QObject(parent)
 {
     this->silent = silent;
-    connect(&mAccessManager, SIGNAL(finished(QNetworkReply *)), this, SLOT(replyFinished(QNetworkReply *)));
+    connect(&mAccessManager, &QNetworkAccessManager::finished, this, &DkTranslationUpdater::replyFinished);
 
     updateAborted = false;
     updateAbortedQt = false;
@@ -395,12 +395,12 @@ void DkTranslationUpdater::checkForUpdates()
              + ".qm");
     qInfo() << "checking for new translations at " << url;
     mReply = mAccessManager.get(QNetworkRequest(url));
-    connect(mReply, SIGNAL(downloadProgress(qint64, qint64)), this, SLOT(updateDownloadProgress(qint64, qint64)));
+    connect(mReply, &QNetworkReply::downloadProgress, this, &DkTranslationUpdater::updateDownloadProgress);
 
     url = QUrl("https://nomacs.org/translations/qt/qt_" + DkSettingsManager::param().global().language + ".qm");
     qDebug() << "checking for new translations at " << url;
     mReplyQt = mAccessManager.get(QNetworkRequest(url));
-    connect(mReplyQt, SIGNAL(downloadProgress(qint64, qint64)), this, SLOT(updateDownloadProgressQt(qint64, qint64)));
+    connect(mReplyQt, &QNetworkReply::downloadProgress, this, &DkTranslationUpdater::updateDownloadProgressQt);
 }
 
 void DkTranslationUpdater::replyFinished(QNetworkReply *reply)

--- a/ImageLounge/src/DkGui/DkBaseWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkBaseWidgets.cpp
@@ -186,7 +186,7 @@ void DkFadeWidget::animateOpacityUp()
         return;
     }
 
-    QTimer::singleShot(20, this, SLOT(animateOpacityUp()));
+    QTimer::singleShot(20, this, &DkFadeWidget::animateOpacityUp);
     mOpacityEffect->setOpacity(mOpacityEffect->opacity() + 0.05);
 }
 
@@ -204,7 +204,7 @@ void DkFadeWidget::animateOpacityDown()
         return;
     }
 
-    QTimer::singleShot(20, this, SLOT(animateOpacityDown()));
+    QTimer::singleShot(20, this, &DkFadeWidget::animateOpacityDown);
     mOpacityEffect->setOpacity(mOpacityEffect->opacity() - 0.05);
 }
 
@@ -244,7 +244,7 @@ void DkLabel::init()
     mBlocked = false;
 
     mTimer.setSingleShot(true);
-    connect(&mTimer, SIGNAL(timeout()), this, SLOT(hide()));
+    connect(&mTimer, &QTimer::timeout, this, &DkLabel::hide);
 
     // default look and feel
     QFont font;
@@ -516,7 +516,7 @@ void DkFadeLabel::animateOpacityUp()
         return;
     }
 
-    QTimer::singleShot(20, this, SLOT(animateOpacityUp()));
+    QTimer::singleShot(20, this, &DkFadeLabel::animateOpacityUp);
     opacityEffect->setOpacity(opacityEffect->opacity() + 0.05);
 }
 
@@ -534,7 +534,7 @@ void DkFadeLabel::animateOpacityDown()
         return;
     }
 
-    QTimer::singleShot(20, this, SLOT(animateOpacityDown()));
+    QTimer::singleShot(20, this, &DkFadeLabel::animateOpacityDown);
     opacityEffect->setOpacity(opacityEffect->opacity() - 0.05);
 }
 

--- a/ImageLounge/src/DkGui/DkBatch.cpp
+++ b/ImageLounge/src/DkGui/DkBatch.cpp
@@ -141,8 +141,7 @@ void DkBatchContainer::setContentWidget(QWidget *batchContent)
     mBatchContent = dynamic_cast<DkBatchContent *>(batchContent);
 
     connect(mHeaderButton, &DkBatchTabButton::toggled, this, &DkBatchContainer::showContent);
-    // TODO: this is QWidget, maybe need refactoring
-    connect(batchContent, SIGNAL(newHeaderText(const QString &)), mHeaderButton, SLOT(setInfo(const QString &)));
+    connect(mBatchContent, &DkBatchContent::newHeaderText, mHeaderButton, &DkBatchTabButton::setInfo);
 }
 
 QWidget *DkBatchContainer::contentWidget() const
@@ -323,7 +322,7 @@ QString DkInputTextEdit::firstDirPath() const
 
 // File Selection --------------------------------------------------------------------
 DkBatchInput::DkBatchInput(QWidget *parent /* = 0 */, Qt::WindowFlags f /* = 0 */)
-    : DkWidget(parent, f)
+    : DkBatchContent(parent, f)
 {
     setObjectName("DkBatchInput");
     createLayout();
@@ -747,7 +746,7 @@ bool DkFilenameWidget::setTag(const QString &tag)
 
 // DkBatchOutput --------------------------------------------------------------------
 DkBatchOutput::DkBatchOutput(QWidget *parent, Qt::WindowFlags f)
-    : DkWidget(parent, f)
+    : DkBatchContent(parent, f)
 {
     setObjectName("DkBatchOutput");
     createLayout();
@@ -1292,7 +1291,7 @@ void DkProfileSummaryWidget::createLayout()
 
 // DkProfileWidget --------------------------------------------------------------------
 DkProfileWidget::DkProfileWidget(QWidget *parent, Qt::WindowFlags f)
-    : DkWidget(parent, f)
+    : DkBatchContent(parent, f)
 {
     createLayout();
 }
@@ -1492,7 +1491,7 @@ void DkProfileWidget::saveProfile()
 #ifdef WITH_PLUGINS
 // DkBatchPlugin --------------------------------------------------------------------
 DkBatchPluginWidget::DkBatchPluginWidget(QWidget *parent /* = 0 */, Qt::WindowFlags f /* = 0 */)
-    : DkWidget(parent, f)
+    : DkBatchContent(parent, f)
 {
     // mSettings = DkSettingsManager::instance().qSettings();
     DkPluginManager::instance().loadPlugins();
@@ -1769,7 +1768,7 @@ void DkBatchPluginWidget::updateHeader() const
 
 // DkBatchManipulatorWidget --------------------------------------------------------------------
 DkBatchManipulatorWidget::DkBatchManipulatorWidget(QWidget *parent /* = 0 */, Qt::WindowFlags f /* = 0 */)
-    : DkWidget(parent, f)
+    : DkBatchContent(parent, f)
 {
     mManager.createManipulators(this);
     createLayout();
@@ -2005,7 +2004,7 @@ void DkBatchManipulatorWidget::updateHeader() const
 
 // DkBatchTransform --------------------------------------------------------------------
 DkBatchTransformWidget::DkBatchTransformWidget(QWidget *parent /* = 0 */, Qt::WindowFlags f /* = 0 */)
-    : DkWidget(parent, f)
+    : DkBatchContent(parent, f)
 {
     createLayout();
     applyDefault();
@@ -3036,4 +3035,8 @@ void DkBatchWidget::widgetChanged()
     }
 }
 
+DkBatchContent::DkBatchContent(QWidget *parent /* = 0 */, Qt::WindowFlags f /* = 0 */)
+    : DkWidget(parent, f)
+{
+}
 }

--- a/ImageLounge/src/DkGui/DkBatch.h
+++ b/ImageLounge/src/DkGui/DkBatch.h
@@ -101,12 +101,18 @@ class DkSettingsWidget;
 class DkBatchPluginInterface;
 class DkRectWidget;
 
-class DkBatchContent
+class DkBatchContent : public DkWidget
 {
+    Q_OBJECT
+
 public:
+    DkBatchContent(QWidget *parent = 0, Qt::WindowFlags f = Qt::WindowFlags());
     virtual bool hasUserInput() const = 0;
     virtual bool requiresUserInput() const = 0;
     virtual void applyDefault() = 0;
+
+signals:
+    void newHeaderText(const QString &txt) const;
 };
 
 class DkBatchTabButton : public QPushButton
@@ -183,7 +189,7 @@ protected:
     QList<int> mResultList;
 };
 
-class DkBatchInput : public DkWidget, public DkBatchContent
+class DkBatchInput : public DkBatchContent
 {
     Q_OBJECT
 
@@ -229,7 +235,6 @@ public slots:
 
 signals:
     void updateDirSignal(QVector<QSharedPointer<DkImageContainerT>>) const;
-    void newHeaderText(const QString &) const;
     void updateInputDir(const QString &) const;
     void changed() const;
 
@@ -300,7 +305,7 @@ private:
     bool hasChanged = false;
 };
 
-class DkBatchOutput : public DkWidget, public DkBatchContent
+class DkBatchOutput : public DkBatchContent
 {
     Q_OBJECT
 
@@ -325,7 +330,6 @@ public:
     void setExampleFilename(const QString &exampleName);
 
 signals:
-    void newHeaderText(const QString &) const;
     void changed() const;
 
 public slots:
@@ -397,7 +401,7 @@ protected:
     QLabel *mFunctions = 0;
 };
 
-class DkProfileWidget : public DkWidget, public DkBatchContent
+class DkProfileWidget : public DkBatchContent
 {
     Q_OBJECT
 
@@ -420,7 +424,6 @@ public slots:
     void exportCurrentProfile();
 
 signals:
-    void newHeaderText(const QString &txt) const;
     void loadProfileSignal(const QString &profilePath) const;
     void saveProfileSignal(const QString &profilePath) const;
     void applyDefaultSignal() const;
@@ -438,7 +441,7 @@ protected:
 };
 
 #ifdef WITH_PLUGINS
-class DkBatchPluginWidget : public DkWidget, public DkBatchContent
+class DkBatchPluginWidget : public DkBatchContent
 {
     Q_OBJECT
 
@@ -459,9 +462,6 @@ public slots:
     void changeSetting(const QString &key, const QVariant &value, const QStringList &parentList) const;
     void removeSetting(const QString &key, const QStringList &parentList) const;
 
-signals:
-    void newHeaderText(const QString &txt) const;
-
 public slots:
     void updateHeader() const;
 
@@ -480,7 +480,7 @@ protected:
 };
 #endif
 
-class DkBatchManipulatorWidget : public DkWidget, public DkBatchContent
+class DkBatchManipulatorWidget : public DkBatchContent
 {
     Q_OBJECT
 
@@ -499,9 +499,6 @@ public slots:
     void selectionChanged(const QItemSelection &selected);
     void selectManipulator(QSharedPointer<DkBaseManipulator> mpl);
     void selectManipulator();
-
-signals:
-    void newHeaderText(const QString &txt) const;
 
 public slots:
     void updateHeader() const;
@@ -522,7 +519,7 @@ protected:
     int mMaxPreview = 300;
 };
 
-class DkBatchTransformWidget : public DkWidget, public DkBatchContent
+class DkBatchTransformWidget : public DkBatchContent
 {
     Q_OBJECT
 
@@ -538,9 +535,6 @@ public:
 public slots:
     void updateHeader() const;
     void modeChanged();
-
-signals:
-    void newHeaderText(const QString &txt) const;
 
 protected:
     void createLayout();

--- a/ImageLounge/src/DkGui/DkCentralWidget.cpp
+++ b/ImageLounge/src/DkGui/DkCentralWidget.cpp
@@ -529,36 +529,42 @@ DkPreferenceWidget *DkCentralWidget::createPreferences()
     // general preferences
     DkPreferenceTabWidget *tab = new DkPreferenceTabWidget(DkImage::loadIcon(":/nomacs/img/settings.svg", s), tr("General"), this);
     DkGeneralPreference *gp = new DkGeneralPreference(this);
+    connect(gp, &DkGeneralPreference::infoSignal, tab, &DkPreferenceTabWidget::setInfoMessage);
     tab->setWidget(gp);
     pw->addTabWidget(tab);
 
     // display preferences
     tab = new DkPreferenceTabWidget(DkImage::loadIcon(":/nomacs/img/display.svg", s), tr("Display"), this);
     DkDisplayPreference *dp = new DkDisplayPreference(this);
+    connect(dp, &DkDisplayPreference::infoSignal, tab, &DkPreferenceTabWidget::setInfoMessage);
     tab->setWidget(dp);
     pw->addTabWidget(tab);
 
     // file preferences
     tab = new DkPreferenceTabWidget(DkImage::loadIcon(":/nomacs/img/dir.svg", s), tr("File"), this);
     DkFilePreference *fp = new DkFilePreference(this);
+    connect(fp, &DkFilePreference::infoSignal, tab, &DkPreferenceTabWidget::setInfoMessage);
     tab->setWidget(fp);
     pw->addTabWidget(tab);
 
     // file association preferences
     tab = new DkPreferenceTabWidget(DkImage::loadIcon(":/nomacs/img/nomacs-bg.svg", s), tr("File Associations"), this);
     DkFileAssociationsPreference *fap = new DkFileAssociationsPreference(this);
+    connect(fap, &DkFileAssociationsPreference::infoSignal, tab, &DkPreferenceTabWidget::setInfoMessage);
     tab->setWidget(fap);
     pw->addTabWidget(tab);
 
     // advanced preferences
     tab = new DkPreferenceTabWidget(DkImage::loadIcon(":/nomacs/img/advanced-settings.svg", s), tr("Advanced"), this);
     DkAdvancedPreference *ap = new DkAdvancedPreference(this);
+    connect(ap, &DkAdvancedPreference::infoSignal, tab, &DkPreferenceTabWidget::setInfoMessage);
     tab->setWidget(ap);
     pw->addTabWidget(tab);
 
     // file association preferences
     tab = new DkPreferenceTabWidget(DkImage::loadIcon(":/nomacs/img/sliders.svg", s), tr("Editor"), this);
     DkEditorPreference *ep = new DkEditorPreference(this);
+    connect(ep, &DkEditorPreference::infoSignal, tab, &DkPreferenceTabWidget::setInfoMessage);
     tab->setWidget(ep);
     pw->addTabWidget(tab);
 

--- a/ImageLounge/src/DkGui/DkCentralWidget.cpp
+++ b/ImageLounge/src/DkGui/DkCentralWidget.cpp
@@ -843,15 +843,13 @@ void DkCentralWidget::showThumbView(bool show)
             if (tabInfo->getImage())
                 tw->getThumbWidget()->ensureVisible(tabInfo->getImage());
 
-            // TODO: I cannot get rid of this for now because
-            // connect with lambda cannot easily be disconnected
-            connect(tw, SIGNAL(updateDirSignal(const QString &)), tabInfo->getImageLoader().data(), SLOT(loadDir(const QString &)), Qt::UniqueConnection);
+            connect(tw, &DkThumbScrollWidget::updateDirSignal, tabInfo->getImageLoader().data(), &DkImageLoader::loadDirRecursive, Qt::UniqueConnection);
             connect(tw, &DkThumbScrollWidget::filterChangedSignal, tabInfo->getImageLoader().data(), &DkImageLoader::setFolderFilter, Qt::UniqueConnection);
         }
 
     } else {
         if (auto tw = getThumbScrollWidget()) {
-            disconnect(tw, SIGNAL(updateDirSignal(const QString &)), tabInfo->getImageLoader().data(), SLOT(loadDir(const QString &)));
+            disconnect(tw, &DkThumbScrollWidget::updateDirSignal, tabInfo->getImageLoader().data(), &DkImageLoader::loadDirRecursive);
             disconnect(tw, &DkThumbScrollWidget::filterChangedSignal, tabInfo->getImageLoader().data(), &DkImageLoader::setFolderFilter);
         }
         // mViewport->connectLoader(tabInfo->getImageLoader(), true);

--- a/ImageLounge/src/DkGui/DkConnection.cpp
+++ b/ImageLounge/src/DkGui/DkConnection.cpp
@@ -51,8 +51,8 @@ DkConnection::DkConnection(QObject *parent)
     connectionCreated = false;
     mSynchronizedTimer = new QTimer(this);
 
-    connect(mSynchronizedTimer, SIGNAL(timeout()), this, SLOT(synchronizedTimerTimeout()));
-    connect(this, SIGNAL(readyRead()), this, SLOT(processReadyRead()));
+    connect(mSynchronizedTimer, &QTimer::timeout, this, &DkConnection::synchronizedTimerTimeout);
+    connect(this, &DkConnection::readyRead, this, &DkConnection::processReadyRead);
 
     setReadBufferSize(MaxBufferSize);
 }

--- a/ImageLounge/src/DkGui/DkConnection.h
+++ b/ImageLounge/src/DkGui/DkConnection.h
@@ -176,6 +176,7 @@ signals:
 protected slots:
     void processReadyRead();
     void processData();
+public slots:
     void sendQuitMessage();
 
 protected:

--- a/ImageLounge/src/DkGui/DkDialog.cpp
+++ b/ImageLounge/src/DkGui/DkDialog.cpp
@@ -157,7 +157,7 @@ DkSplashScreen::DkSplashScreen(QWidget * /*parent*/, Qt::WindowFlags flags)
     exitButton->setShortcut(QKeySequence(Qt::Key_Escape));
     exitButton->move(10, 435);
     exitButton->hide();
-    connect(exitButton, SIGNAL(clicked()), this, SLOT(close()));
+    connect(exitButton, &QPushButton::clicked, this, &DkSplashScreen::close);
 
     // set the text
     text = QString(
@@ -195,7 +195,7 @@ DkSplashScreen::DkSplashScreen(QWidget * /*parent*/, Qt::WindowFlags flags)
     showTimer = new QTimer(this);
     showTimer->setInterval(5000);
     showTimer->setSingleShot(true);
-    connect(showTimer, SIGNAL(timeout()), exitButton, SLOT(hide()));
+    connect(showTimer, &QTimer::timeout, exitButton, &QPushButton::hide);
 
     qDebug() << "splash screen created...";
 }
@@ -321,11 +321,13 @@ void DkTrainDialog::createLayout()
     mPathEdit = new QLineEdit(this);
     mPathEdit->setValidator(&mFileValidator);
     mPathEdit->setObjectName("DkWarningEdit");
-    connect(mPathEdit, SIGNAL(textChanged(const QString &)), this, SLOT(textChanged(const QString &)));
-    connect(mPathEdit, SIGNAL(editingFinished()), this, SLOT(loadFile()));
+    connect(mPathEdit, &QLineEdit::textChanged, this, &DkTrainDialog::textChanged);
+    connect(mPathEdit, &QLineEdit::editingFinished, this, [this]() {
+        loadFile();
+    });
 
     QPushButton *openButton = new QPushButton(tr("&Browse"), this);
-    connect(openButton, SIGNAL(pressed()), this, SLOT(openFile()));
+    connect(openButton, &QPushButton::pressed, this, &DkTrainDialog::openFile);
 
     mFeedbackLabel = new QLabel("", this);
     mFeedbackLabel->setObjectName("DkDecentInfo");
@@ -340,8 +342,8 @@ void DkTrainDialog::createLayout()
     mButtons->button(QDialogButtonBox::Ok)->setText(tr("&Add"));
     mButtons->button(QDialogButtonBox::Ok)->setEnabled(false);
     mButtons->button(QDialogButtonBox::Cancel)->setText(tr("&Cancel"));
-    connect(mButtons, SIGNAL(accepted()), this, SLOT(accept()));
-    connect(mButtons, SIGNAL(rejected()), this, SLOT(reject()));
+    connect(mButtons, &QDialogButtonBox::accepted, this, &DkTrainDialog::accept);
+    connect(mButtons, &QDialogButtonBox::rejected, this, &DkTrainDialog::reject);
 
     QWidget *trainWidget = new QWidget(this);
     QGridLayout *gdLayout = new QGridLayout(trainWidget);
@@ -523,8 +525,8 @@ void DkAppManagerDialog::createLayout()
     QDialogButtonBox *buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, Qt::Horizontal, this);
     buttons->button(QDialogButtonBox::Ok)->setText(tr("&OK"));
     buttons->button(QDialogButtonBox::Cancel)->setText(tr("&Cancel"));
-    connect(buttons, SIGNAL(accepted()), this, SLOT(accept()));
-    connect(buttons, SIGNAL(rejected()), this, SLOT(reject()));
+    connect(buttons, &QDialogButtonBox::accepted, this, &DkAppManagerDialog::accept);
+    connect(buttons, &QDialogButtonBox::rejected, this, &DkAppManagerDialog::reject);
     buttons->addButton(runButton, QDialogButtonBox::ActionRole);
     buttons->addButton(addButton, QDialogButtonBox::ActionRole);
     buttons->addButton(deleteButton, QDialogButtonBox::ActionRole);
@@ -667,8 +669,8 @@ void DkSearchDialog::init()
     mButtons->button(QDialogButtonBox::Ok)->setText(tr("F&ind"));
     mButtons->addButton(mFilterButton, QDialogButtonBox::ActionRole);
 
-    connect(mButtons, SIGNAL(accepted()), this, SLOT(accept()));
-    connect(mButtons, SIGNAL(rejected()), this, SLOT(reject()));
+    connect(mButtons, &QDialogButtonBox::accepted, this, &DkSearchDialog::accept);
+    connect(mButtons, &QDialogButtonBox::rejected, this, &DkSearchDialog::reject);
 
     layout->addWidget(mSearchBar);
     layout->addWidget(mResultListView);
@@ -922,7 +924,7 @@ void DkResizeDialog::createLayout()
     mOrigView = new DkBaseViewPort(this);
     mOrigView->setForceFastRendering(true);
     mOrigView->setPanControl(QPointF(0.0f, 0.0f));
-    connect(mOrigView, SIGNAL(imageUpdated()), this, SLOT(drawPreview()));
+    connect(mOrigView, &DkBaseViewPort::imageUpdated, this, &DkResizeDialog::drawPreview);
 
     //// maybe we should report this:
     //// if a stylesheet (with border) is set, the var
@@ -1075,8 +1077,8 @@ void DkResizeDialog::createLayout()
     QDialogButtonBox *buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, Qt::Horizontal, this);
     buttons->button(QDialogButtonBox::Ok)->setText(tr("&OK"));
     buttons->button(QDialogButtonBox::Cancel)->setText(tr("&Cancel"));
-    connect(buttons, SIGNAL(accepted()), this, SLOT(accept()));
-    connect(buttons, SIGNAL(rejected()), this, SLOT(reject()));
+    connect(buttons, &QDialogButtonBox::accepted, this, &DkResizeDialog::accept);
+    connect(buttons, &QDialogButtonBox::rejected, this, &DkResizeDialog::reject);
 
     QGridLayout *layout = new QGridLayout(this);
     layout->setColumnStretch(0, 1);
@@ -1480,6 +1482,7 @@ DkShortcutDelegate::DkShortcutDelegate(QObject *parent)
     mClearPm = DkImage::loadIcon(":/nomacs/img/close.svg");
 }
 
+// TODO: I don't think this is ever used
 QWidget *DkShortcutDelegate::createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const
 {
     QWidget *scW = QItemDelegate::createEditor(parent, option, index);
@@ -1487,6 +1490,8 @@ QWidget *DkShortcutDelegate::createEditor(QWidget *parent, const QStyleOptionVie
     if (!scW)
         return scW;
 
+    // TODO: It would seem that this line wants scW to be QKeySequenceEdit,
+    // but I could not verify because this is never called.
     connect(scW, SIGNAL(keySequenceChanged(const QKeySequence &)), this, SLOT(keySequenceChanged(const QKeySequence &)));
 
     return scW;
@@ -1856,11 +1861,14 @@ void DkShortcutsDialog::createLayout()
 
     mDefaultButton = new QPushButton(tr("Set to &Default"), this);
     mDefaultButton->setToolTip(tr("Removes All Custom Shortcuts"));
-    connect(mDefaultButton, SIGNAL(clicked()), this, SLOT(defaultButtonClicked()));
-    connect(mModel, SIGNAL(duplicateSignal(const QString &)), mNotificationLabel, SLOT(setText(const QString &)));
+    connect(mDefaultButton, &QPushButton::clicked, this, &DkShortcutsDialog::defaultButtonClicked);
+    connect(mModel, &DkShortcutsModel::duplicateSignal, mNotificationLabel, &QLabel::setText);
 
-    connect(scDelegate, SIGNAL(checkDuplicateSignal(const QKeySequence &, void *)), mModel, SLOT(checkDuplicate(const QKeySequence &, void *)));
-    connect(scDelegate, SIGNAL(clearDuplicateSignal()), mModel, SLOT(clearDuplicateInfo()));
+    connect(scDelegate,
+            QOverload<const QString &, void *>::of(&DkShortcutDelegate::checkDuplicateSignal),
+            mModel,
+            QOverload<const QString &, void *>::of(&DkShortcutsModel::checkDuplicate));
+    connect(scDelegate, &DkShortcutDelegate::clearDuplicateSignal, mModel, &DkShortcutsModel::clearDuplicateInfo);
 
     // mButtons
     QDialogButtonBox *buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, Qt::Horizontal, this);
@@ -1868,8 +1876,8 @@ void DkShortcutsDialog::createLayout()
     buttons->button(QDialogButtonBox::Cancel)->setText(tr("&Cancel"));
     buttons->addButton(mDefaultButton, QDialogButtonBox::ActionRole);
 
-    connect(buttons, SIGNAL(accepted()), this, SLOT(accept()));
-    connect(buttons, SIGNAL(rejected()), this, SLOT(reject()));
+    connect(buttons, &QDialogButtonBox::accepted, this, &DkShortcutsDialog::accept);
+    connect(buttons, &QDialogButtonBox::rejected, this, &DkShortcutsDialog::reject);
 
     layout->addWidget(treeView);
     layout->addWidget(mNotificationLabel);
@@ -1925,8 +1933,8 @@ void DkTextDialog::createLayout()
     buttons->button(QDialogButtonBox::Ok)->setText(tr("&Save"));
     buttons->button(QDialogButtonBox::Cancel)->setText(tr("&Close"));
 
-    connect(buttons, SIGNAL(accepted()), this, SLOT(save()));
-    connect(buttons, SIGNAL(rejected()), this, SLOT(reject()));
+    connect(buttons, &QDialogButtonBox::accepted, this, &DkTextDialog::save);
+    connect(buttons, &QDialogButtonBox::rejected, this, &DkTextDialog::reject);
 
     // dialog layout
     QVBoxLayout *layout = new QVBoxLayout(this);
@@ -1981,8 +1989,8 @@ void DkUpdateDialog::init()
 {
     createLayout();
 
-    connect(cancelButton, SIGNAL(clicked()), this, SLOT(close()));
-    connect(okButton, SIGNAL(clicked()), this, SLOT(okButtonClicked()));
+    connect(cancelButton, &QPushButton::clicked, this, &DkUpdateDialog::close);
+    connect(okButton, &QPushButton::clicked, this, &DkUpdateDialog::okButtonClicked);
 }
 
 void DkUpdateDialog::createLayout()
@@ -2061,7 +2069,7 @@ void DkPrintPreviewDialog::init()
     setMinimumHeight(600);
     setMinimumWidth(800);
 
-    connect(mPreview, SIGNAL(dpiChanged(int)), mDpiBox, SLOT(setValue(int)));
+    connect(mPreview, &DkPrintPreviewWidget::dpiChanged, mDpiBox, &QSpinBox::setValue);
 }
 
 void DkPrintPreviewDialog::createIcons()
@@ -2142,17 +2150,17 @@ void DkPrintPreviewDialog::createLayout()
     zoomOutButton->setAutoRepeatInterval(200);
     zoomOutButton->setAutoRepeatDelay(200);
 
-    connect(mDpiBox, SIGNAL(valueChanged(int)), mPreview, SLOT(changeDpi(int)));
-    connect(zoomInButton, SIGNAL(clicked()), this, SLOT(zoomIn()));
-    connect(zoomOutButton, SIGNAL(clicked()), this, SLOT(zoomOut()));
+    connect(mDpiBox, QOverload<int>::of(&QSpinBox::valueChanged), mPreview, &DkPrintPreviewWidget::changeDpi);
+    connect(zoomInButton, &QPushButton::clicked, this, &DkPrintPreviewDialog::zoomIn);
+    connect(zoomOutButton, &QPushButton::clicked, this, &DkPrintPreviewDialog::zoomOut);
 
-    connect(lsc, SIGNAL(triggered()), mPreview, SLOT(setLandscapeOrientation()));
-    connect(prt, SIGNAL(triggered()), mPreview, SLOT(setPortraitOrientation()));
-    connect(fitWidth, SIGNAL(triggered()), this, SLOT(previewFitWidth()));
-    connect(fitPage, SIGNAL(triggered()), this, SLOT(previewFitPage()));
+    connect(lsc, &QAction::triggered, mPreview, &DkPrintPreviewWidget::setLandscapeOrientation);
+    connect(prt, &QAction::triggered, mPreview, &DkPrintPreviewWidget::setPortraitOrientation);
+    connect(fitWidth, &QAction::triggered, this, &DkPrintPreviewDialog::previewFitWidth);
+    connect(fitPage, &QAction::triggered, this, &DkPrintPreviewDialog::previewFitPage);
 
-    connect(printAction, SIGNAL(triggered(bool)), this, SLOT(print()));
-    connect(pageSetup, SIGNAL(triggered(bool)), this, SLOT(pageSetup()));
+    connect(printAction, &QAction::triggered, this, &DkPrintPreviewDialog::print);
+    connect(pageSetup, &QAction::triggered, this, &DkPrintPreviewDialog::pageSetup);
 
     QMainWindow *mw = new QMainWindow();
     mw->addToolBar(toolbar);
@@ -2231,7 +2239,7 @@ DkPrintPreviewWidget::DkPrintPreviewWidget(QPrinter *printer, QWidget *parent, Q
     : QPrintPreviewWidget(printer, parent, flags)
 {
     mPrinter = printer;
-    connect(this, SIGNAL(paintRequested(QPrinter *)), this, SLOT(paintPreview(QPrinter *)));
+    connect(this, &DkPrintPreviewWidget::paintRequested, this, &DkPrintPreviewWidget::paintPreview);
 }
 
 void DkPrintPreviewWidget::paintEvent(QPaintEvent *event)
@@ -2373,8 +2381,8 @@ void DkOpacityDialog::createLayout()
     QDialogButtonBox *buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, Qt::Horizontal, this);
     buttons->button(QDialogButtonBox::Ok)->setText(tr("&OK"));
     buttons->button(QDialogButtonBox::Cancel)->setText(tr("&Cancel"));
-    connect(buttons, SIGNAL(accepted()), this, SLOT(accept()));
-    connect(buttons, SIGNAL(rejected()), this, SLOT(reject()));
+    connect(buttons, &QDialogButtonBox::accepted, this, &DkOpacityDialog::accept);
+    connect(buttons, &QDialogButtonBox::rejected, this, &DkOpacityDialog::reject);
 
     layout->addWidget(slider);
     layout->addWidget(buttons);
@@ -2393,10 +2401,10 @@ DkExportTiffDialog::DkExportTiffDialog(QWidget *parent /* = 0 */, Qt::WindowFlag
     createLayout();
     setAcceptDrops(true);
 
-    connect(this, SIGNAL(updateImage(const QImage &)), mViewport, SLOT(setImage(const QImage &)));
-    connect(&mWatcher, SIGNAL(finished()), this, SLOT(processingFinished()));
-    connect(this, SIGNAL(infoMessage(const QString &)), mMsgLabel, SLOT(setText(const QString &)));
-    connect(this, SIGNAL(updateProgress(int)), mProgress, SLOT(setValue(int)));
+    connect(this, &DkExportTiffDialog::updateImage, mViewport, QOverload<QImage>::of(&DkBaseViewPort::setImage));
+    connect(&mWatcher, &QFutureWatcherBase::finished, this, &DkExportTiffDialog::processingFinished);
+    connect(this, &DkExportTiffDialog::infoMessage, mMsgLabel, &QLabel::setText);
+    connect(this, &DkExportTiffDialog::updateProgress, mProgress, &QProgressBar::setValue);
 }
 
 void DkExportTiffDialog::dropEvent(QDropEvent *event)
@@ -2502,8 +2510,8 @@ void DkExportTiffDialog::createLayout()
     mButtons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, Qt::Horizontal, this);
     mButtons->button(QDialogButtonBox::Ok)->setText(tr("&Export"));
     mButtons->button(QDialogButtonBox::Cancel)->setText(tr("&Cancel"));
-    connect(mButtons, SIGNAL(accepted()), this, SLOT(accept()));
-    connect(mButtons, SIGNAL(rejected()), this, SLOT(reject()));
+    connect(mButtons, &QDialogButtonBox::accepted, this, &DkExportTiffDialog::accept);
+    connect(mButtons, &QDialogButtonBox::rejected, this, &DkExportTiffDialog::reject);
 
     QVBoxLayout *layout = new QVBoxLayout(this);
     layout->addWidget(mViewport);
@@ -2694,12 +2702,12 @@ DkMosaicDialog::DkMosaicDialog(QWidget *parent /* = 0 */, Qt::WindowFlags f /* =
     createLayout();
     setAcceptDrops(true);
 
-    connect(this, SIGNAL(updateImage(const QImage &)), mPreview, SLOT(setImage(const QImage &)));
-    connect(&mMosaicWatcher, SIGNAL(finished()), this, SLOT(mosaicFinished()));
-    connect(&mPostProcessWatcher, SIGNAL(finished()), this, SLOT(postProcessFinished()));
-    connect(&mPostProcessWatcher, SIGNAL(canceled()), this, SLOT(postProcessFinished()));
-    connect(this, SIGNAL(infoMessage(const QString &)), mMsgLabel, SLOT(setText(const QString &)));
-    connect(this, SIGNAL(updateProgress(int)), mProgress, SLOT(setValue(int)));
+    connect(this, &DkMosaicDialog::updateImage, mPreview, QOverload<QImage>::of(&DkBaseViewPort::setImage));
+    connect(&mMosaicWatcher, &QFutureWatcherBase::finished, this, &DkMosaicDialog::mosaicFinished);
+    connect(&mPostProcessWatcher, &QFutureWatcherBase::finished, this, &DkMosaicDialog::postProcessFinished);
+    connect(&mPostProcessWatcher, &QFutureWatcherBase::canceled, this, &DkMosaicDialog::postProcessFinished);
+    connect(this, &DkMosaicDialog::infoMessage, mMsgLabel, &QLabel::setText);
+    connect(this, &DkMosaicDialog::updateProgress, mProgress, &QProgressBar::setValue);
 }
 
 void DkMosaicDialog::dropEvent(QDropEvent *event)
@@ -2875,9 +2883,9 @@ void DkMosaicDialog::createLayout()
     mButtons->button(QDialogButtonBox::Save)->setText(tr("&Save"));
     mButtons->button(QDialogButtonBox::Apply)->setText(tr("&Generate"));
     mButtons->button(QDialogButtonBox::Cancel)->setText(tr("&Cancel"));
-    // connect(mButtons, SIGNAL(accepted()), this, SLOT(accept()));
-    connect(mButtons, SIGNAL(clicked(QAbstractButton *)), this, SLOT(buttonClicked(QAbstractButton *)));
-    connect(mButtons, SIGNAL(rejected()), this, SLOT(reject()));
+
+    connect(mButtons, &QDialogButtonBox::clicked, this, &DkMosaicDialog::buttonClicked);
+    connect(mButtons, &QDialogButtonBox::rejected, this, &DkMosaicDialog::reject);
     mButtons->button(QDialogButtonBox::Save)->setEnabled(false);
 
     QVBoxLayout *layout = new QVBoxLayout(this);
@@ -3608,8 +3616,8 @@ void DkForceThumbDialog::createLayout()
     QDialogButtonBox *buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, Qt::Horizontal, this);
     buttons->button(QDialogButtonBox::Ok)->setText(tr("&OK"));
     buttons->button(QDialogButtonBox::Cancel)->setText(tr("&Cancel"));
-    connect(buttons, SIGNAL(accepted()), this, SLOT(accept()));
-    connect(buttons, SIGNAL(rejected()), this, SLOT(reject()));
+    connect(buttons, &QDialogButtonBox::accepted, this, &DkForceThumbDialog::accept);
+    connect(buttons, &QDialogButtonBox::rejected, this, &DkForceThumbDialog::reject);
 
     layout->addWidget(infoLabel);
     layout->addWidget(cbForceSave);
@@ -3654,8 +3662,8 @@ void DkWelcomeDialog::createLayout()
     QDialogButtonBox *buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, Qt::Horizontal, this);
     buttons->button(QDialogButtonBox::Ok)->setText(tr("&OK"));
     buttons->button(QDialogButtonBox::Cancel)->setText(tr("&Cancel"));
-    connect(buttons, SIGNAL(accepted()), this, SLOT(accept()));
-    connect(buttons, SIGNAL(rejected()), this, SLOT(reject()));
+    connect(buttons, &QDialogButtonBox::accepted, this, &DkWelcomeDialog::accept);
+    connect(buttons, &QDialogButtonBox::rejected, this, &DkWelcomeDialog::reject);
 
     layout->addItem(new QSpacerItem(10, 10), 0, 0, -1, -1);
     layout->addWidget(welcomeLabel, 1, 0, 1, 3);
@@ -3716,20 +3724,22 @@ void DkArchiveExtractionDialog::createLayout()
     mArchivePathEdit = new QLineEdit(this);
     mArchivePathEdit->setObjectName("DkWarningEdit");
     mArchivePathEdit->setValidator(&mFileValidator);
-    connect(mArchivePathEdit, SIGNAL(textChanged(const QString &)), this, SLOT(textChanged(const QString &)));
-    connect(mArchivePathEdit, SIGNAL(editingFinished()), this, SLOT(loadArchive()));
+    connect(mArchivePathEdit, &QLineEdit::textChanged, this, &DkArchiveExtractionDialog::textChanged);
+    connect(mArchivePathEdit, &QLineEdit::editingFinished, this, [this]() {
+        loadArchive();
+    });
 
     QPushButton *openArchiveButton = new QPushButton(tr("&Browse"));
-    connect(openArchiveButton, SIGNAL(pressed()), this, SLOT(openArchive()));
+    connect(openArchiveButton, &QPushButton::pressed, this, &DkArchiveExtractionDialog::openArchive);
 
     // dir file path
     QLabel *dirLabel = new QLabel(tr("Extract to"));
     mDirPathEdit = new QLineEdit();
     mDirPathEdit->setValidator(&mFileValidator);
-    connect(mDirPathEdit, SIGNAL(textChanged(const QString &)), this, SLOT(dirTextChanged(const QString &)));
+    connect(mDirPathEdit, &QLineEdit::textChanged, this, &DkArchiveExtractionDialog::dirTextChanged);
 
     QPushButton *openDirButton = new QPushButton(tr("&Browse"));
-    connect(openDirButton, SIGNAL(pressed()), this, SLOT(openDir()));
+    connect(openDirButton, &QPushButton::pressed, this, &DkArchiveExtractionDialog::openDir);
 
     mFeedbackLabel = new QLabel("", this);
     mFeedbackLabel->setObjectName("DkDecentInfo");
@@ -3738,15 +3748,19 @@ void DkArchiveExtractionDialog::createLayout()
 
     mRemoveSubfolders = new QCheckBox(tr("Remove Subfolders"), this);
     mRemoveSubfolders->setChecked(false);
-    connect(mRemoveSubfolders, SIGNAL(stateChanged(int)), this, SLOT(checkbocChecked(int)));
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+    connect(mRemoveSubfolders, &QCheckBox::checkStateChanged, this, &DkArchiveExtractionDialog::checkbocChecked);
+#else
+    connect(mRemoveSubfolders, &QCheckBox::stateChanged, this, &DkArchiveExtractionDialog::checkbocChecked);
+#endif
 
     // mButtons
     mButtons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, Qt::Horizontal, this);
     mButtons->button(QDialogButtonBox::Ok)->setText(tr("&Extract"));
     mButtons->button(QDialogButtonBox::Ok)->setEnabled(false);
     mButtons->button(QDialogButtonBox::Cancel)->setText(tr("&Cancel"));
-    connect(mButtons, SIGNAL(accepted()), this, SLOT(accept()));
-    connect(mButtons, SIGNAL(rejected()), this, SLOT(reject()));
+    connect(mButtons, &QDialogButtonBox::accepted, this, &DkArchiveExtractionDialog::accept);
+    connect(mButtons, &QDialogButtonBox::rejected, this, &DkArchiveExtractionDialog::reject);
 
     QWidget *extractWidget = new QWidget(this);
     QGridLayout *gdLayout = new QGridLayout(extractWidget);
@@ -4004,10 +4018,10 @@ DkDialogManager::DkDialogManager(QObject *parent)
 {
     DkActionManager &am = DkActionManager::instance();
 
-    connect(am.action(DkActionManager::menu_edit_shortcuts), SIGNAL(triggered()), this, SLOT(openShortcutsDialog()));
-    connect(am.action(DkActionManager::menu_file_app_manager), SIGNAL(triggered()), this, SLOT(openAppManager()));
-    connect(am.action(DkActionManager::menu_file_print), SIGNAL(triggered()), this, SLOT(openPrintDialog()));
-    connect(am.action(DkActionManager::menu_tools_mosaic), SIGNAL(triggered()), this, SLOT(openMosaicDialog()));
+    connect(am.action(DkActionManager::menu_edit_shortcuts), &QAction::triggered, this, &DkDialogManager::openShortcutsDialog);
+    connect(am.action(DkActionManager::menu_file_app_manager), &QAction::triggered, this, &DkDialogManager::openAppManager);
+    connect(am.action(DkActionManager::menu_file_print), &QAction::triggered, this, &DkDialogManager::openPrintDialog);
+    connect(am.action(DkActionManager::menu_tools_mosaic), &QAction::triggered, this, &DkDialogManager::openMosaicDialog);
 }
 
 void DkDialogManager::openShortcutsDialog() const
@@ -4055,7 +4069,7 @@ void DkDialogManager::openAppManager() const
     DkActionManager &am = DkActionManager::instance();
 
     DkAppManagerDialog *appManagerDialog = new DkAppManagerDialog(am.appManager(), DkUtils::getMainWindow());
-    connect(appManagerDialog, SIGNAL(openWithSignal(QAction *)), am.appManager(), SIGNAL(openFileSignal(QAction *))); // forward
+    connect(appManagerDialog, &DkAppManagerDialog::openWithSignal, am.appManager(), &DkAppManager::openFileSignal); // forward
     appManagerDialog->exec();
 
     appManagerDialog->deleteLater();
@@ -4262,8 +4276,8 @@ void DkSvgSizeDialog::createLayout()
     auto buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, Qt::Horizontal, this);
     buttons->button(QDialogButtonBox::Ok)->setText(tr("&OK"));
     buttons->button(QDialogButtonBox::Cancel)->setText(tr("&Cancel"));
-    connect(buttons, SIGNAL(accepted()), this, SLOT(accept()));
-    connect(buttons, SIGNAL(rejected()), this, SLOT(reject()));
+    connect(buttons, &QDialogButtonBox::accepted, this, &DkSvgSizeDialog::accept);
+    connect(buttons, &QDialogButtonBox::rejected, this, &DkSvgSizeDialog::reject);
 
     QGridLayout *layout = new QGridLayout(this);
     layout->addWidget(wl, 1, 1);
@@ -4323,8 +4337,8 @@ void DkChooseMonitorDialog::createLayout()
     auto buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, Qt::Horizontal, this);
     buttons->button(QDialogButtonBox::Ok)->setText(tr("&OK"));
     buttons->button(QDialogButtonBox::Cancel)->setText(tr("&Cancel"));
-    connect(buttons, SIGNAL(accepted()), this, SLOT(accept()));
-    connect(buttons, SIGNAL(rejected()), this, SLOT(reject()));
+    connect(buttons, &QDialogButtonBox::accepted, this, &DkChooseMonitorDialog::accept);
+    connect(buttons, &QDialogButtonBox::rejected, this, &DkChooseMonitorDialog::reject);
 
     QGridLayout *layout = new QGridLayout(this);
     layout->setRowStretch(0, 1);

--- a/ImageLounge/src/DkGui/DkDialog.cpp
+++ b/ImageLounge/src/DkGui/DkDialog.cpp
@@ -1482,7 +1482,6 @@ DkShortcutDelegate::DkShortcutDelegate(QObject *parent)
     mClearPm = DkImage::loadIcon(":/nomacs/img/close.svg");
 }
 
-// TODO: I don't think this is ever used
 QWidget *DkShortcutDelegate::createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const
 {
     QWidget *scW = QItemDelegate::createEditor(parent, option, index);
@@ -1490,9 +1489,10 @@ QWidget *DkShortcutDelegate::createEditor(QWidget *parent, const QStyleOptionVie
     if (!scW)
         return scW;
 
-    // TODO: It would seem that this line wants scW to be QKeySequenceEdit,
-    // but I could not verify because this is never called.
-    connect(scW, SIGNAL(keySequenceChanged(const QKeySequence &)), this, SLOT(keySequenceChanged(const QKeySequence &)));
+    const auto edit = dynamic_cast<QKeySequenceEdit *>(scW);
+    if (edit != nullptr) {
+        connect(edit, &QKeySequenceEdit::keySequenceChanged, this, &DkShortcutDelegate::keySequenceChanged);
+    }
 
     return scW;
 }

--- a/ImageLounge/src/DkGui/DkLogWidget.cpp
+++ b/ImageLounge/src/DkGui/DkLogWidget.cpp
@@ -52,7 +52,7 @@ DkLogWidget::DkLogWidget(QWidget *parent)
     if (!msgQueuer)
         msgQueuer = QSharedPointer<DkMessageQueuer>(new DkMessageQueuer());
 
-    connect(msgQueuer.data(), SIGNAL(message(const QString &)), this, SLOT(log(const QString &)), Qt::QueuedConnection);
+    connect(msgQueuer.data(), &DkMessageQueuer::message, this, &DkLogWidget::log, Qt::QueuedConnection);
 
     qInstallMessageHandler(widgetMessageHandler);
 }

--- a/ImageLounge/src/DkGui/DkManipulatorWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkManipulatorWidgets.cpp
@@ -70,7 +70,7 @@ DkManipulatorWidget::DkManipulatorWidget(QWidget *parent)
         w->setObjectName("darkManipulator");
 
     for (QAction *a : am.manipulatorActions())
-        connect(a, SIGNAL(triggered()), this, SLOT(selectManipulator()), Qt::UniqueConnection);
+        connect(a, &QAction::triggered, this, &DkManipulatorWidget::selectManipulator, Qt::UniqueConnection);
 }
 
 void DkManipulatorWidget::createLayout()
@@ -90,7 +90,7 @@ void DkManipulatorWidget::createLayout()
         auto mpl = am.manipulatorManager().manipulatorExt((DkManipulatorManager::ManipulatorExtId)idx);
 
         DkTabEntryWidget *entry = new DkTabEntryWidget(mpl->action()->icon(), mpl->name(), this);
-        connect(entry, SIGNAL(clicked()), mpl->action(), SIGNAL(triggered()), Qt::UniqueConnection);
+        connect(entry, &DkTabEntryWidget::clicked, mpl->action(), &QAction::triggered, Qt::UniqueConnection);
 
         aLayout->addWidget(entry);
         group->addButton(entry);
@@ -124,7 +124,7 @@ void DkManipulatorWidget::createLayout()
     undoButton->setIconSize(QSize(32, 32));
     undoButton->setObjectName("DkRestartButton");
     undoButton->setStatusTip(tr("Undo"));
-    connect(undoButton, SIGNAL(clicked()), am.action(DkActionManager::menu_edit_undo), SIGNAL(triggered()));
+    connect(undoButton, &QPushButton::clicked, am.action(DkActionManager::menu_edit_undo), &QAction::triggered);
 
     pm = DkImage::colorizePixmap(QIcon(":/nomacs/img/rotate-cw.svg").pixmap(QSize(32, 32)), QColor(255, 255, 255));
     QPushButton *redoButton = new QPushButton(pm, "", this);
@@ -132,7 +132,7 @@ void DkManipulatorWidget::createLayout()
     redoButton->setIconSize(QSize(32, 32));
     redoButton->setObjectName("DkRestartButton");
     redoButton->setStatusTip(tr("Redo"));
-    connect(redoButton, SIGNAL(clicked()), am.action(DkActionManager::menu_edit_redo), SIGNAL(triggered()));
+    connect(redoButton, &QPushButton::clicked, am.action(DkActionManager::menu_edit_redo), &QAction::triggered);
 
     QWidget *buttonWidget = new QWidget(this);
     QHBoxLayout *buttonLayout = new QHBoxLayout(buttonWidget);
@@ -413,7 +413,7 @@ DkResizeWidget::DkResizeWidget(QSharedPointer<DkBaseManipulatorExt> manipulator,
     manipulator->setWidget(this);
 
     // I would have loved setObjectName to be virtual : )
-    connect(this, SIGNAL(objectNameChanged(const QString &)), this, SLOT(onObjectNameChanged(const QString &)));
+    connect(this, &DkResizeWidget::objectNameChanged, this, &DkResizeWidget::onObjectNameChanged);
 }
 
 QSharedPointer<DkResizeManipulator> DkResizeWidget::manipulator() const

--- a/ImageLounge/src/DkGui/DkMenu.cpp
+++ b/ImageLounge/src/DkGui/DkMenu.cpp
@@ -55,7 +55,7 @@ DkMenuBar::DkMenuBar(QWidget *parent, int timeToShow)
 
     mTimerMenu = new QTimer(this);
     mTimerMenu->setSingleShot(true);
-    connect(mTimerMenu, SIGNAL(timeout()), this, SLOT(hideMenu()));
+    connect(mTimerMenu, &QTimer::timeout, this, &DkMenuBar::hideMenu);
 
     // uncomment if you want to show menu on start-up
     // if (timeToShow != -1)
@@ -153,8 +153,8 @@ void DkMenuBar::leaveEvent(QEvent *event)
 DkTcpMenu::DkTcpMenu(const QString &title, QWidget *parent)
     : QMenu(title, parent)
 {
-    connect(this, SIGNAL(aboutToShow()), this, SLOT(updatePeers()));
-    connect(this, SIGNAL(synchronizeWithSignal(quint16)), DkSyncManager::inst().client(), SLOT(synchronizeWith(quint16)));
+    connect(this, &DkTcpMenu::aboutToShow, this, &DkTcpMenu::updatePeers);
+    connect(this, &DkTcpMenu::synchronizeWithSignal, DkSyncManager::inst().client(), &DkClientManager::synchronizeWith);
 }
 
 DkTcpMenu::~DkTcpMenu()
@@ -234,9 +234,11 @@ void DkTcpMenu::updatePeers()
         if (!mNoClientsFound)
             peerEntry->setTcpActions(&mTcpActions);
 
-        connect(peerEntry, SIGNAL(synchronizeWithSignal(quint16)), ct, SLOT(synchronizeWith(quint16)));
-        connect(peerEntry, SIGNAL(disableSynchronizeWithSignal(quint16)), ct, SLOT(stopSynchronizeWith(quint16)));
-        connect(peerEntry, SIGNAL(enableActions(bool)), this, SLOT(enableActions(bool)));
+        connect(peerEntry, &DkTcpAction::synchronizeWithSignal, ct, &DkClientManager::synchronizeWith);
+        connect(peerEntry, &DkTcpAction::disableSynchronizeWithSignal, ct, &DkClientManager::stopSynchronizeWith);
+        connect(peerEntry, &DkTcpAction::enableActions, this, [this](bool enable) {
+            this->enableActions(enable);
+        });
 
         addAction(peerEntry);
     }
@@ -279,7 +281,7 @@ void DkTcpAction::init()
     setObjectName("tcpAction");
     setCheckable(true);
     setChecked(peer->isSynchronized());
-    connect(this, SIGNAL(triggered(bool)), this, SLOT(synchronize(bool)));
+    connect(this, &DkTcpAction::triggered, this, &DkTcpAction::synchronize);
 }
 
 void DkTcpAction::setTcpActions(QList<QAction *> *actions)

--- a/ImageLounge/src/DkGui/DkMetaDataWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkMetaDataWidgets.cpp
@@ -470,7 +470,7 @@ void DkMetaDataDock::setImage(QSharedPointer<DkImageContainerT> imgC)
         // we need to load the thumbnail fresh to guarantee, that we just consider the exif thumb
         // the imgC thumbnail might be created from the image
         mThumb = QSharedPointer<DkThumbNailT>(new DkThumbNailT(imgC->filePath()));
-        connect(mThumb.data(), SIGNAL(thumbLoadedSignal(bool)), this, SLOT(thumbLoaded(bool)));
+        connect(mThumb.data(), &DkThumbNailT::thumbLoadedSignal, this, &DkMetaDataDock::thumbLoaded);
         mThumb->fetchThumb(DkThumbNailT::force_exif_thumb);
     }
 }
@@ -575,7 +575,7 @@ void DkMetaDataSelection::createLayout()
 
     mCbCheckAll = new QCheckBox(tr("Check All"), this);
     mCbCheckAll->setTristate(true);
-    connect(mCbCheckAll, SIGNAL(clicked(bool)), this, SLOT(checkAll(bool)));
+    connect(mCbCheckAll, &QCheckBox::clicked, this, &DkMetaDataSelection::checkAll);
 
     QVBoxLayout *l = new QVBoxLayout(this);
     l->addWidget(scrollArea);
@@ -588,7 +588,7 @@ void DkMetaDataSelection::appendGUIEntry(const QString &key, const QString &valu
     cleanKey = cleanKey.replace(".", " > ");
 
     QCheckBox *cb = new QCheckBox(cleanKey, this);
-    connect(cb, SIGNAL(clicked()), this, SLOT(selectionChanged()));
+    connect(cb, &QCheckBox::clicked, this, &DkMetaDataSelection::selectionChanged);
     mSelection.append(cb);
 
     QString cleanValue = DkUtils::cleanFraction(value);
@@ -752,32 +752,32 @@ void DkMetaDataHUD::createActions()
 
     mActions[action_change_keys] = new QAction(tr("Change Entries"), this);
     mActions[action_change_keys]->setStatusTip(tr("You can customize the entries displayed here."));
-    connect(mActions[action_change_keys], SIGNAL(triggered()), this, SLOT(changeKeys()));
+    connect(mActions[action_change_keys], &QAction::triggered, this, &DkMetaDataHUD::changeKeys);
 
     mActions[action_num_columns] = new QAction(tr("Number of Columns"), this);
     mActions[action_num_columns]->setStatusTip(tr("Select the desired number of columns."));
-    connect(mActions[action_num_columns], SIGNAL(triggered()), this, SLOT(changeNumColumns()));
+    connect(mActions[action_num_columns], &QAction::triggered, this, &DkMetaDataHUD::changeNumColumns);
 
     mActions[action_set_to_default] = new QAction(tr("Set to Default"), this);
     mActions[action_set_to_default]->setStatusTip(tr("Reset the metadata panel."));
-    connect(mActions[action_set_to_default], SIGNAL(triggered()), this, SLOT(setToDefault()));
+    connect(mActions[action_set_to_default], &QAction::triggered, this, &DkMetaDataHUD::setToDefault);
 
     // orientations
     mActions[action_pos_west] = new QAction(tr("Show Left"), this);
     mActions[action_pos_west]->setStatusTip(tr("Shows the Metadata on the Left"));
-    connect(mActions[action_pos_west], SIGNAL(triggered()), this, SLOT(newPosition()));
+    connect(mActions[action_pos_west], &QAction::triggered, this, &DkMetaDataHUD::newPosition);
 
     mActions[action_pos_north] = new QAction(tr("Show Top"), this);
     mActions[action_pos_north]->setStatusTip(tr("Shows the Metadata at the Top"));
-    connect(mActions[action_pos_north], SIGNAL(triggered()), this, SLOT(newPosition()));
+    connect(mActions[action_pos_north], &QAction::triggered, this, &DkMetaDataHUD::newPosition);
 
     mActions[action_pos_east] = new QAction(tr("Show Right"), this);
     mActions[action_pos_east]->setStatusTip(tr("Shows the Metadata on the Right"));
-    connect(mActions[action_pos_east], SIGNAL(triggered()), this, SLOT(newPosition()));
+    connect(mActions[action_pos_east], &QAction::triggered, this, &DkMetaDataHUD::newPosition);
 
     mActions[action_pos_south] = new QAction(tr("Show Bottom"), this);
     mActions[action_pos_south]->setStatusTip(tr("Shows the Metadata at the Bottom"));
-    connect(mActions[action_pos_south], SIGNAL(triggered()), this, SLOT(newPosition()));
+    connect(mActions[action_pos_south], &QAction::triggered, this, &DkMetaDataHUD::newPosition);
 }
 
 void DkMetaDataHUD::loadSettings()
@@ -1098,8 +1098,8 @@ void DkMetaDataHUD::changeKeys()
     QDialogButtonBox *buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, Qt::Horizontal, this);
     buttons->button(QDialogButtonBox::Ok)->setText(tr("&OK"));
     buttons->button(QDialogButtonBox::Cancel)->setText(tr("&Cancel"));
-    connect(buttons, SIGNAL(accepted()), dialog, SLOT(accept()));
-    connect(buttons, SIGNAL(rejected()), dialog, SLOT(reject()));
+    connect(buttons, &QDialogButtonBox::accepted, dialog, &QDialog::accept);
+    connect(buttons, &QDialogButtonBox::rejected, dialog, &QDialog::reject);
 
     QVBoxLayout *layout = new QVBoxLayout(dialog);
     layout->addWidget(selWidget);

--- a/ImageLounge/src/DkGui/DkNetwork.cpp
+++ b/ImageLounge/src/DkGui/DkNetwork.cpp
@@ -169,9 +169,10 @@ void DkClientManager::sendTitle(const QString &newTitle)
         if (!peer)
             continue;
 
-        connect(this, SIGNAL(sendNewTitleMessage(const QString &)), peer->connection, SLOT(sendNewTitleMessage(const QString &)));
+        // TODO: why not call the method directly?
+        connect(this, &DkClientManager::sendNewTitleMessage, peer->connection, &DkConnection::sendNewTitleMessage);
         emit sendNewTitleMessage(newTitle);
-        disconnect(this, SIGNAL(sendNewTitleMessage(const QString &)), peer->connection, SLOT(sendNewTitleMessage(const QString &)));
+        disconnect(this, &DkClientManager::sendNewTitleMessage, peer->connection, &DkConnection::sendNewTitleMessage);
     }
 }
 
@@ -182,15 +183,9 @@ void DkClientManager::sendTransform(QTransform transform, QTransform imgTransfor
         if (!peer)
             continue;
 
-        connect(this,
-                SIGNAL(sendNewTransformMessage(QTransform, QTransform, QPointF)),
-                peer->connection,
-                SLOT(sendNewTransformMessage(QTransform, QTransform, QPointF)));
+        connect(this, &DkClientManager::sendNewTransformMessage, peer->connection, &DkConnection::sendNewTransformMessage);
         emit sendNewTransformMessage(transform, imgTransform, canvasSize);
-        disconnect(this,
-                   SIGNAL(sendNewTransformMessage(QTransform, QTransform, QPointF)),
-                   peer->connection,
-                   SLOT(sendNewTransformMessage(QTransform, QTransform, QPointF)));
+        disconnect(this, &DkClientManager::sendNewTransformMessage, peer->connection, &DkConnection::sendNewTransformMessage);
     }
 }
 
@@ -201,9 +196,9 @@ void DkClientManager::sendPosition(QRect newRect, bool overlaid)
         if (!peer)
             continue;
 
-        connect(this, SIGNAL(sendNewPositionMessage(QRect, bool, bool)), peer->connection, SLOT(sendNewPositionMessage(QRect, bool, bool)));
+        connect(this, &DkClientManager::sendNewPositionMessage, peer->connection, &DkConnection::sendNewPositionMessage);
         emit sendNewPositionMessage(newRect, true, overlaid);
-        disconnect(this, SIGNAL(sendNewPositionMessage(QRect, bool, bool)), peer->connection, SLOT(sendNewPositionMessage(QRect, bool, bool)));
+        disconnect(this, &DkClientManager::sendNewPositionMessage, peer->connection, &DkConnection::sendNewPositionMessage);
     }
 }
 
@@ -214,9 +209,9 @@ void DkClientManager::sendNewFile(qint16 op, const QString &filename)
         if (!peer)
             continue;
 
-        connect(this, SIGNAL(sendNewFileMessage(qint16, const QString &)), peer->connection, SLOT(sendNewFileMessage(qint16, const QString &)));
+        connect(this, &DkClientManager::sendNewFileMessage, peer->connection, &DkConnection::sendNewFileMessage);
         emit sendNewFileMessage(op, filename);
-        disconnect(this, SIGNAL(sendNewFileMessage(qint16, const QString &)), peer->connection, SLOT(sendNewFileMessage(qint16, const QString &)));
+        disconnect(this, &DkClientManager::sendNewFileMessage, peer->connection, &DkConnection::sendNewFileMessage);
     }
 }
 
@@ -232,34 +227,16 @@ void DkClientManager::newConnection(int socketDescriptor)
 void DkClientManager::connectConnection(DkConnection *connection)
 {
     qRegisterMetaType<QList<quint16>>("QList<quint16>");
-    connect(connection,
-            SIGNAL(connectionReadyForUse(quint16, const QString &, DkConnection *)),
-            this,
-            SLOT(connectionReadyForUse(quint16, const QString &, DkConnection *)));
-    connect(connection, SIGNAL(connectionStopSynchronize(DkConnection *)), this, SLOT(connectionStopSynchronized(DkConnection *)));
-    connect(connection, SIGNAL(connectionStartSynchronize(QList<quint16>, DkConnection *)), this, SLOT(connectionSynchronized(QList<quint16>, DkConnection *)));
-    connect(connection, SIGNAL(disconnected()), this, SLOT(disconnected()));
-    connect(connection,
-            SIGNAL(connectionTitleHasChanged(DkConnection *, const QString &)),
-            this,
-            SLOT(connectionSentNewTitle(DkConnection *, const QString &)));
-    connect(connection,
-            SIGNAL(connectionNewPosition(DkConnection *, QRect, bool, bool)),
-            this,
-            SLOT(connectionReceivedPosition(DkConnection *, QRect, bool, bool)));
-    connect(connection,
-            SIGNAL(connectionNewTransform(DkConnection *, QTransform, QTransform, QPointF)),
-            this,
-            SLOT(connectionReceivedTransformation(DkConnection *, QTransform, QTransform, QPointF)));
-    connect(connection,
-            SIGNAL(connectionNewFile(DkConnection *, qint16, const QString &)),
-            this,
-            SLOT(connectionReceivedNewFile(DkConnection *, qint16, const QString &)));
-    connect(connection, SIGNAL(connectionGoodBye(DkConnection *)), this, SLOT(connectionReceivedGoodBye(DkConnection *)));
-    connect(connection,
-            SIGNAL(connectionShowStatusMessage(DkConnection *, const QString &)),
-            this,
-            SLOT(connectionShowStatusMessage(DkConnection *, const QString &)));
+    connect(connection, &DkConnection::connectionReadyForUse, this, &DkClientManager::connectionReadyForUse);
+    connect(connection, &DkConnection::connectionStopSynchronize, this, &DkClientManager::connectionStopSynchronized);
+    connect(connection, &DkConnection::connectionStartSynchronize, this, &DkClientManager::connectionSynchronized);
+    connect(connection, &DkConnection::disconnected, this, &DkClientManager::disconnected);
+    connect(connection, &DkConnection::connectionTitleHasChanged, this, &DkClientManager::connectionSentNewTitle);
+    connect(connection, &DkConnection::connectionNewPosition, this, &DkClientManager::connectionReceivedPosition);
+    connect(connection, &DkConnection::connectionNewTransform, this, &DkClientManager::connectionReceivedTransformation);
+    connect(connection, &DkConnection::connectionNewFile, this, &DkClientManager::connectionReceivedNewFile);
+    connect(connection, &DkConnection::connectionGoodBye, this, &DkClientManager::connectionReceivedGoodBye);
+    connect(connection, &DkConnection::connectionShowStatusMessage, this, &DkClientManager::connectionShowStatusMessage);
 
     connection->synchronizedPeersListChanged(mPeerList.getSynchronizedPeerServerPorts());
 }
@@ -296,9 +273,9 @@ void DkClientManager::sendGoodByeToAll()
         if (!peer)
             continue;
 
-        connect(this, SIGNAL(sendGoodByeMessage()), peer->connection, SLOT(sendNewGoodbyeMessage()));
+        connect(this, &DkClientManager::sendGoodByeMessage, peer->connection, &DkConnection::sendNewGoodbyeMessage);
         emit sendGoodByeMessage();
-        disconnect(this, SIGNAL(sendGoodByeMessage()), peer->connection, SLOT(sendNewGoodbyeMessage()));
+        disconnect(this, &DkClientManager::sendGoodByeMessage, peer->connection, &DkConnection::sendNewGoodbyeMessage);
     }
 }
 
@@ -338,13 +315,13 @@ QMimeData *DkLocalClientManager::mimeData() const
 void DkLocalClientManager::startServer()
 {
     mServer = new DkLocalTcpServer(this);
-    connect(mServer, SIGNAL(serverReiceivedNewConnection(int)), this, SLOT(newConnection(int)));
+    connect(mServer, &DkLocalTcpServer::serverReiceivedNewConnection, this, &DkLocalClientManager::newConnection);
 
     // TODO: hook on thread
     searchForOtherClients();
 
     DkActionManager &am = DkActionManager::instance();
-    connect(am.action(DkActionManager::menu_sync_connect_all), SIGNAL(triggered()), this, SLOT(connectAll()));
+    connect(am.action(DkActionManager::menu_sync_connect_all), &QAction::triggered, this, &DkLocalClientManager::connectAll);
 }
 
 // slots
@@ -397,9 +374,9 @@ void DkLocalClientManager::connectionSynchronized(QList<quint16> synchronizedPee
             if (!peer)
                 continue;
 
-            connect(this, SIGNAL(sendSynchronizeMessage()), peer->connection, SLOT(sendStartSynchronizeMessage()));
+            connect(this, &DkLocalClientManager::sendSynchronizeMessage, peer->connection, &DkConnection::sendStartSynchronizeMessage);
             emit sendSynchronizeMessage();
-            disconnect(this, SIGNAL(sendSynchronizeMessage()), peer->connection, SLOT(sendStartSynchronizeMessage()));
+            disconnect(this, &DkLocalClientManager::sendSynchronizeMessage, peer->connection, &DkConnection::sendStartSynchronizeMessage);
         }
     }
     // qDebug() << "--------------------";
@@ -441,9 +418,9 @@ void DkLocalClientManager::synchronizeWith(quint16 peerId)
 
     // qDebug() << "synchronizing with: " << peerId;
 
-    connect(this, SIGNAL(sendSynchronizeMessage()), peer->connection, SLOT(sendStartSynchronizeMessage()));
+    connect(this, &DkLocalClientManager::sendSynchronizeMessage, peer->connection, &DkConnection::sendStartSynchronizeMessage);
     emit sendSynchronizeMessage();
-    disconnect(this, SIGNAL(sendSynchronizeMessage()), peer->connection, SLOT(sendStartSynchronizeMessage()));
+    disconnect(this, &DkLocalClientManager::sendSynchronizeMessage, peer->connection, &DkConnection::sendStartSynchronizeMessage);
 }
 
 void DkLocalClientManager::stopSynchronizeWith(quint16)
@@ -454,10 +431,10 @@ void DkLocalClientManager::stopSynchronizeWith(quint16)
         if (!peer)
             continue;
 
-        connect(this, SIGNAL(sendDisableSynchronizeMessage()), peer->connection, SLOT(sendStopSynchronizeMessage()));
+        connect(this, &DkLocalClientManager::sendDisableSynchronizeMessage, peer->connection, &DkConnection::sendStopSynchronizeMessage);
         emit sendDisableSynchronizeMessage();
         mPeerList.setSynchronized(peer->peerId, false);
-        disconnect(this, SIGNAL(sendDisableSynchronizeMessage()), peer->connection, SLOT(sendStopSynchronizeMessage()));
+        disconnect(this, &DkLocalClientManager::sendDisableSynchronizeMessage, peer->connection, &DkConnection::sendStopSynchronizeMessage);
     }
 
     emit synchronizedPeersListChanged(mPeerList.getSynchronizedPeerServerPorts());
@@ -491,9 +468,9 @@ void DkLocalClientManager::sendArrangeInstances(bool overlaid)
             continue;
 
         QRect newPosition = QRect(curX, curY, width, height);
-        connect(this, SIGNAL(sendNewPositionMessage(QRect, bool, bool)), peer->connection, SLOT(sendNewPositionMessage(QRect, bool, bool)));
+        connect(this, &DkLocalClientManager::sendNewPositionMessage, peer->connection, &DkConnection::sendNewPositionMessage);
         emit sendNewPositionMessage(newPosition, false, overlaid);
-        disconnect(this, SIGNAL(sendNewPositionMessage(QRect, bool, bool)), peer->connection, SLOT(sendNewPositionMessage(QRect, bool, bool)));
+        disconnect(this, &DkLocalClientManager::sendNewPositionMessage, peer->connection, &DkConnection::sendNewPositionMessage);
 
         count++;
         if (count < instancesPerRow)
@@ -533,10 +510,10 @@ DkLocalConnection *DkLocalClientManager::createConnection()
     connection->setLocalTcpServerPort(mServer->serverPort());
     connection->setTitle(mCurrentTitle);
     connectConnection(connection);
-    connect(this, SIGNAL(synchronizedPeersListChanged(QList<quint16>)), connection, SLOT(synchronizedPeersListChanged(QList<quint16>)));
-    connect(this, SIGNAL(sendQuitMessage()), connection, SLOT(sendQuitMessage()));
-    connect(connection, SIGNAL(connectionQuitReceived()), this, SLOT(connectionReceivedQuit()));
-    connect(connection, SIGNAL(connected()), this, SLOT(connectToNomacs()));
+    connect(this, &DkLocalClientManager::synchronizedPeersListChanged, connection, &DkLocalConnection::synchronizedPeersListChanged);
+    connect(this, &DkLocalClientManager::sendQuitMessage, connection, &DkLocalConnection::sendQuitMessage);
+    connect(connection, &DkLocalConnection::connectionQuitReceived, this, &DkLocalClientManager::connectionReceivedQuit);
+    connect(connection, &DkLocalConnection::connected, this, &DkLocalClientManager::connectToNomacs);
 
     return connection;
 }
@@ -583,7 +560,7 @@ DkPeer::DkPeer(quint16 port,
     this->clientName = clientName;
     this->showInMenu = showInMenu;
     mHasChangedRecently = false;
-    connect(timer, SIGNAL(timeout()), this, SLOT(timerTimeout()), Qt::UniqueConnection);
+    connect(timer, &QTimer::timeout, this, &DkPeer::timerTimeout, Qt::UniqueConnection);
 }
 
 DkPeer::~DkPeer()
@@ -594,7 +571,7 @@ void DkPeer::setSynchronized(bool flag)
 {
     sychronized = flag;
     mHasChangedRecently = true;
-    connect(timer, SIGNAL(timeout()), this, SLOT(timerTimeout()), Qt::UniqueConnection);
+    connect(timer, &QTimer::timeout, this, &DkPeer::timerTimeout, Qt::UniqueConnection);
     timer->start(1000);
 }
 
@@ -757,8 +734,6 @@ DkSyncManager::DkSyncManager()
     DkTimer dt;
     mClient = new DkLocalClientManager("nomacs | Image Lounge", 0);
 
-    // connect(this, SIGNAL(syncWithSignal(quint16)), mClient, SLOT(synchronizeWith(quint16)));
-    // connect(this, SIGNAL(stopSyncWithSignal(quint16)), mClient, SLOT(stopSynchronizeWith(quint16)));
     qInfo() << "local client created in: " << dt; // takes 1 sec in the client thread
 }
 

--- a/ImageLounge/src/DkGui/DkNoMacs.cpp
+++ b/ImageLounge/src/DkGui/DkNoMacs.cpp
@@ -1913,8 +1913,7 @@ void DkNoMacs::restartWithTranslationUpdate()
 
     mTranslationUpdater->silent = true;
 
-    // TODO: restart does not exist in DkNoMacs
-    connect(mTranslationUpdater, SIGNAL(downloadFinished()), this, SLOT(restart()));
+    connect(mTranslationUpdater, &DkTranslationUpdater::downloadFinished, getTabWidget(), &DkCentralWidget::restart);
     updateTranslations();
 }
 

--- a/ImageLounge/src/DkGui/DkNoMacs.cpp
+++ b/ImageLounge/src/DkGui/DkNoMacs.cpp
@@ -280,8 +280,7 @@ void DkNoMacs::createActions()
     connect(am.action(DkActionManager::menu_file_rename), &QAction::triggered, this, &DkNoMacs::renameFile);
     connect(am.action(DkActionManager::menu_file_goto), &QAction::triggered, this, &DkNoMacs::goTo);
 
-    // TODO: centralWidget() returns showRecentFiles, not sure the underlying type
-    connect(am.action(DkActionManager::menu_file_show_recent), SIGNAL(triggered(bool)), centralWidget(), SLOT(showRecentFiles(bool)));
+    connect(am.action(DkActionManager::menu_file_show_recent), &QAction::triggered, getTabWidget(), &DkCentralWidget::showRecentFiles);
     connect(am.action(DkActionManager::menu_file_new_instance), &QAction::triggered, this, [this]() {
         newInstance();
     });

--- a/ImageLounge/src/DkGui/DkPong.cpp
+++ b/ImageLounge/src/DkGui/DkPong.cpp
@@ -322,8 +322,8 @@ DkPongPort::DkPongPort(QWidget *parent, Qt::WindowFlags)
     mCountDownTimer = new QTimer(this);
     mCountDownTimer->setInterval(500);
 
-    connect(mEventLoop, SIGNAL(timeout()), this, SLOT(gameLoop()));
-    connect(mCountDownTimer, SIGNAL(timeout()), this, SLOT(countDown()));
+    connect(mEventLoop, &QTimer::timeout, this, &DkPongPort::gameLoop);
+    connect(mCountDownTimer, &QTimer::timeout, this, &DkPongPort::countDown);
 
     initGame();
     pauseGame();

--- a/ImageLounge/src/DkGui/DkPreferenceWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkPreferenceWidgets.cpp
@@ -71,13 +71,13 @@ DkPreferenceWidget::DkPreferenceWidget(QWidget *parent)
 
     QAction *nextAction = new QAction(tr("next"), this);
     nextAction->setShortcut(Qt::Key_PageDown);
-    connect(nextAction, SIGNAL(triggered()), this, SLOT(nextTab()));
+    connect(nextAction, &QAction::triggered, this, &DkPreferenceWidget::nextTab);
     addAction(nextAction);
 
     QAction *previousAction = new QAction(tr("previous"), this);
     previousAction->setShortcut(Qt::Key_PageUp);
     previousAction->setShortcutContext(Qt::WidgetWithChildrenShortcut);
-    connect(previousAction, SIGNAL(triggered()), this, SLOT(previousTab()));
+    connect(previousAction, &QAction::triggered, this, &DkPreferenceWidget::previousTab);
     addAction(previousAction);
 }
 
@@ -95,7 +95,7 @@ void DkPreferenceWidget::createLayout()
     restartButton->setIconSize(pm.size());
     restartButton->setObjectName("DkRestartButton");
     restartButton->setStatusTip(tr("Restart nomacs"));
-    connect(restartButton, SIGNAL(clicked()), this, SIGNAL(restartSignal()));
+    connect(restartButton, &QPushButton::clicked, this, &DkPreferenceWidget::restartSignal);
 
     mTabLayout = new QVBoxLayout(tabs);
     mTabLayout->setContentsMargins(0, 60, 0, 0);
@@ -131,8 +131,8 @@ void DkPreferenceWidget::addTabWidget(DkPreferenceTabWidget *tabWidget)
 
     DkTabEntryWidget *tabEntry = new DkTabEntryWidget(tabWidget->icon(), tabWidget->name(), this);
     mTabLayout->insertWidget(mTabLayout->count() - 2, tabEntry); // -2 -> insert before stretch
-    connect(tabEntry, SIGNAL(clicked()), this, SLOT(changeTab()));
-    connect(tabWidget, SIGNAL(restartSignal()), this, SIGNAL(restartSignal()));
+    connect(tabEntry, &DkTabEntryWidget::clicked, this, &DkPreferenceWidget::changeTab);
+    connect(tabWidget, &DkPreferenceTabWidget::restartSignal, this, &DkPreferenceWidget::restartSignal);
     mTabEntries.append(tabEntry);
 
     // tick the first
@@ -201,7 +201,7 @@ void DkPreferenceTabWidget::createLayout()
     mInfoButton->setObjectName("infoButton");
     mInfoButton->setFlat(true);
     mInfoButton->setVisible(false);
-    connect(mInfoButton, SIGNAL(clicked()), this, SIGNAL(restartSignal()));
+    connect(mInfoButton, &QPushButton::clicked, this, &DkPreferenceTabWidget::restartSignal);
 
     QGridLayout *l = new QGridLayout(this);
     l->setContentsMargins(0, 0, 0, 0);
@@ -216,6 +216,7 @@ void DkPreferenceTabWidget::setWidget(QWidget *w)
     mCentralScroller->setWidget(w);
     w->setObjectName("DkPreferenceWidget");
 
+    // TODO: cannot get rid of this befause infoSignal is not an interface of QWidget
     connect(w, SIGNAL(infoSignal(const QString &)), this, SLOT(setInfoMessage(const QString &)));
 }
 
@@ -1536,14 +1537,8 @@ void DkEditorPreference::createLayout()
 
     layout->addWidget(mSettingsWidget);
 
-    connect(mSettingsWidget,
-            SIGNAL(changeSettingSignal(const QString &, const QVariant &, const QStringList &)),
-            this,
-            SLOT(changeSetting(const QString &, const QVariant &, const QStringList &)));
-    connect(mSettingsWidget,
-            SIGNAL(removeSettingSignal(const QString &, const QStringList &)),
-            this,
-            SLOT(removeSetting(const QString &, const QStringList &)));
+    connect(mSettingsWidget, &DkSettingsWidget::changeSettingSignal, this, &DkEditorPreference::changeSetting);
+    connect(mSettingsWidget, &DkSettingsWidget::removeSettingSignal, this, &DkEditorPreference::removeSetting);
 }
 void DkEditorPreference::paintEvent(QPaintEvent *event)
 {

--- a/ImageLounge/src/DkGui/DkPreferenceWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkPreferenceWidgets.cpp
@@ -215,9 +215,6 @@ void DkPreferenceTabWidget::setWidget(QWidget *w)
 {
     mCentralScroller->setWidget(w);
     w->setObjectName("DkPreferenceWidget");
-
-    // TODO: cannot get rid of this befause infoSignal is not an interface of QWidget
-    connect(w, SIGNAL(infoSignal(const QString &)), this, SLOT(setInfoMessage(const QString &)));
 }
 
 void DkPreferenceTabWidget::setInfoMessage(const QString &msg)

--- a/ImageLounge/src/DkGui/DkQuickAccess.cpp
+++ b/ImageLounge/src/DkGui/DkQuickAccess.cpp
@@ -146,7 +146,7 @@ DkQuickAccessEdit::DkQuickAccessEdit(QWidget *parent)
     mCompleter->setCaseSensitivity(Qt::CaseInsensitive);
     setCompleter(mCompleter);
 
-    connect(this, SIGNAL(returnPressed()), this, SLOT(editConfirmed()));
+    connect(this, &DkQuickAccessEdit::returnPressed, this, &DkQuickAccessEdit::editConfirmed);
 }
 
 void DkQuickAccessEdit::setModel(QStandardItemModel *model)

--- a/ImageLounge/src/DkGui/DkToolbars.cpp
+++ b/ImageLounge/src/DkGui/DkToolbars.cpp
@@ -313,9 +313,9 @@ void DkGradient::addSlider(qreal pos, QColor color)
 {
     DkColorSlider *actSlider = new DkColorSlider(this, pos, color, mSliderWidth);
     mSliders.append(actSlider);
-    connect(actSlider, SIGNAL(sliderMoved(DkColorSlider *, int, int)), this, SLOT(moveSlider(DkColorSlider *, int, int)));
-    connect(actSlider, SIGNAL(colorChanged(DkColorSlider *)), this, SLOT(changeColor(DkColorSlider *)));
-    connect(actSlider, SIGNAL(sliderActivated(DkColorSlider *)), this, SLOT(activateSlider(DkColorSlider *)));
+    connect(actSlider, &DkColorSlider::sliderMoved, this, &DkGradient::moveSlider);
+    connect(actSlider, &DkColorSlider::colorChanged, this, &DkGradient::changeColor);
+    connect(actSlider, &DkColorSlider::sliderActivated, this, &DkGradient::activateSlider);
 }
 
 void DkGradient::insertSlider(qreal pos, QColor col)
@@ -516,14 +516,14 @@ DkTransferToolBar::DkTransferToolBar(QWidget *parent)
     mHistoryCombo = new QComboBox(this);
 
     QAction *delGradientAction = new QAction(tr("Delete"), mHistoryCombo);
-    connect(delGradientAction, SIGNAL(triggered()), this, SLOT(deleteGradient()));
+    connect(delGradientAction, &QAction::triggered, this, &DkTransferToolBar::deleteGradient);
 
     mHistoryCombo->addAction(delGradientAction);
     mHistoryCombo->setContextMenuPolicy(Qt::ActionsContextMenu);
 
     updateGradientHistory();
-    connect(mHistoryCombo, SIGNAL(currentIndexChanged(int)), this, SLOT(switchGradient(int)));
-    connect(mHistoryCombo, SIGNAL(customContextMenuRequested(QPoint)), this, SLOT(deleteGradientMenu(QPoint)));
+    connect(mHistoryCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &DkTransferToolBar::switchGradient);
+    connect(mHistoryCombo, &QComboBox::customContextMenuRequested, this, &DkTransferToolBar::deleteGradientMenu);
 
     this->addWidget(mHistoryCombo);
 
@@ -547,11 +547,11 @@ DkTransferToolBar::DkTransferToolBar(QWidget *parent)
     enableToolBar(false);
     mEnableTFCheckBox->setEnabled(true);
 
-    connect(mEnableTFCheckBox, SIGNAL(stateChanged(int)), this, SLOT(enableTFCheckBoxClicked(int)));
-    connect(mGradient, SIGNAL(gradientChanged()), this, SLOT(applyTF()));
+    connect(mEnableTFCheckBox, &QCheckBox::stateChanged, this, &DkTransferToolBar::enableTFCheckBoxClicked);
+    connect(mGradient, &DkGradient::gradientChanged, this, &DkTransferToolBar::applyTF);
 
     // needed for initialization
-    connect(this, SIGNAL(gradientChanged()), mGradient, SIGNAL(gradientChanged()));
+    connect(this, &DkTransferToolBar::gradientChanged, mGradient, &DkGradient::gradientChanged);
 
     if (!mOldGradients.empty())
         mGradient->setGradient(mOldGradients.first());
@@ -575,7 +575,7 @@ void DkTransferToolBar::createIcons()
     mToolBarActions.resize(toolbar_end);
     mToolBarActions[toolbar_reset] = new QAction(mToolBarIcons[icon_toolbar_reset], tr("Reset"), this);
     mToolBarActions[toolbar_reset]->setStatusTip(tr("Resets the Pseudo Color function"));
-    connect(mToolBarActions[toolbar_reset], SIGNAL(triggered()), this, SLOT(resetGradient()));
+    connect(mToolBarActions[toolbar_reset], &QAction::triggered, this, &DkTransferToolBar::resetGradient);
 
     // toolBarActions[toolbar_reset]->setToolTip("was geht?");
 
@@ -583,11 +583,11 @@ void DkTransferToolBar::createIcons()
     mToolBarActions[toolbar_pipette]->setStatusTip(tr("Adds a slider at the selected color value"));
     mToolBarActions[toolbar_pipette]->setCheckable(true);
     mToolBarActions[toolbar_pipette]->setChecked(false);
-    connect(mToolBarActions[toolbar_pipette], SIGNAL(triggered(bool)), this, SLOT(pickColor(bool)));
+    connect(mToolBarActions[toolbar_pipette], &QAction::triggered, this, &DkTransferToolBar::pickColor);
 
     mToolBarActions[toolbar_save] = new QAction(mToolBarIcons[icon_toolbar_save], tr("Save Gradient"), this);
     mToolBarActions[toolbar_save]->setStatusTip(tr("Saves the current Gradient"));
-    connect(mToolBarActions[toolbar_save], SIGNAL(triggered()), this, SLOT(saveGradient()));
+    connect(mToolBarActions[toolbar_save], &QAction::triggered, this, &DkTransferToolBar::saveGradient);
 
     addActions(mToolBarActions.toList());
 }
@@ -654,7 +654,7 @@ void DkTransferToolBar::deleteGradientMenu(QPoint pos)
 {
     QMenu *cm = new QMenu(this);
     QAction *delAction = new QAction("Delete", this);
-    connect(delAction, SIGNAL(triggered()), this, SLOT(deleteGradient()));
+    connect(delAction, &QAction::triggered, this, &DkTransferToolBar::deleteGradient);
     cm->popup(mHistoryCombo->mapToGlobal(pos));
     cm->exec();
 }
@@ -705,7 +705,7 @@ void DkTransferToolBar::applyImageMode(int mode)
         return;
     }
 
-    disconnect(mChannelComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(changeChannel(int)));
+    disconnect(mChannelComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &DkTransferToolBar::changeChannel);
     mChannelComboBox->clear();
 
     if (mode == mode_gray) {
@@ -719,7 +719,7 @@ void DkTransferToolBar::applyImageMode(int mode)
 
     mChannelComboBox->setCurrentIndex(0);
 
-    connect(mChannelComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(changeChannel(int)));
+    connect(mChannelComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &DkTransferToolBar::changeChannel);
 }
 
 void DkTransferToolBar::pickColor(bool enabled)
@@ -1006,7 +1006,7 @@ void DkCropToolBar::createLayout()
     addSeparator();
     addWidget(mCropRect);
 
-    connect(mCropRect, SIGNAL(updateRectSignal(const QRect &)), this, SIGNAL(updateRectSignal(const QRect &)));
+    connect(mCropRect, &DkRectWidget::updateRectSignal, this, &DkCropToolBar::updateRectSignal);
 }
 
 void DkCropToolBar::setVisible(bool visible)

--- a/ImageLounge/src/DkGui/DkViewPort.cpp
+++ b/ImageLounge/src/DkGui/DkViewPort.cpp
@@ -58,6 +58,7 @@
 #include <QSvgRenderer>
 #include <QVBoxLayout>
 #include <QtConcurrentRun>
+#include <QtGlobal>
 
 #include <qmath.h>
 #pragma warning(pop) // no warnings from includes - end
@@ -85,10 +86,10 @@ DkViewPort::DkViewPort(QWidget *parent)
     }
 
     mRepeatZoomTimer->setInterval(20);
-    connect(mRepeatZoomTimer, SIGNAL(timeout()), this, SLOT(repeatZoom()));
+    connect(mRepeatZoomTimer, &QTimer::timeout, this, &DkViewPort::repeatZoom);
 
     mAnimationTimer->setInterval(5);
-    connect(mAnimationTimer, SIGNAL(timeout()), this, SLOT(animateFade()));
+    connect(mAnimationTimer, &QTimer::timeout, this, &DkViewPort::animateFade);
 
     // no border
     setMouseTracking(true); // receive mouse event everytime
@@ -137,47 +138,47 @@ DkViewPort::DkViewPort(QWidget *parent)
     addActions(am.pluginActionManager()->pluginDummyActions().toList());
 #endif
 
-    connect(&mImgStorage, SIGNAL(infoSignal(const QString &)), this, SIGNAL(infoSignal(const QString &)));
+    connect(&mImgStorage, &DkImageStorage::infoSignal, this, &DkViewPort::infoSignal);
 
     if (am.pluginActionManager())
         connect(am.pluginActionManager(),
-                SIGNAL(runPlugin(DkPluginContainer *, const QString &)),
+                QOverload<DkPluginContainer *, const QString &>::of(&DkPluginActionManager::runPlugin),
                 this,
-                SLOT(applyPlugin(DkPluginContainer *, const QString &)));
+                &DkViewPort::applyPlugin);
 
     // connect
-    connect(am.action(DkActionManager::menu_file_reload), SIGNAL(triggered()), this, SLOT(reloadFile()));
-    connect(am.action(DkActionManager::menu_file_next), SIGNAL(triggered()), this, SLOT(loadNextFileFast()));
-    connect(am.action(DkActionManager::menu_file_prev), SIGNAL(triggered()), this, SLOT(loadPrevFileFast()));
-    connect(am.action(DkActionManager::menu_file_save), SIGNAL(triggered()), this, SLOT(saveFile()));
-    connect(am.action(DkActionManager::menu_file_save_as), SIGNAL(triggered()), this, SLOT(saveFileAs()));
-    connect(am.action(DkActionManager::menu_file_save_web), SIGNAL(triggered()), this, SLOT(saveFileWeb()));
-    connect(am.action(DkActionManager::menu_tools_wallpaper), SIGNAL(triggered()), this, SLOT(setAsWallpaper()));
+    connect(am.action(DkActionManager::menu_file_reload), &QAction::triggered, this, &DkViewPort::reloadFile);
+    connect(am.action(DkActionManager::menu_file_next), &QAction::triggered, this, &DkViewPort::loadNextFileFast);
+    connect(am.action(DkActionManager::menu_file_prev), &QAction::triggered, this, &DkViewPort::loadPrevFileFast);
+    connect(am.action(DkActionManager::menu_file_save), &QAction::triggered, this, &DkViewPort::saveFile);
+    connect(am.action(DkActionManager::menu_file_save_as), &QAction::triggered, this, &DkViewPort::saveFileAs);
+    connect(am.action(DkActionManager::menu_file_save_web), &QAction::triggered, this, &DkViewPort::saveFileWeb);
+    connect(am.action(DkActionManager::menu_tools_wallpaper), &QAction::triggered, this, &DkViewPort::setAsWallpaper);
 
-    connect(am.action(DkActionManager::menu_edit_rotate_cw), SIGNAL(triggered()), this, SLOT(rotateCW()));
-    connect(am.action(DkActionManager::menu_edit_rotate_ccw), SIGNAL(triggered()), this, SLOT(rotateCCW()));
-    connect(am.action(DkActionManager::menu_edit_rotate_180), SIGNAL(triggered()), this, SLOT(rotate180()));
-    connect(am.action(DkActionManager::menu_edit_transform), SIGNAL(triggered()), this, SLOT(resizeImage()));
-    connect(am.action(DkActionManager::menu_edit_delete), SIGNAL(triggered()), this, SLOT(deleteImage()));
-    connect(am.action(DkActionManager::menu_edit_copy), SIGNAL(triggered()), this, SLOT(copyImage()));
-    connect(am.action(DkActionManager::menu_edit_copy_buffer), SIGNAL(triggered()), this, SLOT(copyImageBuffer()));
-    connect(am.action(DkActionManager::menu_edit_copy_color), SIGNAL(triggered()), this, SLOT(copyPixelColorValue()));
+    connect(am.action(DkActionManager::menu_edit_rotate_cw), &QAction::triggered, this, &DkViewPort::rotateCW);
+    connect(am.action(DkActionManager::menu_edit_rotate_ccw), &QAction::triggered, this, &DkViewPort::rotateCCW);
+    connect(am.action(DkActionManager::menu_edit_rotate_180), &QAction::triggered, this, &DkViewPort::rotate180);
+    connect(am.action(DkActionManager::menu_edit_transform), &QAction::triggered, this, &DkViewPort::resizeImage);
+    connect(am.action(DkActionManager::menu_edit_delete), &QAction::triggered, this, &DkViewPort::deleteImage);
+    connect(am.action(DkActionManager::menu_edit_copy), &QAction::triggered, this, &DkViewPort::copyImage);
+    connect(am.action(DkActionManager::menu_edit_copy_buffer), &QAction::triggered, this, &DkViewPort::copyImageBuffer);
+    connect(am.action(DkActionManager::menu_edit_copy_color), &QAction::triggered, this, &DkViewPort::copyPixelColorValue);
 
-    connect(am.action(DkActionManager::menu_view_reset), SIGNAL(triggered()), this, SLOT(zoomToFit()));
-    connect(am.action(DkActionManager::menu_view_100), SIGNAL(triggered()), this, SLOT(fullView()));
-    connect(am.action(DkActionManager::menu_view_zoom_in), SIGNAL(triggered()), this, SLOT(zoomIn()));
-    connect(am.action(DkActionManager::menu_view_zoom_out), SIGNAL(triggered()), this, SLOT(zoomOut()));
-    connect(am.action(DkActionManager::menu_view_tp_pattern), SIGNAL(toggled(bool)), this, SLOT(togglePattern(bool)));
-    connect(am.action(DkActionManager::menu_view_movie_pause), SIGNAL(triggered(bool)), this, SLOT(pauseMovie(bool)));
-    connect(am.action(DkActionManager::menu_view_movie_prev), SIGNAL(triggered()), this, SLOT(previousMovieFrame()));
-    connect(am.action(DkActionManager::menu_view_movie_next), SIGNAL(triggered()), this, SLOT(nextMovieFrame()));
+    connect(am.action(DkActionManager::menu_view_reset), &QAction::triggered, this, &DkViewPort::zoomToFit);
+    connect(am.action(DkActionManager::menu_view_100), &QAction::triggered, this, &DkViewPort::fullView);
+    connect(am.action(DkActionManager::menu_view_zoom_in), &QAction::triggered, this, &DkViewPort::zoomIn);
+    connect(am.action(DkActionManager::menu_view_zoom_out), &QAction::triggered, this, &DkViewPort::zoomOut);
+    connect(am.action(DkActionManager::menu_view_tp_pattern), &QAction::toggled, this, &DkViewPort::togglePattern);
+    connect(am.action(DkActionManager::menu_view_movie_pause), &QAction::triggered, this, &DkViewPort::pauseMovie);
+    connect(am.action(DkActionManager::menu_view_movie_prev), &QAction::triggered, this, &DkViewPort::previousMovieFrame);
+    connect(am.action(DkActionManager::menu_view_movie_next), &QAction::triggered, this, &DkViewPort::nextMovieFrame);
 
-    connect(am.action(DkActionManager::sc_test_img), SIGNAL(triggered()), this, SLOT(loadLena()));
-    connect(am.action(DkActionManager::menu_sync_view), SIGNAL(triggered()), this, SLOT(tcpForceSynchronize()));
+    connect(am.action(DkActionManager::sc_test_img), &QAction::triggered, this, &DkViewPort::loadLena);
+    connect(am.action(DkActionManager::menu_sync_view), &QAction::triggered, this, &DkViewPort::tcpForceSynchronize);
 
     // playing
-    connect(mNavigationWidget, SIGNAL(previousSignal()), this, SLOT(loadPrevFileFast()));
-    connect(mNavigationWidget, SIGNAL(nextSignal()), this, SLOT(loadNextFileFast()));
+    connect(mNavigationWidget, &DkHudNavigation::previousSignal, this, &DkViewPort::loadPrevFileFast);
+    connect(mNavigationWidget, &DkHudNavigation::nextSignal, this, &DkViewPort::loadNextFileFast);
 
     // trivial connects
     connect(this, &DkViewPort::movieLoadedSignal, [this](bool movie) {
@@ -187,16 +188,18 @@ DkViewPort::DkViewPort(QWidget *parent)
     // connect sync
     auto cm = DkSyncManager::inst().client();
 
-    connect(this, SIGNAL(sendTransformSignal(QTransform, QTransform, QPointF)), cm, SLOT(sendTransform(QTransform, QTransform, QPointF)));
-    connect(this, SIGNAL(sendNewFileSignal(qint16, const QString &)), cm, SLOT(sendNewFile(qint16, const QString &)));
-    connect(cm, SIGNAL(receivedNewFile(qint16, const QString &)), this, SLOT(tcpLoadFile(qint16, const QString &)));
-    connect(cm, SIGNAL(updateConnectionSignal(const QString &)), mController, SLOT(setInfo(const QString &)));
-    connect(cm, SIGNAL(receivedTransformation(QTransform, QTransform, QPointF)), this, SLOT(tcpSetTransforms(QTransform, QTransform, QPointF)));
+    connect(this, &DkViewPort::sendTransformSignal, cm, &DkClientManager::sendTransform);
+    connect(this, &DkViewPort::sendNewFileSignal, cm, &DkClientManager::sendNewFile);
+    connect(cm, &DkClientManager::receivedNewFile, this, &DkViewPort::tcpLoadFile);
+    connect(cm, &DkClientManager::updateConnectionSignal, mController, [this](const QString &msg) {
+        mController->setInfo(msg);
+    });
+    connect(cm, &DkClientManager::receivedTransformation, this, &DkViewPort::tcpSetTransforms);
 
     for (auto action : am.manipulatorActions())
-        connect(action, SIGNAL(triggered()), this, SLOT(applyManipulator()));
+        connect(action, &QAction::triggered, this, &DkViewPort::applyManipulator);
 
-    connect(&mManipulatorWatcher, SIGNAL(finished()), this, SLOT(manipulatorApplied()));
+    connect(&mManipulatorWatcher, &QFutureWatcher<QImage>::finished, this, &DkViewPort::manipulatorApplied);
 
     // TODO:
     // one could blur the canvas if a transparent GUI is present
@@ -218,14 +221,14 @@ DkViewPort::~DkViewPort()
 void DkViewPort::createShortcuts()
 {
     DkActionManager &am = DkActionManager::instance();
-    connect(am.action(DkActionManager::sc_first_file), SIGNAL(triggered()), this, SLOT(loadFirst()));
-    connect(am.action(DkActionManager::sc_last_file), SIGNAL(triggered()), this, SLOT(loadLast()));
-    connect(am.action(DkActionManager::sc_skip_prev), SIGNAL(triggered()), this, SLOT(loadSkipPrev10()));
-    connect(am.action(DkActionManager::sc_skip_next), SIGNAL(triggered()), this, SLOT(loadSkipNext10()));
-    connect(am.action(DkActionManager::sc_first_file_sync), SIGNAL(triggered()), this, SLOT(loadFirst()));
-    connect(am.action(DkActionManager::sc_last_file_sync), SIGNAL(triggered()), this, SLOT(loadLast()));
-    connect(am.action(DkActionManager::sc_skip_next_sync), SIGNAL(triggered()), this, SLOT(loadNextFileFast()));
-    connect(am.action(DkActionManager::sc_skip_prev_sync), SIGNAL(triggered()), this, SLOT(loadPrevFileFast()));
+    connect(am.action(DkActionManager::sc_first_file), &QAction::triggered, this, &DkViewPort::loadFirst);
+    connect(am.action(DkActionManager::sc_last_file), &QAction::triggered, this, &DkViewPort::loadLast);
+    connect(am.action(DkActionManager::sc_skip_prev), &QAction::triggered, this, &DkViewPort::loadSkipPrev10);
+    connect(am.action(DkActionManager::sc_skip_next), &QAction::triggered, this, &DkViewPort::loadSkipNext10);
+    connect(am.action(DkActionManager::sc_first_file_sync), &QAction::triggered, this, &DkViewPort::loadFirst);
+    connect(am.action(DkActionManager::sc_last_file_sync), &QAction::triggered, this, &DkViewPort::loadLast);
+    connect(am.action(DkActionManager::sc_skip_next_sync), &QAction::triggered, this, &DkViewPort::loadNextFileFast);
+    connect(am.action(DkActionManager::sc_skip_prev_sync), &QAction::triggered, this, &DkViewPort::loadPrevFileFast);
 }
 
 void DkViewPort::setPaintWidget(QWidget *widget, bool removeWidget)
@@ -248,6 +251,11 @@ void DkViewPort::setImage(cv::Mat newImg)
     setImage(imgQt);
 }
 #endif
+
+void DkViewPort::updateLoadedImage(QSharedPointer<DkImageContainerT> image)
+{
+    updateImage(image, true);
+}
 
 void DkViewPort::updateImage(QSharedPointer<DkImageContainerT> image, bool loaded)
 {
@@ -1025,7 +1033,7 @@ void DkViewPort::loadMovie()
 
     mMovie = m;
 
-    connect(mMovie.data(), SIGNAL(frameChanged(int)), this, SLOT(update()));
+    connect(mMovie.data(), &QMovie::frameChanged, this, QOverload<>::of(&DkViewPort::update));
     mMovie->start();
 
     emit movieLoadedSignal(true);
@@ -1043,7 +1051,7 @@ void DkViewPort::loadSvg()
         mSvg = QSharedPointer<QSvgRenderer>(new QSvgRenderer(mLoader->filePath()));
     }
 
-    connect(mSvg.data(), SIGNAL(repaintNeeded()), this, SLOT(update()));
+    connect(mSvg.data(), &QSvgRenderer::repaintNeeded, this, QOverload<>::of(&DkViewPort::update));
 }
 
 void DkViewPort::pauseMovie(bool pause)
@@ -1864,96 +1872,77 @@ void DkViewPort::connectLoader(QSharedPointer<DkImageLoader> loader, bool connec
         return;
 
     if (connectSignals) {
+        connect(loader.data(), &DkImageLoader::imageLoadedSignal, this, &DkViewPort::updateImage, Qt::UniqueConnection);
         connect(loader.data(),
-                SIGNAL(imageLoadedSignal(QSharedPointer<DkImageContainerT>, bool)),
-                this,
-                SLOT(updateImage(QSharedPointer<DkImageContainerT>, bool)),
-                Qt::UniqueConnection);
-        connect(loader.data(),
-                SIGNAL(imageLoadedSignal(QSharedPointer<DkImageContainerT>)),
+                &DkImageLoader::imageLoadedSignal,
                 mController->getMetaDataWidget(),
-                SLOT(updateMetaData(QSharedPointer<DkImageContainerT>)),
+                QOverload<QSharedPointer<DkImageContainerT>>::of(&DkMetaDataHUD::updateMetaData),
                 Qt::UniqueConnection);
-        connect(loader.data(),
-                SIGNAL(imageLoadedSignal(QSharedPointer<DkImageContainerT>)),
-                mController,
-                SLOT(updateImage(QSharedPointer<DkImageContainerT>)),
-                Qt::UniqueConnection);
+        connect(loader.data(), &DkImageLoader::imageLoadedSignal, mController, &DkControlWidget::updateImage, Qt::UniqueConnection);
 
         connect(loader.data(),
-                SIGNAL(imageUpdatedSignal(QSharedPointer<DkImageContainerT>)),
+                QOverload<QSharedPointer<DkImageContainerT>>::of(&DkImageLoader::imageUpdatedSignal),
                 this,
-                SLOT(updateImage(QSharedPointer<DkImageContainerT>)),
+                &DkViewPort::updateLoadedImage,
                 Qt::UniqueConnection); // update image matrix
 
+        connect(loader.data(), &DkImageLoader::updateDirSignal, mController->getFilePreview(), &DkFilePreview::updateThumbs, Qt::UniqueConnection);
         connect(loader.data(),
-                SIGNAL(updateDirSignal(QVector<QSharedPointer<DkImageContainerT>>)),
+                QOverload<QSharedPointer<DkImageContainerT>>::of(&DkImageLoader::imageUpdatedSignal),
                 mController->getFilePreview(),
-                SLOT(updateThumbs(QVector<QSharedPointer<DkImageContainerT>>)),
-                Qt::UniqueConnection);
-        connect(loader.data(),
-                SIGNAL(imageUpdatedSignal(QSharedPointer<DkImageContainerT>)),
-                mController->getFilePreview(),
-                SLOT(setFileInfo(QSharedPointer<DkImageContainerT>)),
+                &DkFilePreview::setFileInfo,
                 Qt::UniqueConnection);
 
-        connect(loader.data(), SIGNAL(showInfoSignal(const QString &, int, int)), mController, SLOT(setInfo(const QString &, int, int)), Qt::UniqueConnection);
+        connect(loader.data(), &DkImageLoader::showInfoSignal, mController, &DkControlWidget::setInfo, Qt::UniqueConnection);
 
-        connect(loader.data(), SIGNAL(setPlayer(bool)), mController->getPlayer(), SLOT(play(bool)), Qt::UniqueConnection);
+        connect(loader.data(), &DkImageLoader::setPlayer, mController->getPlayer(), &DkPlayer::play, Qt::UniqueConnection);
 
+        connect(loader.data(), &DkImageLoader::updateDirSignal, mController->getScroller(), &DkFolderScrollBar::updateDir, Qt::UniqueConnection);
         connect(loader.data(),
-                SIGNAL(updateDirSignal(QVector<QSharedPointer<DkImageContainerT>>)),
+                QOverload<int>::of(&DkImageLoader::imageUpdatedSignal),
                 mController->getScroller(),
-                SLOT(updateDir(QVector<QSharedPointer<DkImageContainerT>>)),
+                &DkFolderScrollBar::updateFile,
                 Qt::UniqueConnection);
-        connect(loader.data(), SIGNAL(imageUpdatedSignal(int)), mController->getScroller(), SLOT(updateFile(int)), Qt::UniqueConnection);
-        connect(mController->getScroller(), SIGNAL(valueChanged(int)), loader.data(), SLOT(loadFileAt(int)));
+
+        // TODO: this connect seems to have no corresponding disconnect
+        connect(mController->getScroller(), &DkFolderScrollBar::valueChanged, loader.data(), &DkImageLoader::loadFileAt);
     } else {
+        disconnect(loader.data(), &DkImageLoader::imageLoadedSignal, this, &DkViewPort::updateImage);
         disconnect(loader.data(),
-                   SIGNAL(imageLoadedSignal(QSharedPointer<DkImageContainerT>, bool)),
-                   this,
-                   SLOT(updateImage(QSharedPointer<DkImageContainerT>, bool)));
-        disconnect(loader.data(),
-                   SIGNAL(imageLoadedSignal(QSharedPointer<DkImageContainerT>)),
+                   &DkImageLoader::imageLoadedSignal,
                    mController->getMetaDataWidget(),
-                   SLOT(updateMetaData(QSharedPointer<DkImageContainerT>)));
-        disconnect(loader.data(),
-                   SIGNAL(imageLoadedSignal(QSharedPointer<DkImageContainerT>)),
-                   mController,
-                   SLOT(updateImage(QSharedPointer<DkImageContainerT>)));
+                   QOverload<QSharedPointer<DkImageContainerT>>::of(&DkMetaDataHUD::updateMetaData));
+        disconnect(loader.data(), &DkImageLoader::imageLoadedSignal, mController, &DkControlWidget::updateImage);
 
-        disconnect(loader.data(), SIGNAL(imageUpdatedSignal(QSharedPointer<DkImageContainerT>)), this, SLOT(updateImage(QSharedPointer<DkImageContainerT>)));
+        disconnect(loader.data(), QOverload<QSharedPointer<DkImageContainerT>>::of(&DkImageLoader::imageUpdatedSignal), this, &DkViewPort::updateLoadedImage);
 
+        disconnect(loader.data(), &DkImageLoader::updateDirSignal, mController->getFilePreview(), &DkFilePreview::updateThumbs);
         disconnect(loader.data(),
-                   SIGNAL(updateDirSignal(QVector<QSharedPointer<DkImageContainerT>>)),
+                   QOverload<QSharedPointer<DkImageContainerT>>::of(&DkImageLoader::imageUpdatedSignal),
                    mController->getFilePreview(),
-                   SLOT(updateThumbs(QVector<QSharedPointer<DkImageContainerT>>)));
+                   &DkFilePreview::setFileInfo);
+
+        disconnect(loader.data(), &DkImageLoader::showInfoSignal, mController, &DkControlWidget::setInfo);
+
+        disconnect(loader.data(), &DkImageLoader::setPlayer, mController->getPlayer(), &DkPlayer::play);
+
+        disconnect(loader.data(), &DkImageLoader::updateDirSignal, mController->getScroller(), &DkFolderScrollBar::updateDir);
+
+        disconnect(loader.data(), QOverload<int>::of(&DkImageLoader::imageUpdatedSignal), mController->getScroller(), &DkFolderScrollBar::updateFile);
+
+        // TODO: this disconnect seems to have no corresponding connect
         disconnect(loader.data(),
-                   SIGNAL(imageUpdatedSignal(QSharedPointer<DkImageContainerT>)),
-                   mController->getFilePreview(),
-                   SLOT(setFileInfo(QSharedPointer<DkImageContainerT>)));
-        disconnect(loader.data(),
-                   SIGNAL(imageUpdatedSignal(QSharedPointer<DkImageContainerT>)),
+                   QOverload<QSharedPointer<DkImageContainerT>>::of(&DkImageLoader::imageUpdatedSignal),
                    mController->getMetaDataWidget(),
-                   SLOT(updateMetaData(QSharedPointer<DkImageContainerT>)));
+                   QOverload<QSharedPointer<DkImageContainerT>>::of(&DkMetaDataHUD::updateMetaData));
+        // TODO: this disconnect seems to have no corresponding connect
         disconnect(loader.data(),
-                   SIGNAL(imageUpdatedSignal(QSharedPointer<DkImageContainerT>)),
+                   QOverload<QSharedPointer<DkImageContainerT>>::of(&DkImageLoader::imageUpdatedSignal),
                    mController,
-                   SLOT(setFileInfo(QSharedPointer<DkImageContainerT>)));
+                   &DkControlWidget::updateImage);
 
-        disconnect(loader.data(), SIGNAL(showInfoSignal(const QString &, int, int)), mController, SLOT(setInfo(const QString &, int, int)));
-        disconnect(loader.data(), SIGNAL(updateSpinnerSignalDelayed(bool, int)), mController, SLOT(setSpinnerDelayed(bool, int)));
-
-        disconnect(loader.data(), SIGNAL(setPlayer(bool)), mController->getPlayer(), SLOT(play(bool)));
-
-        disconnect(loader.data(),
-                   SIGNAL(updateDirSignal(QVector<QSharedPointer<DkImageContainerT>>)),
-                   mController->getScroller(),
-                   SLOT(updateDir(QVector<QSharedPointer<DkImageContainerT>>)));
-        disconnect(loader.data(),
-                   SIGNAL(imageUpdatedSignal(QSharedPointer<DkImageContainerT>)),
-                   mController->getScroller(),
-                   SLOT(updateFile(QSharedPointer<DkImageContainerT>)));
+        // TODO: setSpinnerDelayed does not exist
+        // disconnect(loader.data(), &DkImageLoader::updateSpinnerSignalDelayed, mController, &DkControlWidget::setSpinnerDelayed);
     }
 }
 
@@ -2303,12 +2292,12 @@ DkViewPortContrast::DkViewPortContrast(QWidget *parent)
 
     // connect
     auto ttb = DkToolBarManager::inst().transferToolBar();
-    connect(ttb, SIGNAL(colorTableChanged(QGradientStops)), this, SLOT(changeColorTable(QGradientStops)));
-    connect(ttb, SIGNAL(channelChanged(int)), this, SLOT(changeChannel(int)));
-    connect(ttb, SIGNAL(pickColorRequest(bool)), this, SLOT(pickColor(bool)));
-    connect(ttb, SIGNAL(tFEnabled(bool)), this, SLOT(enableTF(bool)));
-    connect(this, SIGNAL(tFSliderAdded(qreal)), ttb, SLOT(insertSlider(qreal)));
-    connect(this, SIGNAL(imageModeSet(int)), ttb, SLOT(setImageMode(int)));
+    connect(ttb, &DkTransferToolBar::colorTableChanged, this, &DkViewPortContrast::changeColorTable);
+    connect(ttb, &DkTransferToolBar::channelChanged, this, &DkViewPortContrast::changeChannel);
+    connect(ttb, &DkTransferToolBar::pickColorRequest, this, &DkViewPortContrast::pickColor);
+    connect(ttb, &DkTransferToolBar::tFEnabled, this, &DkViewPortContrast::enableTF);
+    connect(this, &DkViewPortContrast::tFSliderAdded, ttb, &DkTransferToolBar::insertSlider);
+    connect(this, &DkViewPortContrast::imageModeSet, ttb, &DkTransferToolBar::setImageMode);
 }
 
 DkViewPortContrast::~DkViewPortContrast()

--- a/ImageLounge/src/DkGui/DkViewPort.h
+++ b/ImageLounge/src/DkGui/DkViewPort.h
@@ -188,6 +188,7 @@ public slots:
     virtual void applyManipulator();
     void manipulatorApplied();
 
+    void updateLoadedImage(QSharedPointer<DkImageContainerT> image);
     virtual void updateImage(QSharedPointer<DkImageContainerT> image, bool loaded = true);
     virtual void setImageUpdated();
     virtual void loadImage(const QImage &newImg);

--- a/ImageLounge/src/DkGui/DkWidgets.h
+++ b/ImageLounge/src/DkGui/DkWidgets.h
@@ -326,7 +326,6 @@ public slots:
     void animateOpacityUp();
     void animateOpacityDown();
 
-protected slots:
     void updateFile(int idx);
 
 signals:
@@ -835,7 +834,7 @@ public:
         if (time)
             timer->start(time);
 
-        connect(timer, SIGNAL(timeout()), this, SLOT(sendInfo()));
+        connect(timer, &QTimer::timeout, this, &DkDelayedInfo::sendInfo);
     }
 
     virtual ~DkDelayedInfo()

--- a/ImageLounge/src/main.cpp
+++ b/ImageLounge/src/main.cpp
@@ -323,7 +323,7 @@ int main(int argc, char *argv[])
 #ifdef Q_WS_MAC
     nmc::DkNomacsOSXEventFilter *osxEventFilter = new nmc::DkNomacsOSXEventFilter();
     app.installEventFilter(osxEventFilter);
-    QObject::connect(osxEventFilter, SIGNAL(loadFile(const QFileInfo &)), w, SLOT(loadFile(const QFileInfo &)));
+    QObject::connect(osxEventFilter, &nmc::DkNomacsOSXEventFilter::loadFile, w, &nmc::DkNoMacs::loadFile);
 #endif
 
     int rVal = -1;


### PR DESCRIPTION
Remove text based signal connection macros SIGNAL and SLOT in favor of function pointer based syntax. This enables compile time check of the signal and slot name and signatures, and makes the methods searchable via LSP.