### PR TITLE
Doc: various cleanup and update build recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,19 @@
 # nomacs - Image Lounge 🍸
 
-nomacs is a free, open source image viewer, which supports multiple platforms. You can use it for viewing all common image formats including RAW and psd images. nomacs is licensed under the GNU General Public License v3 and available for Windows, Linux, FreeBSD, Mac, and OS/2.
+nomacs is a free, open source image viewer, which supports multiple platforms. You can use it for viewing all common image formats including RAW and psd images. nomacs is licensed under the GNU General Public License v3 and available for Windows, Linux, FreeBSD, Mac, Haiku, and OS/2.
 
 [![Build status](https://ci.appveyor.com/api/projects/status/ye6wd1hap4cebyo8?svg=true)](https://ci.appveyor.com/project/novomesk/nomacs)
 [![Downloads](https://img.shields.io/github/downloads/nomacs/nomacs/total.svg)](https://github.com/nomacs/nomacs/releases/latest)
 [![Crowdin](https://badges.crowdin.net/nomacs/localized.svg)](http://translate.nomacs.org/project/nomacs)
+
+## Get the Source
+
+```console
+git clone https://github.com/nomacs/nomacs.git
+cd nomacs
+git submodule init
+git submodule update
+```
 
 ## Build nomacs (Windows)
 
@@ -48,63 +57,125 @@ python scripts/make.py "qt/bin" --lib-path "nomacs/3rd-party/build"
 - check if your Qt is set correctly (otherwise set the path to `qt_install_dir/qtbase/bin/qmake.exe`)
 - check if your builds proceeded correctly
 
-## Build nomacs (Ubuntu)
+## Build nomacs (Linux/Unix)
 
-Get the required packages:
+Before you build nomacs, please note the following:
 
-- For Ubuntu 21.04 and above:
+- We recommend using the Qt6 version of nomacs. However, you may want to match the Qt version of your desktop environment (e.g. KDE in 24.04 is Qt5-based).
+- [kimageformats-plugins](https://github.com/KDE/kimageformats) provides additional formats (AVIF,HEIC/HEIF) and is sometimes only available for the Qt5 version. Otherwise, you must compile it separately.
+- Zip file support requires Quazip, which has varied support in distributions. If the system package is missing or does not work, you can set `USE_SYSTEM_QUAZIP=NO` to use the version in nomacs/3rdparty. However, you may also need to remove the any system quazip development package temporarily. (`llibquazip*-dev`)
 
-  ```console
-  sudo apt-get install debhelper cdbs qt5-qmake qttools5-dev-tools qtbase5-dev qttools5-dev libqt5svg5-dev qt5-image-formats-plugins libexiv2-dev libraw-dev libopencv-dev cmake libtiff-dev libquazip5-dev libwebp-dev git build-essential lcov libzip-dev
-  ```
+### Get the required packages
 
-- For older Ubuntu versions:
-
-  ```console
-  sudo apt-get install debhelper cdbs qt5-qmake qttools5-dev-tools qt5-default qttools5-dev libqt5svg5-dev qt5-image-formats-plugins libexiv2-dev libraw-dev libopencv-dev cmake libtiff-dev libquazip5-dev libwebp-dev git build-essential lcov libzip-dev
-  ```
-
-Clone the nomacs repository from GitHub:
+#### Ubuntu 24.04
 
 ```console
-git clone https://github.com/nomacs/nomacs.git
+# qt6
+sudo apt install qt6-base-dev qt6-tools-dev qt6-svg-dev qt6-image-formats-plugins libexiv2-dev libraw-dev libopencv-dev libtiff-dev libtiff-dev libquazip1-qt6-dev build-essential git cmake lcov libgtest-dev
+
+# qt5
+# note: cmake configuration will fail if libquazip1-qt6-dev is also installed; or you can use USE_SYSTEM_QUAZIP=OFF
+sudo apt install qtbase5-dev qttools5-dev libqt5svg5-dev qt5-image-formats-plugins libexiv2-dev libraw-dev libopencv-dev libtiff-dev libtiff-dev libquazip1-qt5-dev build-essential git cmake lcov libgtest-dev kimageformat-plugins
 ```
 
-This will by default place the source into ~/nomacs
-Go to the nomacs/ImageLounge directory and run `cmake` to get the Makefiles:
+#### Ubuntu 22.04
 
 ```console
+# qt6
+sudo apt install qt6-base-dev qt6-tools-dev qt6-tools-dev-tools libqt6svg6-dev libqt6core5compat6-dev qt6-l10n-tools qt6-image-formats-plugins libexiv2-dev libraw-dev libopencv-dev libtiff-dev libtiff-dev build-essential git cmake lcov libgtest-dev libgl-dev
+
+# qt5
+sudo apt install qtbase5-dev qttools5-dev libqt5svg5-dev qt5-image-formats-plugins libexiv2-dev libraw-dev libopencv-dev libtiff-dev libtiff-dev libquazip5-dev build-essential git cmake lcov libgtest-dev kimageformat-plugins
+```
+
+#### Arch
+
+```console
+# qt6
+sudo pacman --sync qt6-base qt6-imageformats qt6-svg qt6-tools quazip-qt6 kimageformats exiv2 libraw libtiff opencv kimageformats git cmake gtest base-devel make
+```
+
+#### Redhat/Fedora/CentOS (tested on Rocky 9.5)
+```console
+# qt6
+sudo dnf install qt6-qtbase-devel qt6-qtimageformats qt6-qtsvg-devel qt6-qttools-devel qt6-qt5compat-devel LibRaw-devel opencv-devel exiv2-devel libtiff-devel git cmake lcov gtest-devel gcc-c++
+
+# qt5
+sudo dnf install qt5-qtbase-devel qt5-qtimageformats qt5-qtsvg-devel qt5-qttools-devel LibRaw-devel opencv-devel exiv2-devel libtiff-devel git cmake lcov gtest-devel gcc-c++ quazip-qt5-devel
+```
+
+#### FreeBSD (14.2 release)
+
+```
+# qt6
+sudo pkg install qt6-base qt6-imageformats qt6-svg qt6-5compat qt6-tools quazip-qt6 tiff exiv2 kf6-kimageformats libraw opencv git cmake googletest gcc
+
+#qt5
+sudo pkg install qt5-gui qt5-imageformats
+qt5-svg qt5-linguisttools qt5-qmake qt5-buildtools qt5-uitools qt5-concurrent quazip-qt5 tiff exiv2 kf5-kimageformats libraw opencv git cmake googletest gcc
+```
+
+#### Haiku (r1 beta 5)
+```console
+# qt6
+pkgman install qt6_base_devel qt6_tools_devel qt6_svg_devel qt6_5compat_devel quazip1_qt6_devel tiff_devel libraw_devel opencv_devel gtest_devel exiv2_devel kimageformats6 qt6_imageformats cake git gcc make pkgconfig lcms_devel
+```
+
+### Configure nomacs
+
+Nomacs is configured with cmake. These cmake options are often needed:
+- QT_VERSION_MAJOR=[5|6] - Default 5, 6 recommended
+- ENABLE_QUAZIP=[ON|OFF] - Default OFF, ON recommended
+- USE_SYSTEM_QUAZIP=[ON|OFF] - Default ON, recommended
+- CMAKE_BUILD_TYPE=[Debug|Release|RelWithDebInfo] - Debug builds have more logging as well as debug symbols.
+
+
+```console
+cd nomacs
 mkdir build
 cd build
-cmake ../ImageLounge/.
+cmake -D QT_VERSION_MAJOR=5 -D ENABLE_QUAZIP=ON -D USE_SYSTEM_QUAZIP=ON ../ImageLounge
 ```
 
-Compile nomacs:
+### Compile nomacs
 
 ```console
-make
+make [-j 8]
 ```
 
-You will now have a binary (~/nomacs/build/nomacs), which you can test (or use directly). To install it to /usr/local/bin, use:
+You will now have a binary (~/nomacs/build/nomacs), which you can use directly, however you may need to set LD_LIBRARY_PATH for this to work. You can check the log output to see that nomacs is loading configuration files from the expected locations.
+
+```console
+# running nomacs from ~/nomacs/build/
+LD_LIBRARY_PATH=.:$LD_LIBRARY_PATH ./nomacs
+```
+
+## Build and run tests
+
+Nomacs uses googletest (libgtest-dev), this is included in package lists above. A `check`target will be created if GoogleTest is present. To build and run tests:
+
+```bash
+make check
+```
+
+
+### Install nomacs
+
+By default nomacs is installed to /usr/local/ unless you set `CMAKE_INSTALL_PREFIX`
 
 ```console
 sudo make install
-```
-
-note that you have to execute
-
-```console
+# ldconfig is required on most linux distros
+# Some systems you also require changes to 
+# `/etc/ld.so.conf` to add `/usr/local/lib` 
 sudo ldconfig
 ```
 
-after a successful install.
-
-Install the [heif plugin](https://github.com/jakar/qt-heif-image-plugin) for HEIF support.
-
 ### For Package Maintainers
 
-- Set `ENABLE_TRANSLATIONS` to `true` (default: `false`)
-- Build all officially supported [plugins](https://github.com/nomacs/nomacs-plugins/)
+- Recommended additional packages: kimageformats provides HEIF/HEIC and AVIF image loading, and many others
+- Set `ENABLE_TRANSLATIONS` to `true` (default: `true`)
+- Build all officially supported [plugins](https://github.com/nomacs/nomacs-plugins/), enabled by default if `3rd-party/plugins` is present.
 
 ## Build nomacs (MacOS)
 
@@ -113,12 +184,6 @@ Install required dependencies:
 
 ```console
 brew install qt5 exiv2 opencv libraw quazip cmake pkg-config
-```
-
-Clone the nomacs repository from GitHub:
-
-```console
-git clone https://github.com/nomacs/nomacs.git
 ```
 
 Go to the `nomacs` directory and run cmake to get the Makefiles:
@@ -158,7 +223,8 @@ You will now have a binary (`nomacs.app`), which you can test (or use directly).
 sudo make install
 ```
 
-If you want to have an independent bundle image (`nomacs.dmg`) you can create it by using
+If you want to have an independent bundle image (`nomacs.dmg`) you c
+an create it by using
 
 ```console
 $ make bundle
@@ -187,7 +253,7 @@ cd mxe
 make MXE_TARGETS='x86_64-w64-mingw32.shared' qtbase qtimageformats qtwinextras opencv quazip tiff exiv2 libraw
 
 # qt6 (quazip-qt6 is unavailable)
-make MXE_TARGETS='x86_64-w64-mingw32.shared' qt6-qtbase qt6-qtimageformats qt6-qttools opencv tiff exiv2 libraw
+make MXE_TARGETS='x86_64-w64-mingw32.shared' qt6-qtbase qt6-qtimageformats qt6-qttools qt6-qt5compat opencv tiff exiv2 libraw
 ```
 
 Setup build environment:
@@ -285,15 +351,6 @@ cmake -D CMAKE_BUILD_TYPE=Debug ...
 
 at the Makefiles generation phase.
 
-## Build and run tests
-
-To build tests, install [GoogleTest](https://github.com/google/googletest) before running the cmake configuration.
-A `check` target will be created by default if GoogleTest is present
-to build the test binaries and execute `ctest`.
-
-```bash
-make check
-```
 
 ## Links
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ This is the list of configurable packages and what they provide in nomacs. If yo
 | nomacs/plugins| No | OpenCV  | `ENABLE_PLUGINS`   | Paint on image, Composite, Affine Transform, Fake Miniatures, Page Extraction
 | googletest    | No |         | `ENABLE_TESTING`   | Enables `make check` target for unit testing
 | QImageFormats | No |         | n/a                | Enables reading ICNS, MNG, TGA, TIFF, WBMP, WEBP
-| KImageFormats | No |         | n/a                | Enables reading AVIF, HEIF, JXL, JXR, EXR, EPS and [more](https://github.com/KDE/kimageformats)
+| KImageFormats | No |         | n/a                | Enables reading AVIF, HEIF/HEIC, JXL, EXR, EPS and [more](https://github.com/KDE/kimageformats)
 
 (**) Quazip is not enabled by default as of nomacs 3.19.1, this may change in a future update.
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ python scripts/make.py "qt/bin" --lib-path "nomacs/3rd-party/build"
 Before you build nomacs, please note the following:
 
 - We recommend using the Qt6 version of nomacs. However, you may want to match the Qt version of your desktop environment (e.g. KDE in Ubuntu 24.04 is Qt5-based).
-- [kimageformats-plugins](https://github.com/KDE/kimageformats) is an optional dependency that provides additional formats such as AVIF and HEIC/HEIF. The Qt version of the plugins should match the Qt version when compiling nomacs.
+- [kimageformats-plugins]([https://github.com/KDE/kimageformats](https://invent.kde.org/frameworks/kimageformats)) is an optional dependency that provides additional formats such as AVIF, HEIC/HEIF, and JPEG XL/JXL. The Qt version of the plugins should match the Qt version when compiling nomacs.
 - Zip file support requires Quazip, which has varied support in distributions. If the system package is missing or does not work, you can set `USE_SYSTEM_QUAZIP=NO` to use the version in nomacs/3rdparty. However, you may also need to remove the any system quazip development package temporarily. (such as `llibquazip*-dev` for Ubuntu)
 
 ### Get the required packages
@@ -98,6 +98,7 @@ sudo pacman -S qt6-base qt6-imageformats qt6-svg qt6-tools quazip-qt6 exiv2 libr
 ```
 
 #### Redhat/Fedora/CentOS (tested on Rocky 9.5)
+
 ```console
 # qt6
 sudo dnf install qt6-qtbase-devel qt6-qtimageformats qt6-qtsvg-devel qt6-qttools-devel qt6-qt5compat-devel LibRaw-devel opencv-devel exiv2-devel libtiff-devel git cmake lcov gtest-devel gcc-c++
@@ -108,11 +109,11 @@ sudo dnf install qt5-qtbase-devel qt5-qtimageformats qt5-qtsvg-devel qt5-qttools
 
 #### FreeBSD (14.2 release)
 
-```
+```console
 # qt6
 sudo pkg install qt6-base qt6-imageformats qt6-svg qt6-5compat qt6-tools quazip-qt6 tiff exiv2 kf6-kimageformats libraw opencv git cmake googletest gcc
 
-#qt5
+# qt5
 sudo pkg install qt5-gui qt5-imageformats
 qt5-svg qt5-linguisttools qt5-qmake qt5-buildtools qt5-uitools qt5-concurrent quazip-qt5 tiff exiv2 kf5-kimageformats libraw opencv git cmake googletest gcc
 ```
@@ -130,7 +131,6 @@ Nomacs is configured with cmake. These cmake options are often needed:
 - ENABLE_QUAZIP=[ON|OFF] - Default OFF, ON recommended
 - USE_SYSTEM_QUAZIP=[ON|OFF] - Default ON, recommended
 - CMAKE_BUILD_TYPE=[Debug|Release|RelWithDebInfo] - Debug builds have more logging as well as debug symbols.
-
 
 ```console
 cd nomacs
@@ -160,7 +160,6 @@ Nomacs uses [GoogleTest](https://github.com/google/googletest), which is include
 make check
 ```
 
-
 ### Install nomacs
 
 By default nomacs is installed to /usr/local/ unless you set `CMAKE_INSTALL_PREFIX`
@@ -175,9 +174,12 @@ sudo ldconfig
 
 ### For Package Maintainers
 
-- Recommended optional dependency: kimageformats provides HEIF/HEIC and AVIF image loading, and many others
-- Set `ENABLE_TRANSLATIONS` to `true` (default: `true`)
-- Build all officially supported [plugins](https://github.com/nomacs/nomacs-plugins/), enabled by default if `3rd-party/plugins` is present.
+- Highly recommended optional dependency: nomacs officially supported [plugins](https://github.com/nomacs/nomacs-plugins/), provide core features like paint-on-image. Enabled by default if `3rd-party/plugins` is present.
+- Recommended optional dependency: qt-imageformats-plugins provides WEBP and many more formats
+- Recommended optional dependency: quazip provides support for reading images from zip files (with `ENABLE_QUAZIP=ON`). In the unlikely case there is a conflict with the quazip package, you may use 3rdparty/quazip with `USE_SYSTEM_QUAZIP=OFF`.
+- Recommended optional dependency: kimageformats provides AVIF, HEIF/HEIC, JXL and many more formats.
+- Recommended build dependency: gtest so you may run `make check` to validate the build
+- Ensure `ENABLE_TRANSLATIONS` is `ON` (default: `ON`)
 
 ## Build nomacs (MacOS)
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ This is the list of configurable packages and what they provide in nomacs. If yo
 | LibRAW  |  No      | OpenCV  | `ENABLE_RAW`       | Enables reading RAW images
 | LibTiff |  No      | OpenCV  | `ENABLE_TIFF`      | Enable reading multi-page TIFF
 | Quazip**|  No      |         | `ENABLE_QUAZIP`    | Enable reading from zip files
-| OpenCV  |  No      |         | `ENABLE_OPENCV`    | RAW, TIFF, Adjustments, High-quality thumbnails, DRIF files, histogram, fake miniatures, mosaic
+| OpenCV  |  No      |         | `ENABLE_OPENCV`    | RAW, TIFF, Adjustments, High-quality thumbnails, DRIF files, histogram, mosaic
+| nomacs/plugins| No | OpenCV  | `ENABLE_PLUGINS`   | Paint on image, Composite, Affine Transform, Fake Miniatures, Page Extraction
 | googletest    | No |         | `ENABLE_TESTING`   | Enables `make check` target for unit testing
 | QImageFormats | No |         | n/a                | Enables reading ICNS, MNG, TGA, TIFF, WBMP, WEBP
 | KImageFormats | No |         | n/a                | Enables reading AVIF, HEIF, JXL, JXR, EXR, EPS and [more](https://github.com/KDE/kimageformats)

--- a/README.md
+++ b/README.md
@@ -71,21 +71,30 @@ Before you build nomacs, please note the following:
 
 The package lists and cmake configuration listed below enable all features in nomacs, which we recommend. However, if you do not want a particular feature you can omit certain packages.
 
-This is the list of configurable packages and what they provide in nomacs. If you want to be sure a feature is included/excluded set the cmake option for that feature. By default, all features are enabled if the dependencies are met**.
+#### Build options and their dependencies
 
-| Package | Required | Depends | cmake | Description
-| -       | -        | -       | -     | -
-| Qt      |  Yes     |         | `QT_VERSION_MAJOR` | Qt components: Core, Concurrent, Network, PrintSupport, SVG, Widgets, Core5Compat
-| LibRAW  |  No      | OpenCV  | `ENABLE_RAW`       | Enables reading RAW images
-| LibTiff |  No      | OpenCV  | `ENABLE_TIFF`      | Enable reading multi-page TIFF
-| Quazip**|  No      |         | `ENABLE_QUAZIP`    | Enable reading from zip files
-| OpenCV  |  No      |         | `ENABLE_OPENCV`    | RAW, TIFF, Adjustments, High-quality thumbnails, DRIF files, histogram, mosaic
-| nomacs/plugins| No | OpenCV  | `ENABLE_PLUGINS`   | Paint on image, Composite, Affine Transform, Fake Miniatures, Page Extraction
-| googletest    | No |         | `ENABLE_TESTING`   | Enables `make check` target for unit testing
-| QImageFormats | No |         | n/a                | Enables reading ICNS, MNG, TGA, TIFF, WBMP, WEBP
-| KImageFormats | No |         | n/a                | Enables reading AVIF, HEIF/HEIC, JXL, EXR, EPS and [more](https://github.com/KDE/kimageformats)
+This is the list of configurable packages and what they provide in nomacs. To ensure a feature is included/excluded set the cmake option for that feature. By default, all features are enabled if the dependencies are found when running cmake**.
 
-(**) Quazip is not enabled by default as of nomacs 3.19.1, this may change in a future update.
+The following Qt components are necessary: Core, Concurrent, Network, PrintSupport, SVG, Widgets, Core5Compat.
+
+There are other optional features that can be enabled during build:
+
+| Option             | Depends on     | Requires        | Description
+| ------------------ | -------------- | --------------- | -
+| `ENABLE_RAW`       | LibRAW         | `ENABLE_OPENCV` | Enables reading RAW images
+| `ENABLE_TIFF`      | LibTiff        | `ENABLE_OPENCV` | Enable reading multi-page TIFF
+| `ENABLE_QUAZIP`    | Quazip**       |                 | Enable reading from zip files
+| `ENABLE_OPENCV`    | OpenCV         |                 | RAW, TIFF, Adjustments, High-quality thumbnails, DRIF files, histogram, mosaic
+| `ENABLE_PLUGINS`   | nomacs/plugins | `ENABLE_OPENCV` | Paint on image, Composite, Affine Transform, Fake Miniatures, Page Extraction
+| `ENABLE_TESTING`   | GoogleTest     |                 | Enables `make check` target for unit testing
+
+(**) Quazip is not enabled by default as of nomacs 3.19.1
+
+#### Runtime dependencies
+
+Additional packages will be used by nomacs if they are available at runtime, and they use the same Qt version as nomacs (5 or 6).
+- QImageFormats: Enables reading ICNS, MNG, TGA, TIFF, WBMP, WEBP
+- KImageFormats: Enables reading AVIF, HEIF/HEIC, JXL, EXR, EPS and [more](https://github.com/KDE/kimageformats)
 
 #### Ubuntu 24.04
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ nomacs is a free, open source image viewer, which supports multiple platforms. Y
 ```console
 git clone https://github.com/nomacs/nomacs.git
 cd nomacs
+
+# nomacs uses submodules for third party libraries
 git submodule init
 git submodule update
 ```
@@ -61,9 +63,9 @@ python scripts/make.py "qt/bin" --lib-path "nomacs/3rd-party/build"
 
 Before you build nomacs, please note the following:
 
-- We recommend using the Qt6 version of nomacs. However, you may want to match the Qt version of your desktop environment (e.g. KDE in 24.04 is Qt5-based).
-- [kimageformats-plugins](https://github.com/KDE/kimageformats) provides additional formats (AVIF,HEIC/HEIF) and is sometimes only available for the Qt5 version. Otherwise, you must compile it separately.
-- Zip file support requires Quazip, which has varied support in distributions. If the system package is missing or does not work, you can set `USE_SYSTEM_QUAZIP=NO` to use the version in nomacs/3rdparty. However, you may also need to remove the any system quazip development package temporarily. (`llibquazip*-dev`)
+- We recommend using the Qt6 version of nomacs. However, you may want to match the Qt version of your desktop environment (e.g. KDE in Ubuntu 24.04 is Qt5-based).
+- [kimageformats-plugins](https://github.com/KDE/kimageformats) is an optional dependency that provides additional formats such as AVIF and HEIC/HEIF. The Qt version of the plugins should match the Qt version when compiling nomacs.
+- Zip file support requires Quazip, which has varied support in distributions. If the system package is missing or does not work, you can set `USE_SYSTEM_QUAZIP=NO` to use the version in nomacs/3rdparty. However, you may also need to remove the any system quazip development package temporarily. (such as `llibquazip*-dev` for Ubuntu)
 
 ### Get the required packages
 
@@ -92,7 +94,7 @@ sudo apt install qtbase5-dev qttools5-dev libqt5svg5-dev qt5-image-formats-plugi
 
 ```console
 # qt6
-sudo pacman --sync qt6-base qt6-imageformats qt6-svg qt6-tools quazip-qt6 kimageformats exiv2 libraw libtiff opencv kimageformats git cmake gtest base-devel make
+sudo pacman -S qt6-base qt6-imageformats qt6-svg qt6-tools quazip-qt6 exiv2 libraw libtiff opencv kimageformats git cmake gtest base-devel
 ```
 
 #### Redhat/Fedora/CentOS (tested on Rocky 9.5)
@@ -134,7 +136,7 @@ Nomacs is configured with cmake. These cmake options are often needed:
 cd nomacs
 mkdir build
 cd build
-cmake -D QT_VERSION_MAJOR=5 -D ENABLE_QUAZIP=ON -D USE_SYSTEM_QUAZIP=ON ../ImageLounge
+cmake ../ImageLounge
 ```
 
 ### Compile nomacs
@@ -152,7 +154,7 @@ LD_LIBRARY_PATH=.:$LD_LIBRARY_PATH ./nomacs
 
 ## Build and run tests
 
-Nomacs uses googletest (libgtest-dev), this is included in package lists above. A `check`target will be created if GoogleTest is present. To build and run tests:
+Nomacs uses [GoogleTest](https://github.com/google/googletest), which is included in the package lists above. A `check` target will be created if GoogleTest is present. To build and run tests:
 
 ```bash
 make check
@@ -173,7 +175,7 @@ sudo ldconfig
 
 ### For Package Maintainers
 
-- Recommended additional packages: kimageformats provides HEIF/HEIC and AVIF image loading, and many others
+- Recommended optional dependency: kimageformats provides HEIF/HEIC and AVIF image loading, and many others
 - Set `ENABLE_TRANSLATIONS` to `true` (default: `true`)
 - Build all officially supported [plugins](https://github.com/nomacs/nomacs-plugins/), enabled by default if `3rd-party/plugins` is present.
 
@@ -223,8 +225,7 @@ You will now have a binary (`nomacs.app`), which you can test (or use directly).
 sudo make install
 ```
 
-If you want to have an independent bundle image (`nomacs.dmg`) you c
-an create it by using
+If you want to have an independent bundle image (`nomacs.dmg`) you can create it by using
 
 ```console
 $ make bundle

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ sudo ldconfig
 
 ### For Package Maintainers
 
-- Highly recommended optional dependency: nomacs officially supported [plugins](https://github.com/nomacs/nomacs-plugins/), provide core features like paint-on-image. Enabled by default if `3rd-party/plugins` is present.
+- Highly recommended optional dependency: nomacs officially supported [plugins](https://github.com/nomacs/nomacs-plugins/), provide core features like paint-on-image. Enabled by default if `nomacs/ImageLounge/plugins` submodule is present.
 - Recommended optional dependency: qt-imageformats-plugins provides WEBP and many more formats
 - Recommended optional dependency: quazip provides support for reading images from zip files (with `ENABLE_QUAZIP=ON`). In the unlikely case there is a conflict with the quazip package, you may use 3rdparty/quazip with `USE_SYSTEM_QUAZIP=OFF`.
 - Recommended optional dependency: kimageformats provides AVIF, HEIF/HEIC, JXL and many more formats.

--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ sudo ldconfig
 - Recommended optional dependency: kimageformats provides AVIF, HEIF/HEIC, JXL and many more formats.
 - Recommended build dependency: gtest so you may run `make check` to validate the build
 - Ensure `ENABLE_TRANSLATIONS` is `ON` (default: `ON`)
+- Nomacs only requires the opencv-core and opencv-imgproc components at runtime, not the full opencv suite. This will save substantial space when installing nomacs.
 
 ## Build nomacs (MacOS)
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,23 @@ Before you build nomacs, please note the following:
 
 ### Get the required packages
 
+The package lists and cmake configuration listed below enable all features in nomacs, which we recommend. However, if you do not want a particular feature you can omit certain packages.
+
+This is the list of configurable packages and what they provide in nomacs. If you want to be sure a feature is included/excluded set the cmake option for that feature. By default, all features are enabled if the dependencies are met**.
+
+| Package | Required | Depends | cmake | Description
+| -       | -        | -       | -     | -
+| Qt      |  Yes     |         | `QT_VERSION_MAJOR` | Qt components: Core, Concurrent, Network, PrintSupport, SVG, Widgets, Core5Compat
+| LibRAW  |  No      | OpenCV  | `ENABLE_RAW`       | Enables reading RAW images
+| LibTiff |  No      | OpenCV  | `ENABLE_TIFF`      | Enable reading multi-page TIFF
+| Quazip**|  No      |         | `ENABLE_QUAZIP`    | Enable reading from zip files
+| OpenCV  |  No      |         | `ENABLE_OPENCV`    | RAW, TIFF, Adjustments, High-quality thumbnails, DRIF files, histogram, fake miniatures, mosaic
+| googletest    | No |         | `ENABLE_TESTING`   | Enables `make check` target for unit testing
+| QImageFormats | No |         | n/a                | Enables reading ICNS, MNG, TGA, TIFF, WBMP, WEBP
+| KImageFormats | No |         | n/a                | Enables reading AVIF, HEIF, JXL, JXR, EXR, EPS and [more](https://github.com/KDE/kimageformats)
+
+(**) Quazip is not enabled by default as of nomacs 3.19.1, this may change in a future update.
+
 #### Ubuntu 24.04
 
 ```console

--- a/README.md
+++ b/README.md
@@ -128,9 +128,9 @@ pkgman install qt6_base_devel qt6_tools_devel qt6_svg_devel qt6_5compat_devel qu
 
 Nomacs is configured with cmake. These cmake options are often needed:
 - QT_VERSION_MAJOR=[5|6] - Default 5, 6 recommended
-- ENABLE_QUAZIP=[ON|OFF] - Default OFF, ON recommended
-- USE_SYSTEM_QUAZIP=[ON|OFF] - Default ON, recommended
-- CMAKE_BUILD_TYPE=[Debug|Release|RelWithDebInfo] - Debug builds have more logging as well as debug symbols.
+- ENABLE_QUAZIP=[ON|OFF] - Default OFF
+- USE_SYSTEM_QUAZIP=[ON|OFF] - Default ON
+- CMAKE_BUILD_TYPE=[Debug|Release|RelWithDebInfo] - For normal usage, choose `RelWithDebInfo`. For development, `Debug` builds have more logging as well as debug symbols.
 
 ```console
 cd nomacs


### PR DESCRIPTION
- move common git clone stuff to the top
- add Arch, RedHat, FreeBSD, Haiku
- remove old Ubuntu package lists; omit 20.04 as it is EOL in 2025
