### PR TITLE
fix: prevent viewport update when applying manipulator

### DIFF
--- a/ImageLounge/src/DkGui/DkViewPort.cpp
+++ b/ImageLounge/src/DkGui/DkViewPort.cpp
@@ -867,7 +867,15 @@ void DkViewPort::applyManipulator()
         auto l = imageContainer()->getLoader();
         l->setMinHistorySize(3); // increase the min history size to 3 for correctly popping back
         if (!l->history()->isEmpty() && l->lastEdit().editName() == mplExt->name()) {
-            imageContainer()->undo();
+            // This undo is only to merge the operations and is not meant to
+            // update the view.
+            // Directly call undo on the loader instead of the container
+            // so the imageUpdated signal does not fire.
+            l->undo();
+
+            // TODO: The design of the undo here is weird.
+            // This merges the two same operations, which might be beneficial for things like rotation.
+            // However, the next undo will be wrong.
         }
 
         img = imageContainer()->image();

--- a/ImageLounge/src/DkGui/DkViewPort.cpp
+++ b/ImageLounge/src/DkGui/DkViewPort.cpp
@@ -557,11 +557,6 @@ void DkViewPort::repeatZoom()
     }
 }
 
-void DkViewPort::toggleResetMatrix()
-{
-    DkSettingsManager::param().display().keepZoom = !DkSettingsManager::param().display().keepZoom;
-}
-
 void DkViewPort::updateImageMatrix()
 {
     if (mImgStorage.isEmpty())

--- a/ImageLounge/src/DkGui/DkViewPort.h
+++ b/ImageLounge/src/DkGui/DkViewPort.h
@@ -110,10 +110,6 @@ public:
     QSharedPointer<DkImageContainerT> imageContainer() const;
     void setImageLoader(QSharedPointer<DkImageLoader> newLoader);
     DkControlWidget *getController();
-    bool isTestLoaded()
-    {
-        return mTestLoaded;
-    };
 
     QString getCurrentPixelHexValue();
     QPoint mapToImage(const QPoint &windowPos) const;
@@ -142,7 +138,6 @@ public slots:
     void deleteImage();
     void zoomToFit();
     void resizeEvent(QResizeEvent *event) override;
-    void toggleResetMatrix();
     void zoomTo(double zoomLevel);
 
     // tcp actions


### PR DESCRIPTION
The same manipulator were undoed before applying a new one and triggers
a viewport paintEvent, causing the image to change back to original when
dragging the rotation or scaling slidebar.

Modify the undo call to avoid triggering paintEvent.

Fixes https://github.com/nomacs/nomacs/issues/665.
Fixes https://github.com/nomacs/nomacs/issues/711.

