### PR TITLE
Give default focus to central widget

### DIFF
--- a/ImageLounge/src/DkGui/DkControlWidget.cpp
+++ b/ImageLounge/src/DkGui/DkControlWidget.cpp
@@ -108,9 +108,7 @@ DkControlWidget::DkControlWidget(DkViewPort *parent, Qt::WindowFlags flags)
 
 void DkControlWidget::init()
 {
-    // debug: show invisible widgets
     setFocusPolicy(Qt::StrongFocus);
-    setFocus(Qt::TabFocusReason);
     setMouseTracking(true);
 
     // connect widgets with their settings

--- a/ImageLounge/src/DkGui/DkMetaDataWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkMetaDataWidgets.cpp
@@ -388,7 +388,6 @@ void DkMetaDataDock::createLayout()
 {
     mFilterEdit = new QLineEdit(this);
     mFilterEdit->setPlaceholderText(tr("Filter"));
-    mFilterEdit->setFocusPolicy(Qt::ClickFocus);
     connect(mFilterEdit, &QLineEdit::textChanged, this, &DkMetaDataDock::onFilterTextChanged);
 
     // create our beautiful shortcut view
@@ -402,7 +401,6 @@ void DkMetaDataDock::createLayout()
     mTreeView->setAlternatingRowColors(true);
     // mTreeView->setIndentation(8);
     // mTreeView->setStyleSheet("QTreeView{border: none;}");
-    mTreeView->setFocusPolicy(Qt::ClickFocus);
 
     mThumbNailLabel = new QLabel(tr("Thumbnail"), this);
     mThumbNailLabel->hide();

--- a/ImageLounge/src/main.cpp
+++ b/ImageLounge/src/main.cpp
@@ -67,6 +67,7 @@
 #include "DkSettings.h"
 #include "DkTimer.h"
 #include "DkUtils.h"
+#include "DkViewPort.h"
 
 #include "DkDependencyResolver.h"
 #include "DkMetaData.h"
@@ -319,6 +320,9 @@ int main(int argc, char *argv[])
     if (parser.isSet(slideshowOpt)) {
         cw->startSlideshow();
     }
+
+    if (cw->hasViewPort())
+        cw->getViewPort()->setFocus(Qt::TabFocusReason);
 
 #ifdef Q_WS_MAC
     nmc::DkNomacsOSXEventFilter *osxEventFilter = new nmc::DkNomacsOSXEventFilter();


### PR DESCRIPTION
On startup, gives focus to the central widget viewport, if there is one. This prevents any panel/dock from taking keyboard focus.

Other calls to setFocus/setFocusPolicy that were working around this are removed.

Fixes #843
Fixes #908
Fixes #629

