### PR TITLE
Draft: properly recurse into subdirectories

### DIFF
--- a/ImageLounge/src/DkCore/DkImageLoader.cpp
+++ b/ImageLounge/src/DkCore/DkImageLoader.cpp
@@ -1707,11 +1707,10 @@ QFileInfoList DkImageLoader::updateSubFolders(const QString &rootDirPath)
     // find the first subfolder that has images
     for (int idx = 0; idx < mSubFolders.size(); idx++) {
         mCurrentDir = mSubFolders[idx];
-        files = getFilteredFileInfoList(mCurrentDir,
-                                        mIgnoreKeywords,
-                                        mKeywords); // this line takes seconds if you have lots of files and slow loading (e.g. network)
-        if (!files.empty())
-            break;
+        // this takes seconds if you have lots of files and slow loading (e.g. network)
+        files.append(getFilteredFileInfoList(mCurrentDir,
+                                             mIgnoreKeywords,
+                                             mKeywords));
     }
 
     return files;


### PR DESCRIPTION
It seems the original code did everything to do recursion into
subfolders except it explicitly stopped at the first folder with
images. This made browsing folders weird; it would find some
subfolder (any subfolder, not necessarily the first one listed in the
file explorer) and show *that*.

We change that behavior and just bite the bullet: we take *everything*
the QDirIterator gives us and throw that in the QFileInfoList, which
is really a QList. According to the documentation:

"This operation is relatively fast, because QList typically allocates
more memory than necessary, so it can grow without reallocating the
entire list each time."

https://doc.qt.io/qt-6/qlist.html#append

That said, obviously that list can grow to be absolutely huge, but
doing otherwise would need to refactor the loader into something that
returns an iterator (which raises the question of why we're not just
passing along that QDirIterator, probably because we're sorting
things...)

This also doesn't work so well for directories that have multiple
layers of subdirectories. From what I can tell from experience, the
images in the final list come out of order, and all mixed up
together. For example, if you have:

Photos/2024/01/01/foo.jpg
Photos/2024/01/01/bar.jpg
Photos/2024/01/02/quux.jpg

quux.jpg might be inserted between foo and bar.

On the other hand, if you have:

Photos/2024-01-01/foo.jpg
Photos/2024-01-01/bar.jpg
Photos/2024-01-02/quux.jpg

... the new code seems to handle this fine.

Either way, this *feels* to me like an improvement to the current
code, but I'll let the maintainers decide of that.

Closes: #797
Closes: #297
