### PR TITLE
Splash Screen: Add more build info

### DIFF
--- a/ImageLounge/src/DkCore/DkUtils.cpp
+++ b/ImageLounge/src/DkCore/DkUtils.cpp
@@ -29,6 +29,7 @@
 #include "DkMath.h"
 #include "DkNoMacs.h"
 #include "DkSettings.h"
+#include "DkVersion.h"
 #include "DkViewPort.h"
 
 #if defined(Q_OS_LINUX) && !defined(Q_OS_OPENBSD)
@@ -65,6 +66,19 @@
 
 #include <QSystemSemaphore>
 #pragma warning(pop) // no warnings from includes - end
+
+#include <exiv2/version.hpp>
+
+#ifdef WITH_LIBRAW
+#include <libraw/libraw.h>
+#endif
+
+#ifdef WITH_LIBTIFF
+#ifdef Q_CC_MSVC
+#include <tif_config.h>
+#endif
+#include <tiffio.h>
+#endif
 
 #if defined(Q_OS_WIN) && !defined(SOCK_STREAM)
 #include <winsock2.h> // needed since libraw 0.16
@@ -487,6 +501,84 @@ QSize DkUtils::getInitialDialogSize()
     QSize s(qRound(width), qRound(height));
 
     return s;
+}
+
+QString DkUtils::getBuildInfo()
+{
+    QString info;
+
+    // architecture
+    QString arch = QSysInfo::buildCpuArchitecture();
+
+    // version & build date
+    info += "nomacs " + QApplication::applicationVersion() + ", " + arch + "\n";
+    info += QString(nmc::revisionString) + "\n";
+
+// omit from Linux for reproducable builds (see #139)
+#ifdef Q_OS_WIN
+    info += QString(__DATE__);
+#endif
+
+    if (DkSettingsManager::param().isPortable())
+        info += " Portable"; // same line as __DATE__ (running out of room)
+
+    info += "\n\n";
+
+    QString memory = QString::number(int(DkMemory::getTotalMemory() / 1000)) + "GB";
+    info += QSysInfo::prettyProductName() + ", " + memory + "\n";
+
+    // library versions (dynamic version where possible)
+    info += "Qt " + QString(qVersion()) + ", " + qApp->platformName() + ", scale=" + QString::number(qApp->devicePixelRatio(), 10, 2) + "\n";
+    info += "Exiv2 " + QString(Exiv2::version()) + "\n";
+
+#ifdef WITH_LIBRAW
+#ifdef _MSC_VER
+    // FIXME: library call segfaults in appveyor build
+    info += "LibRAW " + QString(LIBRAW_VERSION_STR) + "\n";
+#else
+    info += "LibRAW " + QString(LibRaw::version()) + "\n";
+#endif
+#else
+    info += "No RAW Support\n";
+#endif
+
+#ifdef WITH_OPENCV
+    info += "OpenCV " + QString(cv::getVersionString().c_str()) + "\n";
+#else
+    info += "No CV Support\n";
+#endif
+
+#if WITH_LIBTIFF
+    {
+        // TIFFGetVersion has other stuff in it, but it doesn't fit here
+        QString version = "error";
+        QRegularExpression re("(\\d+\\.\\d+\\.\\d+)");
+        QRegularExpressionMatch match = re.match(TIFFGetVersion());
+        if (match.hasMatch())
+            version = match.captured(0);
+        info += "TIFF " + version + "\n";
+    }
+#else
+    info += "No TIFF Pages\n";
+#endif
+
+#ifdef WITH_QUAZIP
+#ifdef WITH_QUAZIP1
+    const char *quazip = "v1";
+#else
+    const char *quazip = "v0";
+#endif
+#ifdef QUAZIP_STATIC
+    const char *linkage = "(s)";
+#else
+    const char *linkage = "";
+#endif
+    info += QString("QuaZip ") + quazip + linkage + "\n";
+#else
+    info += "No Zip Support\n";
+#endif
+
+    return info;
 }
 
 void DkUtils::mSleep(int ms)
@@ -1338,5 +1430,4 @@ bool DkRunGuard::tryRunning()
 
     return !attached;
 }
-
 }

--- a/ImageLounge/src/DkCore/DkUtils.h
+++ b/ImageLounge/src/DkCore/DkUtils.h
@@ -162,6 +162,8 @@ public:
 
     static QSize getInitialDialogSize();
 
+    static QString getBuildInfo();
+
     /**
      * Sleeps n ms.
      * This function is based on the QTest::qSleep(int ms)

--- a/ImageLounge/src/DkGui/DkDialog.h
+++ b/ImageLounge/src/DkGui/DkDialog.h
@@ -123,27 +123,20 @@ public:
 
 class DkSplashScreen : public QDialog
 {
-    Q_OBJECT
-
 public:
-    DkSplashScreen(QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags());
-    ~DkSplashScreen(){};
+    DkSplashScreen(QWidget *parent = nullptr, Qt::WindowFlags flags = Qt::WindowFlags());
+    ~DkSplashScreen();
 
-protected:
+private:
+    QPoint mDragStart;
+    QTimer *mTimer;
+    QPushButton *mCloseButton;
+    QPushButton *mCopyButton;
+
     void mouseMoveEvent(QMouseEvent *event) override;
     void mousePressEvent(QMouseEvent *event) override;
     void mouseReleaseEvent(QMouseEvent *event) override;
-    void showClose();
-
-private:
-    QPoint mouseGrab;
-    QString text;
-    QLabel *textLabel;
-    QLabel *imgLabel;
-    QTimer *showTimer;
-    QPushButton *exitButton;
-
-    QString versionText() const;
+    void showButtons();
 };
 
 class DkFileValidator : public QValidator

--- a/ImageLounge/src/DkGui/DkNoMacs.cpp
+++ b/ImageLounge/src/DkGui/DkNoMacs.cpp
@@ -87,7 +87,9 @@
 #include <QShortcut>
 #include <QSplashScreen>
 #include <QStringBuilder>
+#include <QSysInfo>
 #include <QTimer>
+#include <QUrlQuery>
 #include <QVector2D>
 #include <QtGlobal>
 #include <qmath.h>
@@ -1523,9 +1525,8 @@ void DkNoMacs::computeThumbsBatch()
 
 void DkNoMacs::aboutDialog()
 {
-    DkSplashScreen *spScreen = new DkSplashScreen(this);
-    spScreen->exec();
-    spScreen->deleteLater();
+    DkSplashScreen splash;
+    splash.exec();
 }
 
 void DkNoMacs::openDocumentation()
@@ -1536,8 +1537,31 @@ void DkNoMacs::openDocumentation()
 
 void DkNoMacs::bugReport()
 {
-    QString url = "https://github.com/nomacs/nomacs/issues/new";
-    QDesktopServices::openUrl(QUrl(url));
+    QString info = R"(
+**Description**
+A clear and concise description.
+
+**Steps to Reproduce**
+List the sequence of actions leading to the bug.
+
+**Expected Behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshot / Screencast / Images**
+Add screen recording or example files to help illustrate the problem.
+
+**Additional context**
+Add any other context about the problem.
+
+**System Info**)";
+    info += '\n' + DkUtils::getBuildInfo().replace("\n\n", "");
+
+    QUrlQuery query;
+    query.addQueryItem("body", info);
+    QUrl url("https://github.com/nomacs/nomacs/issues/new");
+    url.setQuery(query);
+
+    QDesktopServices::openUrl(url);
 }
 
 void DkNoMacs::cleanSettings()

--- a/ImageLounge/src/stylesheet.css
+++ b/ImageLounge/src/stylesheet.css
@@ -243,7 +243,7 @@ QLabel#DkSplashInfoLabel {
     font-size: 12px;
 }
 
-QPushButton#cancelButtonSplash {
+QPushButton#DkSplashCloseButton {
     image: url(":/nomacs/img/close.svg");
     padding: 4px;
     margin: 8px;
@@ -251,10 +251,21 @@ QPushButton#cancelButtonSplash {
     max-height: 1em;
 }
 
-QPushButton#cancelButtonSplash:hover {
+QPushButton#DkSplashCloseButton:hover {
     image: url(":/nomacs/img/close-hover.svg");
 }
 
+QPushButton#DkSplashCopyInfoButton {
+  image: url(":nomacs/img/copy.svg");
+  padding: 2px;
+  margin: 0px;
+  max-width: 1em;
+  max-height: 1em;
+}
+
+QPushButton#DkSplashCopyInfoButton:hover {
+  background-color: #ddd;
+}
 
 QLineEdit#DkWarningEdit {
 	color: #000;


### PR DESCRIPTION
This was inspired by finding out even exiv2 has bugs that affect nomacs. I think we need to have all library versions on the about box. I just realized I am missing zip support so I will look to add that too.

In this patch I'm trying to help the problem of
- Missing system info / library versions in bug reports
- Verifying the build is OK at glance
- Adding more info that is useful -- all of the libraries we use have known bugs and version numbers will help there.

Build info:
- use runtime library versions since they could be different from linked version
- add exiv2, tiff versions
- add qt platform (for wayland detection mainly which has ongoing problems)
- add operating system
- add memory size - could be useful when loading huge images

Splash screen:
- refactor
- add copy button to copy build info
- move version info to common DkUtils::getBuildInfo()

Report-a-bug:
- add build info and bug template

![image](https://github.com/user-attachments/assets/aaa1e2de-3458-40cf-abbd-60a0a0736bda)

![image](https://github.com/user-attachments/assets/3b069c3c-634c-4698-9d35-33e819fc524a)
