### PR TITLE
Frameless: fix bugs and improve mode switching

### DIFF
--- a/ImageLounge/src/DkCore/DkSettings.cpp
+++ b/ImageLounge/src/DkCore/DkSettings.cpp
@@ -374,6 +374,7 @@ void DkSettings::load(QSettings &settings, bool defaults)
     app_p.showRecentFiles = settings.value("showRecentFiles", app_p.showRecentFiles).toBool();
     app_p.useLogFile = settings.value("useLogFile", app_p.useLogFile).toBool();
     app_p.defaultJpgQuality = settings.value("defaultJpgQuality", app_p.defaultJpgQuality).toInt();
+    app_p.appMode = settings.value("appMode", app_p.appMode).toInt();
 
     QStringList tmpFileFilters = app_p.fileFilters;
     QStringList tmpContainerFilters = app_p.containerRawFilters.split(" ");
@@ -535,6 +536,7 @@ void DkSettings::save(bool force)
 {
     DefaultSettings s;
     save(s, force);
+    qDebug() << "saved settings to:" << s.fileName();
 }
 
 void DkSettings::save(QSettings &settings, bool force)
@@ -600,7 +602,7 @@ void DkSettings::save(QSettings &settings, bool force)
     // always save (user setting)
     settings.setValue("defaultJpgQuality", app_p.defaultJpgQuality);
     settings.setValue("appMode", app_p.appMode);
-    settings.setValue("currentAppMode", app_p.currentAppMode);
+    // settings.setValue("currentAppMode", app_p.currentAppMode);
 
     settings.endGroup();
     // Global Settings --------------------------------------------------------------------
@@ -802,8 +804,6 @@ void DkSettings::save(QSettings &settings, bool force)
     sync_d = sync_p;
     meta_d = meta_p;
     resources_d = resources_p;
-
-    qDebug() << "settings saved to" << settingsPath();
 }
 
 void DkSettings::setToDefaultSettings()
@@ -1078,8 +1078,9 @@ void DkSettingsManager::init()
 
     param().load(settings, true); // load defaults
 
-    int mode = settings.value("AppSettings/appMode", param().app().appMode).toInt();
-    param().app().currentAppMode = mode;
+    // TODO currentAppMode is obsolete, now set in main() after argument parsing
+    // int mode = settings.value("AppSettings/appMode", param().app().appMode).toInt();
+    // param().app().currentAppMode = mode;
 
     // init debug
     DkUtils::initializeDebug();

--- a/ImageLounge/src/DkCore/DkSettings.h
+++ b/ImageLounge/src/DkCore/DkSettings.h
@@ -110,14 +110,35 @@ public:
     DkSettings();
 
     enum modes {
+        mode_fullscreen_offset = 3,
         mode_default = 0,
-        mode_frameless,
-        mode_contrast,
-        mode_default_fullscreen,
-        mode_frameless_fullscreen,
-        mode_contrast_fullscreen,
-        mode_end,
+        mode_frameless = 1,
+        mode_contrast = 2,
+        mode_default_fullscreen = mode_default + mode_fullscreen_offset,
+        mode_frameless_fullscreen = mode_frameless + mode_fullscreen_offset,
+        mode_contrast_fullscreen = mode_contrast + mode_fullscreen_offset,
+        mode_end
     };
+
+    static bool modeIsValid(int mode)
+    {
+        return mode >= mode_default && mode < mode_end;
+    }
+
+    static bool modeIsFullscreen(int mode)
+    {
+        return mode >= mode_fullscreen_offset;
+    }
+
+    static int normalMode(int mode)
+    {
+        return modeIsFullscreen(mode) ? mode - mode_fullscreen_offset : mode;
+    }
+
+    static int fullscreenMode(int mode)
+    {
+        return modeIsFullscreen(mode) ? mode : mode + mode_fullscreen_offset;
+    }
 
     enum sortMode {
         sort_filename,

--- a/ImageLounge/src/DkGui/DkNoMacs.h
+++ b/ImageLounge/src/DkGui/DkNoMacs.h
@@ -129,8 +129,6 @@ public:
 
     void loadFile(const QString &filePath);
 
-    bool mSaveSettings = true;
-
 signals:
     void sendArrangeSignal(bool overlaid) const;
     void closeSignal() const;
@@ -232,6 +230,7 @@ protected:
     bool mOtherKeyPressed = true;
     QPoint mPosGrabKey;
     bool mOverlaid = false;
+    bool mWasMaximized = false;
 
     // menu
     DkMenuBar *mMenu = 0;
@@ -330,16 +329,11 @@ public:
     virtual ~DkNoMacsFrameless();
 
 public slots:
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-    void chooseMonitor(bool force = true);
-#endif
+    void chooseMonitor(bool force);
 
 protected:
-    void closeEvent(QCloseEvent *event) override;
     bool eventFilter(QObject *obj, QEvent *event) override;
     virtual void createContextMenu() override;
-
-    QDesktopWidget *mDesktop = 0;
 };
 
 class DllCoreExport DkNoMacsContrast : public DkNoMacsSync

--- a/ImageLounge/src/DkGui/DkViewPort.cpp
+++ b/ImageLounge/src/DkGui/DkViewPort.cpp
@@ -1372,11 +1372,6 @@ void DkViewPort::setFullScreen(bool fullScreen)
     toggleLena(fullScreen);
 
     if (fullScreen)
-        QWidget::setWindowState(windowState() | Qt::WindowFullScreen);
-    else
-        QWidget::setWindowState(windowState() & ~Qt::WindowFullScreen);
-
-    if (fullScreen)
         mHideCursorTimer->start();
     else
         unsetCursor();

--- a/ImageLounge/src/main.cpp
+++ b/ImageLounge/src/main.cpp
@@ -110,9 +110,6 @@ int main(int argc, char *argv[])
     nmc::DkSettingsManager::instance().init();
     nmc::DkMetaDataHelper::initialize(); // this line makes the XmpParser thread-save - so don't delete it even if you seem to know what you do
 
-    nmc::DefaultSettings settings;
-    int mode = settings.value("AppSettings/appMode", nmc::DkSettingsManager::param().app().appMode).toInt();
-
     // uncomment this for the single instance feature...
     //// check for single instance
     // nmc::DkRunGuard guard;
@@ -214,8 +211,8 @@ int main(int argc, char *argv[])
         return 0;
 
     // install translations
-    QString translationName = "nomacs_" + settings.value("GlobalSettings/language", nmc::DkSettingsManager::param().global().language).toString() + ".qm";
-    QString translationNameQt = "qt_" + settings.value("GlobalSettings/language", nmc::DkSettingsManager::param().global().language).toString() + ".qm";
+    const QString translationName = "nomacs_" + nmc::DkSettingsManager::param().global().language + ".qm";
+    const QString translationNameQt = "qt_" + nmc::DkSettingsManager::param().global().language + ".qm";
 
     QTranslator translator;
     nmc::DkSettingsManager::param().loadTranslation(translationName, translator);
@@ -234,44 +231,75 @@ int main(int argc, char *argv[])
         nmc::DkSettingsManager::param().app().privateMode = true;
     }
 
+    int mode = nmc::DkSettingsManager::param().app().appMode;
+    qInfo() << "loaded app mode:" << mode;
+
     if (parser.isSet(modeOpt)) {
         QString pm = parser.value(modeOpt);
 
         if (pm == "default")
-            mode = nmc::DkSettingsManager::param().mode_default;
+            mode = nmc::DkSettings::mode_default;
         else if (pm == "frameless")
-            mode = nmc::DkSettingsManager::param().mode_frameless;
+            mode = nmc::DkSettings::mode_frameless;
         else if (pm == "pseudocolor")
-            mode = nmc::DkSettingsManager::param().mode_contrast;
+            mode = nmc::DkSettings::mode_contrast;
         else
             qWarning() << "illegal mode: " << pm << "use either <default>, <frameless> or <pseudocolor>";
-
-        nmc::DkSettingsManager::param().app().currentAppMode = mode;
     }
+
+    if (parser.isSet(fullScreenOpt))
+        mode = nmc::DkSettings::fullscreenMode(mode);
+
+    if (!nmc::DkSettings::modeIsValid(mode)) {
+        qWarning() << "invalid mode:" << mode;
+        mode = nmc::DkSettings::mode_default;
+    }
+
+    // TODO: currentAppMode is obsolete now; use appMode instead
+    // currentAppMode is not saved/restored by settings but must be set early
+    nmc::DkSettingsManager::param().app().currentAppMode = mode;
 
     nmc::DkTimer dt;
 
     // initialize nomacs
-    if (mode == nmc::DkSettingsManager::param().mode_frameless) {
+    const int modeType = nmc::DkSettings::normalMode(mode);
+    if (modeType == nmc::DkSettings::mode_frameless) {
         w = new nmc::DkNoMacsFrameless();
         qDebug() << "this is the frameless nomacs...";
-    } else if (mode == nmc::DkSettingsManager::param().mode_contrast) {
+    } else if (modeType == nmc::DkSettings::mode_contrast) {
         w = new nmc::DkNoMacsContrast();
         qDebug() << "this is the contrast nomacs...";
     } else if (parser.isSet(pongOpt)) {
         pw = new nmc::DkPong();
         int rVal = app.exec();
         return rVal;
-    } else
+    } else {
         w = new nmc::DkNoMacsIpl();
+    }
 
-    // show what we got...
-    w->show();
+    qInfo() << "init window: appMode:" << nmc::DkSettingsManager::param().app().currentAppMode << "maximized:" << w->isMaximized()
+            << "fullscreen:" << w->isFullScreen() << "geometry:" << w->geometry() << "windowState:" << w->windowState();
 
-    bool maximized = w->isMaximized();
+    if (nmc::DkSettings::modeIsFullscreen(mode))
+        w->showFullScreen();
+    else if (w->windowState() & Qt::WindowMaximized)
+        w->showMaximized();
+    else
+        w->showNormal();
 
-    while (!w->isActiveWindow())
+    const bool maximized = w->isMaximized(); // check if show* actually maximized us
+
+    qInfo() << "show window: appMode:" << nmc::DkSettingsManager::param().app().currentAppMode << "maximized:" << w->isMaximized()
+            << "fullscreen:" << w->isFullScreen() << "geometry:" << w->geometry() << "windowState:" << w->windowState();
+
+    while (!w->isActiveWindow() && dt.elapsed() < 5000) {
+        qDebug() << "waiting for active window";
+        QThread::msleep(10);
         qApp->processEvents();
+    }
+
+    qInfo() << "active window: appMode:" << nmc::DkSettingsManager::param().app().currentAppMode << "maximized:" << w->isMaximized()
+            << "fullscreen:" << w->isFullScreen() << "geometry:" << w->geometry() << "windowState:" << w->windowState();
 
     // Qt emulates showMaximized() on some platforms (X11), so it might not work.
     // If we try again with a visible window, it *could* work correctly (GNOME)
@@ -312,21 +340,14 @@ int main(int argc, char *argv[])
     }
 
     // load recent files if there is nothing to display
-    if (!loading && nmc::DkSettingsManager::param().app().showRecentFiles) {
+    if (!loading && nmc::DkSettingsManager::param().app().showRecentFiles)
         w->showRecentFilesOnStartUp();
-    }
 
-    int fullScreenMode = settings.value("AppSettings/currentAppMode", nmc::DkSettingsManager::param().app().currentAppMode).toInt();
-
-    if (fullScreenMode == nmc::DkSettingsManager::param().mode_default_fullscreen || fullScreenMode == nmc::DkSettingsManager::param().mode_frameless_fullscreen
-        || fullScreenMode == nmc::DkSettingsManager::param().mode_contrast_fullscreen || parser.isSet(fullScreenOpt)) {
+    if (w->isFullScreen())
         w->enterFullScreen();
-        qDebug() << "trying to enter fullscreen...";
-    }
 
-    if (parser.isSet(slideshowOpt)) {
+    if (parser.isSet(slideshowOpt))
         cw->startSlideshow();
-    }
 
     if (cw->hasViewPort())
         cw->getViewPort()->setFocus(Qt::TabFocusReason);


### PR DESCRIPTION
PR #1128 introduced a regression that broke frameless mode on Windows.  This patch resolves that issue and cleans up various aspects of mode switching.

See commit message for list of changes.
