### PR TITLE
Remove libquazip5-dev for Qt6 build

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -17,7 +17,7 @@ jobs:
           - ver: 5
             deps: "qttools5-dev-tools qtbase5-dev qttools5-dev libqt5svg5-dev qt5-image-formats-plugins libquazip5-dev"
           - ver: 6
-            deps: "qt6-tools-dev-tools qt6-base-dev qt6-tools-dev libqt6svg6-dev qt6-image-formats-plugins libquazip5-dev libgl-dev qt6-l10n-tools"
+            deps: "qt6-tools-dev-tools qt6-base-dev qt6-tools-dev libqt6svg6-dev qt6-image-formats-plugins libgl-dev qt6-l10n-tools"
         cmake_flags:
           - type: default
             flags: ""


### PR DESCRIPTION
libquazip5-dev is for Qt5. Ubuntu 22.04 does not have libquazip for Qt6, so we need to wait for 24.04 to enable it.

Tracking in https://github.com/nomacs/nomacs/issues/1116.


