### PR TITLE
Cross-Compile: add Qt6 and output to console

### DIFF
--- a/ImageLounge/cmake/MingwBuildTarget.cmake
+++ b/ImageLounge/cmake/MingwBuildTarget.cmake
@@ -9,8 +9,16 @@ include(cmake/UnixBuildTarget.cmake)
 
 target_sources(${BINARY_NAME} PRIVATE ${NOMACS_QRC})
 
-target_link_libraries(${BINARY_NAME} Qt::WinExtras shlwapi)
-target_link_libraries(${DLL_CORE_NAME} Qt::WinExtras shlwapi)
+target_link_libraries(${BINARY_NAME} shlwapi)
+target_link_libraries(${DLL_CORE_NAME} shlwapi)
+
+if(${QT_VERSION_MAJOR} VERSION_LESS "6") # winextras is removed from Qt6
+    target_link_libraries(${BINARY_NAME} Qt::WinExtras)
+    target_link_libraries(${DLL_CORE_NAME} Qt::WinExtras)
+endif()
+
+set_target_properties(${BINARY_NAME} PROPERTIES LINK_FLAGS_DEBUG "-mconsole")
+set_target_properties(${DLL_CORE_NAME} PROPERTIES LINK_FLAGS_DEBUG "-mconsole")
 
 set(MINGW_PACKAGER ${CMAKE_CURRENT_LIST_DIR}/MingwPackager.sh ${NOMACS_FULL_VERSION} ${QT_VERSION_MAJOR} ${CMAKE_BUILD_TYPE})
 

--- a/ImageLounge/src/main.cpp
+++ b/ImageLounge/src/main.cpp
@@ -77,11 +77,11 @@
 #include <cassert>
 #include <iostream>
 
-#ifdef Q_OS_WIN
+#ifdef _MSC_BUILD
 #include <shlobj.h>
 #endif
 
-#ifdef Q_OS_WIN
+#ifdef _MSC_BUILD
 int main(int argc, wchar_t *argv[])
 {
 #else

--- a/README.md
+++ b/README.md
@@ -163,7 +163,11 @@ MXE environment is usually compiled from source, however you may be able to skip
 git clone <mxe url>
 cd mxe
 
-make MXE_TARGETS=`x86_64-w64-mingw32.shared` qtbase qtimageformats qtwinextras opencv quazip tiff exiv2 libraw
+# qt5
+make MXE_TARGETS='x86_64-w64-mingw32.shared' qtbase qtimageformats qtwinextras opencv quazip tiff exiv2 libraw
+
+# qt6 (quazip-qt6 is unavailable)
+make MXE_TARGETS='x86_64-w64-mingw32.shared' qt6-qtbase qt6-qtimageformats qt6-qttools opencv tiff exiv2 libraw
 ````
 
 Setup build environment:


### PR DESCRIPTION
Previously mingw build had no console output, add that back in to debug builds by linking to console subsystem.

Qt6 build is now working as expected.
