### PR TITLE
Include the `check` target in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,15 @@ cmake -D CMAKE_BUILD_TYPE=Debug ...
 
 at the Makefiles generation phase.
 
+## Build and run tests
+
+To build tests, install [GoogleTest](https://github.com/google/googletest) before running the cmake configuration.
+A `check` target will be created by default if GoogleTest is present
+to build the test binaries and execute `ctest`.
+
+```bash
+make check
+```
 
 ## Links
 


### PR DESCRIPTION
Document the `check` target for testing, so people can build and run tests as well.

Closes https://github.com/nomacs/nomacs/issues/1178.


