### PR TITLE
Startup: fix non-maximized window at startup on GNOME

### DIFF
--- a/ImageLounge/src/main.cpp
+++ b/ImageLounge/src/main.cpp
@@ -265,11 +265,20 @@ int main(int argc, char *argv[])
     } else
         w = new nmc::DkNoMacsIpl();
 
+    qInfo() << "maximized:" << w->isMaximized() << "fullscreen:" << w->isFullScreen();
+
     // show what we got...
     w->show();
 
-    // this triggers a first show
-    QCoreApplication::sendPostedEvents();
+    bool maximized = w->isMaximized();
+
+    while (!w->isActiveWindow())
+        qApp->processEvents();
+
+    // Qt emulates showMaximized() on some platforms (X11), so it might not work.
+    // If we try again with a visible window, it *could* work correctly (GNOME)
+    if (maximized && !w->isMaximized())
+        w->showMaximized();
 
     if (w)
         w->onWindowLoaded();


### PR DESCRIPTION
On some platforms (GNOME/X11) and potentially other X11 window managers, the maximized state of the main window will not be restored.

Since Qt emulates showMaximized() on X11, it is likely this is not limited to GNOME and could affect other WMs now and in the future.

This corrects the problem on GNOME and may also prevent other WMs from breaking in the future.

I have also added a more complete "ensure the window is visible/active" check as sendPostedEvents() is not quite enough to fully realize the window.

---

I have tested the patch on Windows as well and it has no effect as expected.  Also GNOME/Wayland doesn't have this problem, nor the various fullscreen problems (e.g. #550) , which this does not address.

Qt documentation regarding X11 WM issues:
https://doc.qt.io/qt-5/application-windows.html#x11-peculiarities
