### PR TITLE
Fix incorrect positioning when sorted by metadata

### DIFF
--- a/ImageLounge/src/DkCore/DkUtils.cpp
+++ b/ImageLounge/src/DkCore/DkUtils.cpp
@@ -299,12 +299,21 @@ QString DkUtils::getLongestNumber(const QString &str, int startIdx)
 
 bool DkUtils::compDateCreated(const QFileInfo &lhf, const QFileInfo &rhf)
 {
-    return lhf.birthTime() < rhf.birthTime();
+    // avoid equality because we keep our directory position/index using the sorted position
+    auto left = lhf.birthTime(), right = rhf.birthTime();
+    if (left != right)
+        return left < right;
+    else
+        return compFilename(lhf, rhf);
 }
 
 bool DkUtils::compDateModified(const QFileInfo &lhf, const QFileInfo &rhf)
 {
-    return lhf.lastModified() < rhf.lastModified();
+    auto left = lhf.lastModified(), right = rhf.lastModified();
+    if (left != right)
+        return left < right;
+    else
+        return compFilename(lhf, rhf);
 }
 
 bool DkUtils::compFilename(const QFileInfo &lhf, const QFileInfo &rhf)
@@ -314,7 +323,11 @@ bool DkUtils::compFilename(const QFileInfo &lhf, const QFileInfo &rhf)
 
 bool DkUtils::compFileSize(const QFileInfo &lhf, const QFileInfo &rhf)
 {
-    return lhf.size() < rhf.size();
+    auto left = lhf.size(), right = rhf.size();
+    if (left != right)
+        return left < right;
+    else
+        return compFilename(lhf, rhf);
 }
 
 bool DkUtils::compRandom(const QFileInfo &lhf, const QFileInfo &rhf)


### PR DESCRIPTION
Positioning can be incorrect after deletion or other changes to directory when sorted by anything which has the same value for multiple files. This is not uncommon, for example burst shots or batched processed files often have the same ctime/mtime.

This happens because getSkippedImage() re-establishes the position in the folder based on the sorted position of the missing item.

To sidestep the issue, sort files by filename whenever their metadata matches. So there should never be a case when the position is ambiguous.

This handles the case when we delete files and lose our position, or the files were modified externally.

Fixes #391
