### PR TITLE
Rewrite DkFileNameConverter

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libexiv2-dev libraw-dev libopencv-dev cmake libtiff-dev build-essential ninja-build ${{ matrix.qt.deps }}
+          sudo apt-get install -y libexiv2-dev libraw-dev libopencv-dev cmake libtiff-dev build-essential ninja-build libgtest-dev ${{ matrix.qt.deps }}
 
       - name: CMake configure
         run: |
@@ -49,6 +49,11 @@ jobs:
         run: |
           cd ${GITHUB_WORKSPACE}/build
           ninja -j3
+
+      - name: Test
+        run: |
+          cd ${GITHUB_WORKSPACE}/build
+          ninja check 
 
   check:
     # Need to use newer clang-format

--- a/ImageLounge/CMakeLists.txt
+++ b/ImageLounge/CMakeLists.txt
@@ -73,16 +73,8 @@ elseif (MSVC)
     endif()
 endif()
 
-include(CheckCXXCompilerFlag)
-CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
-CHECK_CXX_COMPILER_FLAG("-std=c++0x" COMPILER_SUPPORTS_CXX0X)
-if(COMPILER_SUPPORTS_CXX11)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-elseif(COMPILER_SUPPORTS_CXX0X)
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
-elseif(NOT MSVC)
-	message(STATUS "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler.")
-endif()
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if (ENABLE_CODE_COV AND CMAKE_COMPILER_IS_GNUCXX)
 	# Codecov

--- a/ImageLounge/CMakeLists.txt
+++ b/ImageLounge/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 # check cmake requirements
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 3.10)
 
 if(COMMAND cmake_policy)
 	cmake_policy(SET CMP0003 NEW)
@@ -48,6 +48,7 @@ option(ENABLE_HEIF "Compile nomacs with HEIF support" OFF)
 option(ENABLE_AVIF "Compile nomacs with AVIF support" OFF)
 option(ENABLE_JXL "Compile nomacs with JPEG XL support" OFF)
 option(ENABLE_CODE_COV "Run Code Coverage tests" OFF)
+option(ENABLE_TESTING "Run tests" ON)
 option(USE_SYSTEM_QUAZIP "QuaZip will not be compiled from source" ON) # ignored by MSVC
 
 # Codecov
@@ -110,6 +111,20 @@ elseif(MINGW)
 else()
 	message(STATUS "build system unkown ... fallback to unix")
 	include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Unix.cmake)
+endif()
+
+if (ENABLE_TESTING AND NOT UNIX) 
+	set(ENABLE_TESTING OFF)
+	message(WARNING "testing is only supported on unix")
+elseif (ENABLE_TESTING)
+	find_package(GTest)
+	if(GTEST_FOUND)
+		enable_testing()
+		add_subdirectory(tests EXCLUDE_FROM_ALL)
+	else()
+		set(ENABLE_TESTING OFF)
+		message(WARNING "GTest not found, disabling testing.")
+	endif()
 endif()
 
 file(GLOB NOMACS_EXE_SOURCES "src/*.cpp")
@@ -336,6 +351,12 @@ IF(ENABLE_QUAZIP)
     MESSAGE(STATUS " nomacs will be compiled with QuaZip support .................. YES")
 ELSE()
     MESSAGE(STATUS " nomacs will be compiled with QuaZip support .................. NO")
+ENDIF()
+
+IF(ENABLE_TESTING)
+    MESSAGE(STATUS " nomacs tests ................................................. YES")
+ELSE()
+    MESSAGE(STATUS " nomacs tests ................................................. NO")
 ENDIF()
 
 MESSAGE(STATUS "----------------------------------------------------------------------------------")

--- a/ImageLounge/src/DkCore/DkProcess.cpp
+++ b/ImageLounge/src/DkCore/DkProcess.cpp
@@ -1074,14 +1074,14 @@ void DkBatchProcessing::init()
 
     QStringList fileList = mBatchConfig.getFileList();
 
+    DkFileNameConverter converter(mBatchConfig.getFileNamePattern());
     for (int idx = 0; idx < fileList.size(); idx++) {
         DkSaveInfo si = mBatchConfig.saveInfo();
 
         QFileInfo cFileInfo = QFileInfo(fileList.at(idx));
         QString outDir = si.isInputDirOutputDir() ? cFileInfo.absolutePath() : mBatchConfig.getOutputDirPath();
 
-        DkFileNameConverter converter(cFileInfo.fileName(), mBatchConfig.getFileNamePattern(), idx);
-        QString outputFilePath = QFileInfo(outDir, converter.getConvertedFileName()).absoluteFilePath();
+        QString outputFilePath = QFileInfo(outDir, converter.convert(cFileInfo.fileName(), idx)).absoluteFilePath();
 
         // set input/output file path
         si.setInputFilePath(fileList.at(idx));

--- a/ImageLounge/src/DkCore/DkUtils.h
+++ b/ImageLounge/src/DkCore/DkUtils.h
@@ -447,19 +447,33 @@ public:
 class DllCoreExport DkFileNameConverter
 {
 public:
-    DkFileNameConverter(const QString &fileName, const QString &pattern, int cIdx);
+    DkFileNameConverter(const QString &pattern);
 
-    QString getConvertedFileName();
+    QString convert(const QString &file, int index) const;
 
-protected:
-    QString resolveFilename(const QString &tag) const;
-    QString resolveIdx(const QString &tag) const;
-    QString resolveExt(const QString &tag) const;
-    int getIntAttribute(const QString &tag, int idx = 1) const;
+private:
+    enum class Token {
+        Text,
+        TagName,
+        Number,
+    };
 
-    QString mFileName;
-    QString mPattern;
-    int mCIdx;
+    enum class FragType {
+        FileName,
+        Index,
+        Text,
+        Ext,
+    };
+
+    struct Frag {
+        FragType type;
+        uint indexDigits;
+        uint indexStart;
+        QString text;
+        uint caseConv;
+    };
+
+    std::vector<Frag> mFrags;
 };
 
 // from: http://stackoverflow.com/questions/5006547/qt-best-practice-for-a-single-instance-app-protection

--- a/ImageLounge/src/DkGui/DkBatch.cpp
+++ b/ImageLounge/src/DkGui/DkBatch.cpp
@@ -1032,10 +1032,10 @@ void DkBatchOutput::updateFileLabelPreview()
     if (mExampleName.isEmpty())
         return;
 
-    DkFileNameConverter converter(mExampleName, getFilePattern(), 0);
+    DkFileNameConverter converter(getFilePattern());
 
     mOldFileNameLabel->setText(mExampleName);
-    mNewFileNameLabel->setText(converter.getConvertedFileName());
+    mNewFileNameLabel->setText(converter.convert(mExampleName, 0));
 }
 
 QString DkBatchOutput::getOutputDirectory()

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -1523,22 +1523,25 @@ void DkThumbScene::renameSelected() const
     bool ok;
     QString newFileName = QInputDialog::getText(DkUtils::getMainWindow(), tr("Rename File(s)"), tr("New Filename:"), QLineEdit::Normal, "", &ok);
 
-    if (ok && !newFileName.isEmpty()) {
-        for (int idx = 0; idx < fileList.size(); idx++) {
-            QFileInfo fileInfo = QFileInfo(fileList.at(idx));
-            QFile file(fileInfo.absoluteFilePath());
-            QString pattern = (fileList.size() == 1) ? newFileName + ".<old>" : newFileName + "<d:3>.<old>"; // no index if just 1 file was added
-            DkFileNameConverter converter(fileInfo.fileName(), pattern, idx);
-            QFileInfo newFileInfo(fileInfo.dir(), converter.getConvertedFileName());
-            if (!file.rename(newFileInfo.absoluteFilePath())) {
-                int answer = QMessageBox::critical(DkUtils::getMainWindow(),
-                                                   tr("Error"),
-                                                   tr("Sorry, I cannot rename: %1 to %2").arg(fileInfo.fileName(), newFileInfo.fileName()),
-                                                   QMessageBox::Ok | QMessageBox::Cancel);
+    if (!ok || newFileName.isEmpty()) {
+        return;
+    }
 
-                if (answer == QMessageBox::Cancel) {
-                    break;
-                }
+    QString pattern = (fileList.size() == 1) ? newFileName + ".<old>" : newFileName + "<d:3>.<old>"; // no index if just 1 file was added
+    DkFileNameConverter converter(pattern);
+
+    for (int idx = 0; idx < fileList.size(); idx++) {
+        QFileInfo fileInfo = QFileInfo(fileList.at(idx));
+        QFile file(fileInfo.absoluteFilePath());
+        QFileInfo newFileInfo(fileInfo.dir(), converter.convert(fileInfo.fileName(), idx));
+        if (!file.rename(newFileInfo.absoluteFilePath())) {
+            int answer = QMessageBox::critical(DkUtils::getMainWindow(),
+                                               tr("Error"),
+                                               tr("Sorry, I cannot rename: %1 to %2").arg(fileInfo.fileName(), newFileInfo.fileName()),
+                                               QMessageBox::Ok | QMessageBox::Cancel);
+
+            if (answer == QMessageBox::Cancel) {
+                break;
             }
         }
     }

--- a/ImageLounge/tests/CMakeLists.txt
+++ b/ImageLounge/tests/CMakeLists.txt
@@ -1,0 +1,22 @@
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src/DkCore)
+
+add_executable(core_tests DkUtils_test.cpp)
+
+target_link_libraries(
+    core_tests
+    nomacsCore
+    ${OpenCV_LIBS}
+    GTest::gtest_main
+    Qt${QT_MAJOR_VERSION}::Core
+    Qt${QT_MAJOR_VERSION}::Gui
+)
+
+add_custom_target(
+    check
+    COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure
+    DEPENDS core_tests
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+)
+
+include(GoogleTest)
+gtest_discover_tests(core_tests)

--- a/ImageLounge/tests/DkUtils_test.cpp
+++ b/ImageLounge/tests/DkUtils_test.cpp
@@ -1,0 +1,47 @@
+#include "../src/DkCore/DkUtils.h"
+#include <gtest/gtest.h>
+#include <string>
+
+TEST(DkFileNameConverterTest, Test) {
+  nmc::DkFileNameConverter base("<c:0><d:2:0>.<old>");
+  EXPECT_EQ(base.convert("test.jpg", 1).toStdString(),
+            std::string("test001.jpg"));
+
+  nmc::DkFileNameConverter customStringUpper("image_<c:2>_num_<d:2:0>.png");
+  EXPECT_EQ(customStringUpper.convert("test.jpg", 1).toStdString(),
+            std::string("image_TEST_num_001.png"));
+
+  nmc::DkFileNameConverter lower("<c:1>.png");
+  EXPECT_EQ(lower.convert("teSt_ImaGe.jpg", 0).toStdString(),
+            std::string("test_image.png"));
+}
+
+TEST(DkFileNameConverterTest, OldIndex) {
+  nmc::DkFileNameConverter digits("<d:2:0>");
+  EXPECT_EQ(digits.convert("test.jpg", 1).toStdString(), std::string("001"));
+
+  EXPECT_EQ(digits.convert("test.jpg", 12).toStdString(), std::string("012"));
+
+  EXPECT_EQ(digits.convert("test.jpg", 1000).toStdString(),
+            std::string("1000"));
+
+  nmc::DkFileNameConverter digitsOffset("<d:2:5>");
+  EXPECT_EQ(digitsOffset.convert("test.jpg", 7).toStdString(),
+            std::string("012"));
+
+  nmc::DkFileNameConverter digitsOmitOffset("<d:2>");
+  EXPECT_EQ(digitsOmitOffset.convert("test.jpg", 1).toStdString(),
+            std::string("001"));
+
+  nmc::DkFileNameConverter zeroPad("<d:0:0>");
+  EXPECT_EQ(zeroPad.convert("test.jpg", 1).toStdString(), std::string("1"));
+  EXPECT_EQ(zeroPad.convert("test.jpg", 11).toStdString(), std::string("11"));
+
+  nmc::DkFileNameConverter onePad("<d:1:0>");
+  EXPECT_EQ(onePad.convert("test.jpg", 1).toStdString(), std::string("01"));
+  EXPECT_EQ(onePad.convert("test.jpg", 11).toStdString(), std::string("11"));
+
+  nmc::DkFileNameConverter fourPad("<d:4:0>");
+  EXPECT_EQ(fourPad.convert("test.jpg", 11).toStdString(),
+            std::string("00011"));
+}


### PR DESCRIPTION
The issue https://github.com/nomacs/nomacs/issues/1139 is caused by `DkFileNameConverter` not parsing the input pattern correctly. For example, "<c:0>.<old>" is interpreted as "<c:0>" because that the regex "<.*>" gets the whole string instead of two groups. This rewirtes `DkFileNameConverter` to parse the pattern manually instead of using regex.

The signature of the converter is also changed, so we can create one converter and reuse it instead of creating one in each iteration.

Fixes https://github.com/nomacs/nomacs/issues/1139.
