### PR TITLE
Build: Add libTIFF header hack

### DIFF
--- a/ImageLounge/src/DkCore/DkBasicLoader.cpp
+++ b/ImageLounge/src/DkCore/DkBasicLoader.cpp
@@ -82,22 +82,18 @@
 #include <tif_config.h>
 #endif
 
-// #if defined(Q_OS_MAC) || defined(Q_OS_OPENBSD)
 //  here we clash (typedef redefinition with different types ('long' vs 'int64_t' (aka 'long long')))
 //  so we simply define our own int64 before including tiffio
 #define uint64 uint64_hack_
 #define int64 int64_hack_
-// #endif // defined(Q_OS_MAC) || defined(Q_OS_OPENBSD)
 
 #include <tiffio.h>
 #include <tiffio.hxx> // this is needed if you want to load tiffs from the buffer
 
-// #if defined(Q_OS_MAC) || defined(Q_OS_OPENBSD)
 #undef uint64
 #undef int64
-// #endif // defined(Q_OS_MAC) || defined(Q_OS_OPENBSD)
 
-#endif // #ifdef WITH_LIBTIFF
+#endif // WITH_LIBTIFF
 
 #endif // #ifdef WITH_OPENCV
 

--- a/ImageLounge/src/DkCore/DkUtils.cpp
+++ b/ImageLounge/src/DkCore/DkUtils.cpp
@@ -77,8 +77,17 @@
 #ifdef Q_CC_MSVC
 #include <tif_config.h>
 #endif
+
+//  here we clash (typedef redefinition with different types ('long' vs 'int64_t' (aka 'long long')))
+//  so we simply define our own int64 before including tiffio
+#define uint64 uint64_hack_
+#define int64 int64_hack_
+
 #include <tiffio.h>
-#endif
+
+#undef uint64
+#undef int64
+#endif // WITH_LIBTIFF
 
 #if defined(Q_OS_WIN) && !defined(SOCK_STREAM)
 #include <winsock2.h> // needed since libraw 0.16


### PR DESCRIPTION
Hack was missing which causes breakage on some configurations. Also clean up the other instance of the hack.

Fixes #1240
