### PR TITLE
Theme: Disable Transparent Background on Text Editors

### DIFF
--- a/ImageLounge/src/themes/Dark-Theme.css
+++ b/ImageLounge/src/themes/Dark-Theme.css
@@ -169,7 +169,7 @@ QLineEdit,
 QDoubleSpinBox,
 QSpinBox,
 QComboBox {
-    background-color: rgba(255,255,255,10);
+    background-color: nomacsBlend(BACKGROUND_COLOR,255,255,255,10);
     border: 1px solid rgba(0,0,0,90);
 }
 

--- a/ImageLounge/src/themes/Light-Theme.css
+++ b/ImageLounge/src/themes/Light-Theme.css
@@ -180,7 +180,7 @@ QLineEdit,
 QDoubleSpinBox,
 QSpinBox,
 QComboBox {
-    background-color: rgba(255,255,255,128);
+    background-color: nomacsBlend(BACKGROUND_COLOR,255,255,255,128);
     border: 1px solid rgba(0,0,0,60);
 }
 


### PR DESCRIPTION
Some instances/states of text editing controls draw text behind the control (e.g. QAbstractItemView)) which shows through when editing the text. The solution is to use an opaque background color in the text editor.

Fixes #885