### PR TITLE
Thumbs: save selection on directory change

### DIFF
--- a/ImageLounge/src/DkGui/DkThumbsWidgets.h
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.h
@@ -265,7 +265,7 @@ public slots:
     void selectThumb(int idx, bool select = true);
     void selectAllThumbs(bool select = true);
     void updateThumbs(QVector<QSharedPointer<DkImageContainerT>> thumbs);
-    void deleteSelected() const;
+    void deleteSelected();
     void copySelected() const;
     void pasteImages() const;
     void renameSelected() const;
@@ -283,6 +283,7 @@ protected:
     int mNumRows = 0;
     int mNumCols = 0;
     bool mFirstLayout = true;
+    int mLastSelectedIdx = -1; // last selected item to restore on updateThumbs()
 
     QVector<DkThumbLabel *> mThumbLabels;
     QSharedPointer<DkImageLoader> mLoader;


### PR DESCRIPTION
Currently there is no attempt to save the selection after an operation (delete/rename/paste) that triggers a directory refresh, or external directory change picked up by dir watcher.

This patch saves the first selected index (other indices are lost) on any directory change.

deleteSelected() is also refactored
- prevent deleting the same item twice
- if a delete fails partway the remaining selection is preserved
- remove obsolete trash/vs delete conditional text
- remove loader activate/deactivate, always block signals to prevent use-after-free

Fixes #1125

