### PR TITLE
fix: fix add image format browseFilters

### DIFF
--- a/ImageLounge/src/DkGui/DkDialog.cpp
+++ b/ImageLounge/src/DkGui/DkDialog.cpp
@@ -452,8 +452,10 @@ void DkTrainDialog::accept()
         userFilters.append(tag);
         settings.setValue("ResourceSettings/userFilters", userFilters);
         DkSettingsManager::param().app().openFilters.append(tag);
-        DkSettingsManager::param().app().fileFilters.append("*." + acceptedFileInfo.suffix());
-        DkSettingsManager::param().app().browseFilters += acceptedFileInfo.suffix();
+
+        const QString filter = "*." + acceptedFileInfo.suffix();
+        DkSettingsManager::param().app().fileFilters.append(filter);
+        DkSettingsManager::param().app().browseFilters.append(filter);
     }
 
     QDialog::accept();


### PR DESCRIPTION
The "Add image format" dialog did not append a valid filter to the "browseFilters" list, so the setting did not apply.

Fixed this by using the correct string when appending.

Fixes https://github.com/nomacs/nomacs/issues/1124.
