### PR TITLE
Add UserComment to Metadata Ribbon

### DIFF
--- a/ImageLounge/src/DkGui/DkMetaDataWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkMetaDataWidgets.cpp
@@ -823,6 +823,7 @@ QStringList DkMetaDataHUD::getDefaultKeys() const
     keyValues.append("Exif.Image.DateTime");
     keyValues.append("Exif.Image.ImageDescription");
 
+    keyValues.append("Exif.Photo.UserComment");
     keyValues.append("Exif.Photo.ISO");
     keyValues.append("Exif.Photo.FocalLength");
     keyValues.append("Exif.Photo.ExposureTime");


### PR DESCRIPTION
Makes the Metadata Ribbon able to display Exif.Photo.UserComment