### PR TITLE
Startup: fix restoration of fullscreen state

### DIFF
--- a/ImageLounge/src/DkGui/DkNoMacs.cpp
+++ b/ImageLounge/src/DkGui/DkNoMacs.cpp
@@ -593,7 +593,7 @@ void DkNoMacs::enterFullScreen()
 
     // here is an issue with windows that I can't quite fix:
     // if we send nomacs to fullscreen from an attached window (i.e. split window)
-    setWindowState(windowState() ^ Qt::WindowFullScreen);
+    setWindowState(windowState() | Qt::WindowFullScreen);
 
     if (getTabWidget()->getViewPort())
         getTabWidget()->getViewPort()->setFullScreen(true);
@@ -615,7 +615,7 @@ void DkNoMacs::exitFullScreen()
 
         DkToolBarManager::inst().restore();
         restoreDocks();
-        setWindowState(windowState() ^ Qt::WindowFullScreen);
+        setWindowState(windowState() & ~Qt::WindowFullScreen);
 
         if (getTabWidget())
             getTabWidget()->showTabs(true);

--- a/ImageLounge/src/DkGui/DkViewPort.cpp
+++ b/ImageLounge/src/DkGui/DkViewPort.cpp
@@ -1372,7 +1372,7 @@ void DkViewPort::setFullScreen(bool fullScreen)
     toggleLena(fullScreen);
 
     if (fullScreen)
-        QWidget::setWindowState(windowState() ^ Qt::WindowFullScreen);
+        QWidget::setWindowState(windowState() | Qt::WindowFullScreen);
     else
         QWidget::setWindowState(windowState() & ~Qt::WindowFullScreen);
 

--- a/ImageLounge/src/main.cpp
+++ b/ImageLounge/src/main.cpp
@@ -265,8 +265,6 @@ int main(int argc, char *argv[])
     } else
         w = new nmc::DkNoMacsIpl();
 
-    qInfo() << "maximized:" << w->isMaximized() << "fullscreen:" << w->isFullScreen();
-
     // show what we got...
     w->show();
 


### PR DESCRIPTION
Fullscreen state was not restored correctly in some instances because QMainWindow::restoreState() will set the fullscreen bit, and our own handler will toggle it back off with XOR, when it meant to enable it.

Fixes #1110
Fixes #764
