### PR TITLE
Qt6: Remove Mac OS deprecations

### DIFF
--- a/ImageLounge/src/DkCore/DkMessageBox.cpp
+++ b/ImageLounge/src/DkCore/DkMessageBox.cpp
@@ -117,7 +117,10 @@ void DkMessageBox::createLayout(const QMessageBox::Icon &userIcon, const QString
     grid->addWidget(showAgain, 2, 1, 1, 2);
     grid->addWidget(buttonBox, 3, 0, 1, 2);
 #else
+
+#if QT_VERSION_MAJOR < 6
     grid->setMargin(0);
+#endif
     grid->setVerticalSpacing(8);
     grid->setHorizontalSpacing(0);
     setContentsMargins(24, 15, 24, 20);

--- a/ImageLounge/src/DkGui/DkViewPort.cpp
+++ b/ImageLounge/src/DkGui/DkViewPort.cpp
@@ -1968,8 +1968,8 @@ void DkViewPort::cropImage(const DkRotatingRect &rect, const QColor &bgCol, bool
 DkViewPortFrameless::DkViewPortFrameless(QWidget *parent)
     : DkViewPort(parent)
 {
-#ifdef Q_OS_MAC
-    parent->setAttribute(Qt::WA_MacNoShadow);
+#if defined(Q_OS_MAC) && QT_VERSION_MAJOR < 6
+    parent->setAttribute(Qt::WA_MacNoShadow); // deprecated
 #endif
 
     setAttribute(Qt::WA_TranslucentBackground, true);


### PR DESCRIPTION
Partially fixes the build. The bundle is still broken.
