### PR TITLE
Keyboard: fix shortcut activation and input focus issues

### DIFF
--- a/ImageLounge/src/DkCore/DkActionManager.cpp
+++ b/ImageLounge/src/DkCore/DkActionManager.cpp
@@ -1329,11 +1329,8 @@ void DkActionManager::createActions(QWidget *parent)
     mViewActions[menu_view_last_tab] = new QAction(QObject::tr("La&st Tab"), parent);
     mViewActions[menu_view_last_tab]->setStatusTip(QObject::tr("Switch to last tab"));
 
-    QList<QKeySequence> scs;
-    scs.append(shortcut_full_screen_ff);
-    scs.append(shortcut_full_screen_ad);
     mViewActions[menu_view_fullscreen] = new QAction(mViewIcons[icon_view_fullscreen], QObject::tr("Fu&ll Screen"), parent);
-    mViewActions[menu_view_fullscreen]->setShortcuts(scs);
+    mViewActions[menu_view_fullscreen]->setShortcut(QKeySequence(shortcut_full_screen_ff));
     mViewActions[menu_view_fullscreen]->setStatusTip(QObject::tr("Full Screen"));
 
     mViewActions[menu_view_reset] = new QAction(mViewIcons[icon_view_reset], QObject::tr("&Fit Image to Window"), parent);

--- a/ImageLounge/src/DkCore/DkActionManager.cpp
+++ b/ImageLounge/src/DkCore/DkActionManager.cpp
@@ -1784,6 +1784,51 @@ void DkActionManager::enableMovieActions(bool enable) const
     DkToolBarManager::inst().showMovieToolBar(enable);
 }
 
+void DkActionManager::enableViewPortPluginActions(bool enable) const
+{
+#ifdef WITH_PLUGINS
+    // opening another plugin is currently broken
+    // fixme: for some reason these don't disable in the menu ?!
+    for (auto *a : mPluginManager->pluginActions())
+        a->setEnabled(!enable);
+
+    for (auto *a : mPluginManager->pluginDummyActions())
+        a->setEnabled(!enable);
+
+    // this is a partial workaround; quick launch will continue to launch plugins
+    mPluginManager->menu()->setEnabled(!enable);
+#endif
+
+    constexpr EditMenuActions disabledEditActions[] = {
+        menu_edit_undo, // paint plugin has its own undo
+        menu_edit_redo,
+        menu_edit_copy, // copy/paste work on the original image
+        menu_edit_paste,
+        menu_edit_copy_buffer,
+        menu_edit_copy_color,
+        menu_edit_preferences, // tabs do not work with plugins
+    };
+    for (auto i : disabledEditActions)
+        action(i)->setEnabled(!enable);
+
+    constexpr ViewMenuActions disabledViewActions[] = {
+        menu_view_new_tab, // tabs
+        menu_view_close_tab,
+        menu_view_close_all_tabs,
+        menu_view_first_tab,
+        menu_view_previous_tab,
+        menu_view_goto_tab,
+        menu_view_next_tab,
+        menu_view_last_tab,
+        menu_view_frameless, // restarts nomacs
+        menu_view_slideshow,
+    };
+    for (auto i : disabledViewActions)
+        action(i)->setEnabled(!enable);
+
+    action(menu_tools_batch)->setEnabled(!enable); // tabs
+}
+
 // DkGlobalProgress --------------------------------------------------------------------
 DkGlobalProgress::DkGlobalProgress()
     : showProgress(true)

--- a/ImageLounge/src/DkCore/DkActionManager.cpp
+++ b/ImageLounge/src/DkCore/DkActionManager.cpp
@@ -1786,30 +1786,33 @@ void DkActionManager::enableMovieActions(bool enable) const
 
 void DkActionManager::enableViewPortPluginActions(bool enable) const
 {
+    // actions to disable when a viewport plugin is activated,
+    // and disable when de-activated
+
 #ifdef WITH_PLUGINS
     // opening another plugin is currently broken
     // fixme: for some reason these don't disable in the menu ?!
     for (auto *a : mPluginManager->pluginActions())
-        a->setEnabled(!enable);
+        a->setEnabled(enable);
 
     for (auto *a : mPluginManager->pluginDummyActions())
-        a->setEnabled(!enable);
+        a->setEnabled(enable);
 
     // this is a partial workaround; quick launch will continue to launch plugins
-    mPluginManager->menu()->setEnabled(!enable);
+    mPluginManager->menu()->setEnabled(enable);
 #endif
 
     constexpr EditMenuActions disabledEditActions[] = {
-        menu_edit_undo, // paint plugin has its own undo
+        menu_edit_undo, // plugins have their own undo/redo, do not interface directly with history/imageloader
         menu_edit_redo,
-        menu_edit_copy, // copy/paste work on the original image
+        menu_edit_copy, // plugins have their own copy/paste, should not copy from underlying imageloader
         menu_edit_paste,
         menu_edit_copy_buffer,
         menu_edit_copy_color,
         menu_edit_preferences, // tabs do not work with plugins
     };
     for (auto i : disabledEditActions)
-        action(i)->setEnabled(!enable);
+        action(i)->setEnabled(enable);
 
     constexpr ViewMenuActions disabledViewActions[] = {
         menu_view_new_tab, // tabs
@@ -1824,9 +1827,9 @@ void DkActionManager::enableViewPortPluginActions(bool enable) const
         menu_view_slideshow,
     };
     for (auto i : disabledViewActions)
-        action(i)->setEnabled(!enable);
+        action(i)->setEnabled(enable);
 
-    action(menu_tools_batch)->setEnabled(!enable); // tabs
+    action(menu_tools_batch)->setEnabled(enable); // tabs
 }
 
 // DkGlobalProgress --------------------------------------------------------------------

--- a/ImageLounge/src/DkCore/DkActionManager.cpp
+++ b/ImageLounge/src/DkCore/DkActionManager.cpp
@@ -1674,6 +1674,10 @@ QVector<QAction *> DkActionManager::allActions() const
 
     all += hiddenActions();
 
+#ifdef WITH_PLUGINS
+    all += pluginActionManager()->pluginDummyActions();
+#endif
+
     return all;
 }
 

--- a/ImageLounge/src/DkCore/DkActionManager.cpp
+++ b/ImageLounge/src/DkCore/DkActionManager.cpp
@@ -1011,7 +1011,6 @@ void DkActionManager::createActions(QWidget *parent)
     mFileActions[menu_file_open_list]->setStatusTip(QObject::tr("Open a texfile containing a list of filepaths, and open tabs for them"));
 
     mFileActions[menu_file_quick_launch] = new QAction(QObject::tr("&Quick Launch"), parent);
-    mFileActions[menu_file_quick_launch]->setShortcutContext(Qt::WidgetWithChildrenShortcut);
 #ifdef Q_OS_WIN
     mFileActions[menu_file_quick_launch]->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_Q));
 #else
@@ -1022,7 +1021,6 @@ void DkActionManager::createActions(QWidget *parent)
     mFileActions[menu_file_app_manager]->setShortcut(QKeySequence(shortcut_app_manager));
 
     mFileActions[menu_file_rename] = new QAction(QObject::tr("Re&name"), parent);
-    mFileActions[menu_file_rename]->setShortcutContext(Qt::WidgetWithChildrenShortcut);
     mFileActions[menu_file_rename]->setShortcut(QKeySequence(shortcut_rename));
     mFileActions[menu_file_rename]->setStatusTip(QObject::tr("Rename an image"));
 
@@ -1058,17 +1056,14 @@ void DkActionManager::createActions(QWidget *parent)
     mFileActions[menu_file_show_recent]->setStatusTip(QObject::tr("Show Recent Files"));
 
     mFileActions[menu_file_reload] = new QAction(QObject::tr("&Reload File"), parent);
-    mFileActions[menu_file_reload]->setShortcutContext(Qt::WidgetWithChildrenShortcut);
     mFileActions[menu_file_reload]->setShortcut(QKeySequence(shortcut_reload));
     mFileActions[menu_file_reload]->setStatusTip(QObject::tr("Reload File"));
 
     mFileActions[menu_file_next] = new QAction(mFileIcons[icon_file_next], QObject::tr("Ne&xt File"), parent);
-    mFileActions[menu_file_next]->setShortcutContext(Qt::WidgetShortcut);
     mFileActions[menu_file_next]->setShortcut(QKeySequence(shortcut_next_file));
     mFileActions[menu_file_next]->setStatusTip(QObject::tr("Load next image"));
 
     mFileActions[menu_file_prev] = new QAction(mFileIcons[icon_file_prev], QObject::tr("Pre&vious File"), parent);
-    mFileActions[menu_file_prev]->setShortcutContext(Qt::WidgetWithChildrenShortcut);
     mFileActions[menu_file_prev]->setShortcut(QKeySequence(shortcut_prev_file));
     mFileActions[menu_file_prev]->setStatusTip(QObject::tr("Load previous file"));
 
@@ -1141,12 +1136,10 @@ void DkActionManager::createActions(QWidget *parent)
     mEditActions.resize(menu_edit_end);
 
     mEditActions[menu_edit_rotate_cw] = new QAction(mEditIcons[icon_edit_rotate_cw], QObject::tr("9&0%1 Clockwise").arg(dk_degree_str), parent);
-    mEditActions[menu_edit_rotate_cw]->setShortcutContext(Qt::WidgetWithChildrenShortcut);
     mEditActions[menu_edit_rotate_cw]->setShortcut(QKeySequence(shortcut_rotate_cw));
     mEditActions[menu_edit_rotate_cw]->setStatusTip(QObject::tr("rotate the image 90%1 clockwise").arg(dk_degree_str));
 
     mEditActions[menu_edit_rotate_ccw] = new QAction(mEditIcons[icon_edit_rotate_ccw], QObject::tr("&90%1 Counter Clockwise").arg(dk_degree_str), parent);
-    mEditActions[menu_edit_rotate_ccw]->setShortcutContext(Qt::WidgetWithChildrenShortcut);
     mEditActions[menu_edit_rotate_ccw]->setShortcut(QKeySequence(shortcut_rotate_ccw));
     mEditActions[menu_edit_rotate_ccw]->setStatusTip(QObject::tr("rotate the image 90%1 counter clockwise").arg(dk_degree_str));
 
@@ -1154,27 +1147,22 @@ void DkActionManager::createActions(QWidget *parent)
     mEditActions[menu_edit_rotate_180]->setStatusTip(QObject::tr("rotate the image by 180%1").arg(dk_degree_str));
 
     mEditActions[menu_edit_undo] = new QAction(mEditIcons[icon_edit_undo], QObject::tr("&Undo"), parent);
-    mEditActions[menu_edit_undo]->setShortcutContext(Qt::WidgetWithChildrenShortcut);
     mEditActions[menu_edit_undo]->setShortcut(QKeySequence::Undo);
     mEditActions[menu_edit_undo]->setStatusTip(QObject::tr("Undo Last Action"));
 
     mEditActions[menu_edit_redo] = new QAction(mEditIcons[icon_edit_redo], QObject::tr("&Redo"), parent);
-    mEditActions[menu_edit_redo]->setShortcutContext(Qt::WidgetWithChildrenShortcut);
     mEditActions[menu_edit_redo]->setShortcut(QKeySequence::Redo);
     mEditActions[menu_edit_redo]->setStatusTip(QObject::tr("Redo Last Action"));
 
     mEditActions[menu_edit_copy] = new QAction(mEditIcons[icon_edit_copy], QObject::tr("&Copy"), parent);
-    mEditActions[menu_edit_copy]->setShortcutContext(Qt::WidgetWithChildrenShortcut);
     mEditActions[menu_edit_copy]->setShortcut(QKeySequence::Copy);
     mEditActions[menu_edit_copy]->setStatusTip(QObject::tr("copy image"));
 
     mEditActions[menu_edit_copy_buffer] = new QAction(QObject::tr("Copy &Buffer"), parent);
-    mEditActions[menu_edit_copy_buffer]->setShortcutContext(Qt::WidgetWithChildrenShortcut);
     mEditActions[menu_edit_copy_buffer]->setShortcut(shortcut_copy_buffer);
     mEditActions[menu_edit_copy_buffer]->setStatusTip(QObject::tr("copy image"));
 
     mEditActions[menu_edit_copy_color] = new QAction(QObject::tr("Copy Co&lor"), parent);
-    mEditActions[menu_edit_copy_color]->setShortcutContext(Qt::WidgetWithChildrenShortcut);
     mEditActions[menu_edit_copy_color]->setShortcut(shortcut_copy_color);
     mEditActions[menu_edit_copy_color]->setStatusTip(QObject::tr("copy pixel color value as HEX"));
 
@@ -1182,12 +1170,10 @@ void DkActionManager::createActions(QWidget *parent)
     pastScs.append(QKeySequence::Paste);
     pastScs.append(shortcut_paste);
     mEditActions[menu_edit_paste] = new QAction(mEditIcons[icon_edit_paste], QObject::tr("&Paste"), parent);
-    mEditActions[menu_edit_paste]->setShortcutContext(Qt::WidgetWithChildrenShortcut);
     mEditActions[menu_edit_paste]->setShortcuts(pastScs);
     mEditActions[menu_edit_paste]->setStatusTip(QObject::tr("paste image"));
 
     mEditActions[menu_edit_delete] = new QAction(mEditIcons[icon_edit_delete], QObject::tr("&Delete"), parent);
-    mEditActions[menu_edit_delete]->setShortcutContext(Qt::WidgetWithChildrenShortcut);
     mEditActions[menu_edit_delete]->setShortcut(QKeySequence::Delete);
     mEditActions[menu_edit_delete]->setStatusTip(QObject::tr("delete current fileInfo"));
 
@@ -1201,18 +1187,15 @@ void DkActionManager::createActions(QWidget *parent)
 
     // image adjustments menu
     mEditActions[menu_edit_image] = new QAction(mEditIcons[icon_edit_image], QObject::tr("Image &Adjustments"), parent);
-    mEditActions[menu_edit_image]->setShortcutContext(Qt::WidgetWithChildrenShortcut);
     mEditActions[menu_edit_image]->setShortcut(QKeySequence(shortcut_edit_image));
     mEditActions[menu_edit_image]->setStatusTip(QObject::tr("open image manipulation toolbox"));
     mEditActions[menu_edit_image]->setCheckable(true);
 
     mEditActions[menu_edit_transform] = new QAction(mEditIcons[icon_edit_resize], QObject::tr("R&esize Image"), parent);
-    mEditActions[menu_edit_transform]->setShortcutContext(Qt::WidgetWithChildrenShortcut);
     mEditActions[menu_edit_transform]->setShortcut(shortcut_transform);
     mEditActions[menu_edit_transform]->setStatusTip(QObject::tr("resize the current image"));
 
     mEditActions[menu_edit_crop] = new QAction(mEditIcons[icon_edit_crop], QObject::tr("Cr&op Image"), parent);
-    mEditActions[menu_edit_crop]->setShortcutContext(Qt::WidgetWithChildrenShortcut);
     mEditActions[menu_edit_crop]->setShortcut(shortcut_crop);
     mEditActions[menu_edit_crop]->setStatusTip(QObject::tr("cut the current image"));
     mEditActions[menu_edit_crop]->setCheckable(true);
@@ -1502,7 +1485,6 @@ void DkActionManager::createActions(QWidget *parent)
     mSyncActions[menu_sync_arrange]->setEnabled(false);
 
     mSyncActions[menu_sync_connect_all] = new QAction(QObject::tr("Connect &All"), parent);
-    mSyncActions[menu_sync_connect_all]->setShortcutContext(Qt::WidgetWithChildrenShortcut);
     mSyncActions[menu_sync_connect_all]->setShortcut(QKeySequence(shortcut_connect_all));
     mSyncActions[menu_sync_connect_all]->setStatusTip(QObject::tr("connect all instances"));
 
@@ -1656,10 +1638,8 @@ void DkActionManager::createActions(QWidget *parent)
     assignCustomShortcuts(allActions());
 
     // automatically add status tip as tool tip
-    for (QAction *a : allActions()) {
+    for (QAction *a : allActions())
         a->setToolTip(a->statusTip());
-        a->setShortcutContext(Qt::WidgetWithChildrenShortcut);
-    }
 
     // trivial connects
     QObject::connect(action(menu_panel_toggle), &QAction::triggered, [](bool hide) {
@@ -1716,9 +1696,6 @@ void DkActionManager::assignCustomShortcuts(QVector<QAction *> actions) const
 
         if (val != "no-shortcut")
             a->setShortcut(val);
-
-        // assign widget shortcuts to all of them
-        a->setShortcutContext(Qt::WidgetWithChildrenShortcut);
     }
 
     settings.endGroup();

--- a/ImageLounge/src/DkCore/DkActionManager.h
+++ b/ImageLounge/src/DkCore/DkActionManager.h
@@ -406,7 +406,6 @@ public:
         shortcut_close_tab = Qt::CTRL | Qt::Key_W,
         shortcut_show_toolbar = Qt::CTRL | Qt::Key_B,
         shortcut_show_statusbar = Qt::CTRL | Qt::Key_I,
-        shortcut_full_screen_ad = Qt::CTRL | Qt::Key_L,
         shortcut_show_transfer = Qt::CTRL | Qt::Key_U,
 #ifdef Q_OS_MAC
         shortcut_next_tab = Qt::META | Qt::Key_Tab,

--- a/ImageLounge/src/DkCore/DkActionManager.h
+++ b/ImageLounge/src/DkCore/DkActionManager.h
@@ -545,8 +545,14 @@ public:
 
     void assignCustomShortcuts(QVector<QAction *> actions) const;
 
+    /// Enable actions when an image is loaded in the viewport
     void enableImageActions(bool enable = true) const;
+
+    /// Enable actions for animations in the viewport
     void enableMovieActions(bool enable = true) const;
+
+    /// Enable actions for viewport plugins
+    void enableViewPortPluginActions(bool enable) const;
 
 protected:
     DkActionManager();

--- a/ImageLounge/src/DkCore/DkBaseViewPort.cpp
+++ b/ImageLounge/src/DkCore/DkBaseViewPort.cpp
@@ -28,6 +28,7 @@
 #include "DkBaseViewPort.h"
 #include "DkActionManager.h"
 #include "DkSettings.h"
+#include "DkShortcuts.h"
 #include "DkStatusBar.h"
 #include "DkUtils.h"
 
@@ -87,6 +88,15 @@ DkBaseViewPort::DkBaseViewPort(QWidget *parent)
 
     setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding);
     setMinimumSize(10, 10);
+
+    // disable Qt default keys, prevent keyPressEvent() keys from being broken by shortcuts
+    DkShortcutEventFilter::reserveKeys(this,
+                                       {
+                                           DkActionManager::shortcut_zoom_in,
+                                           DkActionManager::shortcut_zoom_out,
+                                           DkActionManager::shortcut_zoom_in_alt,
+                                           DkActionManager::shortcut_zoom_out_alt,
+                                       });
 
     // connect pan actions
     const DkActionManager &am = DkActionManager::instance();

--- a/ImageLounge/src/DkCore/DkPluginManager.cpp
+++ b/ImageLounge/src/DkCore/DkPluginManager.cpp
@@ -1347,8 +1347,6 @@ void DkPluginActionManager::assignCustomPluginShortcuts()
             if (val != "no-shortcut")
                 action->setShortcut(val);
             connect(action, &QAction::triggered, this, &DkPluginActionManager::runPluginFromShortcut);
-            // assign widget shortcuts to all of them
-            action->setShortcutContext(Qt::WidgetWithChildrenShortcut);
             mPluginDummyActions.append(action);
         }
 
@@ -1360,6 +1358,9 @@ void DkPluginActionManager::setMenu(QMenu *menu)
 {
     mMenu = menu;
     connect(mMenu, &QMenu::aboutToShow, this, &DkPluginActionManager::updateMenu);
+
+    // allow shortcuts to invoke plugins that haven't been loaded yet
+    menu->addActions(pluginDummyActions().toList());
 }
 
 QMenu *DkPluginActionManager::menu() const

--- a/ImageLounge/src/DkGui/DkBatch.cpp
+++ b/ImageLounge/src/DkGui/DkBatch.cpp
@@ -2457,7 +2457,6 @@ DkBatchWidget::DkBatchWidget(const QString &currentDirectory, QWidget *parent /*
 
     QAction *previousAction = new QAction(tr("previous"), this);
     previousAction->setShortcut(Qt::Key_PageUp);
-    previousAction->setShortcutContext(Qt::WidgetWithChildrenShortcut);
     connect(previousAction, &QAction::triggered, this, &DkBatchWidget::previousTab);
     addAction(previousAction);
 }

--- a/ImageLounge/src/DkGui/DkCentralWidget.cpp
+++ b/ImageLounge/src/DkGui/DkCentralWidget.cpp
@@ -513,15 +513,8 @@ void DkCentralWidget::paintEvent(QPaintEvent *)
 DkPreferenceWidget *DkCentralWidget::createPreferences()
 {
     // add preference widget ------------------------------
-    DkActionManager &am = DkActionManager::instance();
     DkPreferenceWidget *pw = new DkPreferenceWidget(this);
     connect(pw, &DkPreferenceWidget::restartSignal, this, &DkCentralWidget::restart, Qt::UniqueConnection);
-
-    // add actions
-    pw->addActions(am.viewActions().toList());
-    pw->addActions(am.editActions().toList());
-    pw->addActions(am.helpActions().toList());
-    pw->addActions(am.hiddenActions().toList());
 
     QSize s(22, 22);
 
@@ -574,21 +567,8 @@ DkPreferenceWidget *DkCentralWidget::createPreferences()
 
 DkRecentFilesWidget *DkCentralWidget::createRecentFiles()
 {
-    DkActionManager &am = DkActionManager::instance();
     DkRecentFilesWidget *rw = new DkRecentFilesWidget(this);
     rw->registerAction(DkActionManager::instance().action(DkActionManager::menu_file_show_recent));
-
-    // add actions
-    rw->addActions(am.fileActions().toList());
-    rw->addActions(am.viewActions().toList());
-    rw->addActions(am.editActions().toList());
-    rw->addActions(am.sortActions().toList());
-    rw->addActions(am.toolsActions().toList());
-    rw->addActions(am.panelActions().toList());
-    rw->addActions(am.syncActions().toList());
-    rw->addActions(am.pluginActions().toList());
-    rw->addActions(am.helpActions().toList());
-    rw->addActions(am.hiddenActions().toList());
 
     connect(rw, &DkRecentFilesWidget::loadFileSignal, this, &DkCentralWidget::loadFile);
     connect(rw, &DkRecentFilesWidget::loadDirSignal, this, &DkCentralWidget::loadDirToTab);
@@ -601,18 +581,6 @@ DkThumbScrollWidget *DkCentralWidget::createThumbScrollWidget()
     DkThumbScrollWidget *thumbScrollWidget = new DkThumbScrollWidget(this);
     // thumbScrollWidget->getThumbWidget()->setBackgroundBrush(DkSettingsManager::param().slideShow().backgroundColor);
     thumbScrollWidget->registerAction(DkActionManager::instance().action(DkActionManager::menu_panel_thumbview));
-
-    DkActionManager &am = DkActionManager::instance();
-    thumbScrollWidget->addActions(am.fileActions().toList());
-    thumbScrollWidget->addActions(am.viewActions().toList());
-    thumbScrollWidget->addActions(am.editActions().toList());
-    thumbScrollWidget->addActions(am.sortActions().toList());
-    thumbScrollWidget->addActions(am.toolsActions().toList());
-    thumbScrollWidget->addActions(am.panelActions().toList());
-    // thumbScrollWidget->addActions(am.syncActions().toList());
-    thumbScrollWidget->addActions(am.pluginActions().toList());
-    thumbScrollWidget->addActions(am.helpActions().toList());
-    thumbScrollWidget->addActions(am.hiddenActions().toList());
 
     // thumbnail preview widget
     connect(thumbScrollWidget->getThumbWidget(), &DkThumbScene::loadFileSignal, this, &DkCentralWidget::loadFile);
@@ -829,6 +797,8 @@ void DkCentralWidget::showThumbView(bool show)
 
     QSharedPointer<DkTabInfo> tabInfo = mTabInfos[mTabbar->currentIndex()];
 
+    showViewPort(!show);
+
     if (show) {
         if (!getThumbScrollWidget()) {
             mWidgets[thumbs_widget] = createThumbScrollWidget();
@@ -838,7 +808,6 @@ void DkCentralWidget::showThumbView(bool show)
         tabInfo->setMode(DkTabInfo::tab_thumb_preview);
         switchWidget(thumbs_widget);
         tabInfo->activate();
-        showViewPort(false);
 
         // should be definitely true
         if (auto tw = getThumbScrollWidget()) {
@@ -858,8 +827,6 @@ void DkCentralWidget::showThumbView(bool show)
             disconnect(tw, &DkThumbScrollWidget::updateDirSignal, tabInfo->getImageLoader().data(), &DkImageLoader::loadDirRecursive);
             disconnect(tw, &DkThumbScrollWidget::filterChangedSignal, tabInfo->getImageLoader().data(), &DkImageLoader::setFolderFilter);
         }
-        // mViewport->connectLoader(tabInfo->getImageLoader(), true);
-        showViewPort(true); // TODO: this triggers switchWidget - but switchWidget might also trigger showThumbView(false)
     }
 }
 
@@ -878,6 +845,7 @@ void DkCentralWidget::showViewPort(bool show /* = true */)
 
 void DkCentralWidget::showRecentFiles(bool show)
 {
+    showViewPort(!show);
     if (show) {
         // create the preferences...
         if (!mWidgets[recent_files_widget]) {
@@ -886,9 +854,6 @@ void DkCentralWidget::showRecentFiles(bool show)
         }
 
         switchWidget(mWidgets[recent_files_widget]);
-    } else {
-        // toggle back to image
-        showViewPort();
     }
 }
 
@@ -908,6 +873,7 @@ void DkCentralWidget::openPreferences()
 
 void DkCentralWidget::showPreferences(bool show)
 {
+    showViewPort(!show);
     if (show) {
         // create the preferences...
         if (!mWidgets[preference_widget]) {
@@ -923,14 +889,7 @@ void DkCentralWidget::showPreferences(bool show)
 
 DkBatchWidget *DkCentralWidget::createBatch()
 {
-    auto bw = new DkBatchWidget(getCurrentDir(), this);
-
-    // add actions
-    DkActionManager &am = DkActionManager::instance();
-    bw->addActions(am.viewActions().toList());
-    bw->addActions(am.panelActions().toList());
-
-    return bw;
+    return new DkBatchWidget(getCurrentDir(), this);
 }
 
 void DkCentralWidget::openBatch(const QStringList &selectedFiles)
@@ -964,6 +923,7 @@ void DkCentralWidget::openBatch(const QStringList &selectedFiles)
 
 void DkCentralWidget::showBatch(bool show)
 {
+    showViewPort(!show);
     if (show) {
         if (!mWidgets[batch_widget]) {
             mWidgets[batch_widget] = createBatch();

--- a/ImageLounge/src/DkGui/DkControlWidget.cpp
+++ b/ImageLounge/src/DkGui/DkControlWidget.cpp
@@ -643,6 +643,10 @@ void DkControlWidget::setPluginWidget(DkViewPortInterface *pluginWidget, bool re
         return;
     }
 
+    // workaround some plugin bugs by disabling actions while the plugin is open
+    // TODO: this belongs in central widget as action enablement is tied to tabs
+    DkActionManager::instance().enableViewPortPluginActions(!removeWidget);
+
     if (!removeWidget) {
         mPluginViewport->setWorldMatrix(mViewport->getWorldMatrixPtr());
         mPluginViewport->setImgMatrix(mViewport->getImageMatrixPtr());

--- a/ImageLounge/src/DkGui/DkControlWidget.cpp
+++ b/ImageLounge/src/DkGui/DkControlWidget.cpp
@@ -645,7 +645,7 @@ void DkControlWidget::setPluginWidget(DkViewPortInterface *pluginWidget, bool re
 
     // workaround some plugin bugs by disabling actions while the plugin is open
     // TODO: this belongs in central widget as action enablement is tied to tabs
-    DkActionManager::instance().enableViewPortPluginActions(!removeWidget);
+    DkActionManager::instance().enableViewPortPluginActions(removeWidget);
 
     if (!removeWidget) {
         mPluginViewport->setWorldMatrix(mViewport->getWorldMatrixPtr());

--- a/ImageLounge/src/DkGui/DkDockWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkDockWidgets.cpp
@@ -50,6 +50,7 @@ void DkHistoryDock::createLayout()
 {
     mHistoryList = new QListWidget(this);
     mHistoryList->setObjectName("historyList");
+    mHistoryList->setFocusPolicy(Qt::ClickFocus);
     mHistoryList->setIconSize(QSize(DkSettingsManager::param().effectiveIconSize(), DkSettingsManager::param().effectiveIconSize()));
     connect(mHistoryList, &QListWidget::itemClicked, this, &DkHistoryDock::onHistoryListItemClicked);
 

--- a/ImageLounge/src/DkGui/DkLogWidget.cpp
+++ b/ImageLounge/src/DkGui/DkLogWidget.cpp
@@ -71,13 +71,16 @@ void DkLogWidget::createLayout()
 {
     mTextEdit = new QTextEdit(this);
     mTextEdit->setReadOnly(true);
+    mTextEdit->setFocusPolicy(Qt::ClickFocus);
 
     // we can't change text colors in qss so also fix the background color
     mTextEdit->setStyleSheet("QTextEdit { font-family: monospace; background-color: #000; }");
 
+    // invisible clear button ?!
     QPushButton *clearButton = new QPushButton(this);
     clearButton->setFlat(true);
     clearButton->setFixedSize(QSize(32, 32));
+    clearButton->setFocusPolicy(Qt::NoFocus);
     connect(clearButton, &QPushButton::clicked, this, &DkLogWidget::onClearButtonPressed);
 
     QGridLayout *layout = new QGridLayout(this);
@@ -114,6 +117,7 @@ DkLogDock::DkLogDock(const QString &title, QWidget *parent, Qt::WindowFlags flag
 void DkLogDock::createLayout()
 {
     DkLogWidget *logWidget = new DkLogWidget(this);
+    logWidget->setFocusPolicy(Qt::ClickFocus);
     setWidget(logWidget);
 }
 

--- a/ImageLounge/src/DkGui/DkManipulatorWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkManipulatorWidgets.cpp
@@ -136,6 +136,10 @@ void DkManipulatorWidget::createLayout()
     layout->setSpacing(0);
     layout->addWidget(actionScroller);
     layout->addWidget(mplWidget);
+
+    // I couldn't find the focus widget so just get them all
+    for (QWidget *w : this->findChildren<QWidget *>())
+        w->setFocusPolicy(Qt::ClickFocus);
 }
 
 void DkManipulatorWidget::setImage(QSharedPointer<DkImageContainerT> imgC)

--- a/ImageLounge/src/DkGui/DkMetaDataWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkMetaDataWidgets.cpp
@@ -388,6 +388,7 @@ void DkMetaDataDock::createLayout()
 {
     mFilterEdit = new QLineEdit(this);
     mFilterEdit->setPlaceholderText(tr("Filter"));
+    mFilterEdit->setFocusPolicy(Qt::ClickFocus);
     connect(mFilterEdit, &QLineEdit::textChanged, this, &DkMetaDataDock::onFilterTextChanged);
 
     // create our beautiful shortcut view
@@ -399,6 +400,7 @@ void DkMetaDataDock::createLayout()
     mTreeView = new QTreeView(this);
     mTreeView->setModel(mProxyModel);
     mTreeView->setAlternatingRowColors(true);
+    mTreeView->setFocusPolicy(Qt::ClickFocus);
     // mTreeView->setIndentation(8);
     // mTreeView->setStyleSheet("QTreeView{border: none;}");
 

--- a/ImageLounge/src/DkGui/DkMetaDataWidgets.h
+++ b/ImageLounge/src/DkGui/DkMetaDataWidgets.h
@@ -270,10 +270,9 @@ signals:
 protected:
     void createLayout();
 
-    DkCommentTextEdit *mCommentLabel;
+    DkCommentTextEdit *mCommentLabel = nullptr;
     QSharedPointer<DkMetaDataT> mMetaData;
     bool mTextEdited = false;
     QString mOldText;
 };
-
 }

--- a/ImageLounge/src/DkGui/DkNoMacs.cpp
+++ b/ImageLounge/src/DkGui/DkNoMacs.cpp
@@ -262,6 +262,9 @@ void DkNoMacs::createMenu()
 #endif // WITH_PLUGINS
 
     mMenu->addMenu(am.helpMenu());
+
+    // makes menu actions available even if menu bar is hidden
+    addActions(mMenu->actions());
 }
 
 void DkNoMacs::createContextMenu()

--- a/ImageLounge/src/DkGui/DkPreferenceWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkPreferenceWidgets.cpp
@@ -78,7 +78,6 @@ DkPreferenceWidget::DkPreferenceWidget(QWidget *parent)
 
     QAction *previousAction = new QAction(tr("previous"), this);
     previousAction->setShortcut(Qt::Key_PageUp);
-    previousAction->setShortcutContext(Qt::WidgetWithChildrenShortcut);
     connect(previousAction, &QAction::triggered, this, &DkPreferenceWidget::previousTab);
     addAction(previousAction);
 }

--- a/ImageLounge/src/DkGui/DkShortcuts.cpp
+++ b/ImageLounge/src/DkGui/DkShortcuts.cpp
@@ -1,0 +1,298 @@
+/*******************************************************************************************************
+ DkShortcuts.cpp
+ Created on:	03.28.2025
+
+ nomacs is a fast and small image viewer with the capability of synchronizing multiple instances
+
+ Copyright (C) 2025 Scrubs <scrubbbbs@gmail.com>
+
+ This file is part of nomacs.
+
+ nomacs is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ nomacs is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+ *******************************************************************************************************/
+
+#include "DkShortcuts.h"
+#include "DkTimer.h"
+
+#pragma warning(push, 0) // no warnings from includes - begin
+#include <QAction>
+#include <QApplication>
+#include <QDebug>
+#include <QEvent>
+#include <QKeyEvent>
+#include <QMainWindow>
+#include <QSet>
+#include <QTreeView>
+#pragma warning(pop) // no warnings from includes - end
+
+namespace nmc
+{
+
+DkShortcutEventFilter *DkShortcutEventFilter::instance()
+{
+    static auto *ptr = new DkShortcutEventFilter; // we don't care about destruction
+    return ptr;
+}
+
+void DkShortcutEventFilter::reserveKeys(const QWidget *target, const QVector<QKeySequence> &keys)
+{
+    QString name = target->objectName();
+    if (name.isEmpty()) {
+        qCritical() << "[shortcuts] reserveKeys requires object name";
+        return;
+    }
+
+    qDebug() << "[shortcuts]" << name << "reserving" << keys;
+
+    instance()->mReservedKeys.insert(name, keys);
+}
+
+static bool resolveShortcut(const QWidget *target, const QSet<const QWidget *> &skip, const QKeySequence &keySeq, int depth = 0)
+{
+    if (!target->isVisible())
+        return false;
+    if (skip.contains(target))
+        return false;
+
+    // breadth-first resolution descending into children
+    // qDebug().noquote() << "[shortcut] resolving:" << keySeq << QString(' ').repeated(depth * 2) << target->metaObject()->className() << target->objectName();
+    for (auto *a : target->actions())
+        if (QKeySequence::ExactMatch == a->shortcut().matches(keySeq)) {
+            a->trigger();
+            return true;
+        }
+
+    for (auto *o : target->children()) {
+        if (!o->metaObject()->inherits(&QWidget::staticMetaObject))
+            continue;
+        bool found = resolveShortcut(static_cast<QWidget *>(o), skip, keySeq, depth++);
+        if (found)
+            return found;
+    }
+
+    return false;
+}
+
+bool DkShortcutEventFilter::eventFilter(QObject *target, QEvent *e)
+{
+    // reject shortcuts that would interfere with widgets, this allows
+    // shortcuts to bind to more keys than would normally be possible,
+    // e.g. arrow keys, space bar, home/end, pgup/pgdown, letters w/o modifiers
+
+    // to test this, bind one of the keys below to a shortcut; you should
+    // not be able to activate the shortcut when the associated widget is focused
+
+    // note: be performance-minded (try not to allocate memory, etc),
+    // since all application events and keypress events need to be handled,
+    // not just ones the ones bound to shortcuts
+
+    if (Q_UNLIKELY(e->type() == QEvent::Shortcut)) {
+        auto *evt = static_cast<QShortcutEvent *>(e);
+        if (!evt->isAmbiguous())
+            return false;
+
+        // stop normal shortcut propagation
+        evt->accept();
+
+        // we have to start looking somewhere, this seems reasonable
+        const QWidget *w = qApp->focusWidget();
+        // const QWidget *w = QApplication::widgetAt(QCursor::pos());
+
+        // resolve shortcuts by breadth-first to the children,
+        // then up through parent widgets
+        DkTimer dt;
+        QSet<const QWidget *> skip;
+        while (w) {
+            bool found = resolveShortcut(w, skip, evt->key());
+            if (found) {
+                qDebug() << "[shortcuts] resolved ambiguous" << evt->key() << "in" << dt;
+                return true;
+            }
+
+            // we're trying the parent next, avoid checking this child
+            skip.insert(w);
+
+            auto *o = w->parent();
+            if (!o->metaObject()->inherits(&QWidget::staticMetaObject))
+                break;
+            w = static_cast<QWidget *>(o);
+        }
+
+        qWarning() << "[shortcuts] " << target->metaObject()->className() << target->objectName() << "unable to resolve ambiguous shortcut" << evt->shortcutId()
+                   << evt->key();
+
+        return false;
+    }
+
+    if (Q_LIKELY(e->type() != QEvent::ShortcutOverride))
+        return false;
+
+    const QWidget *widget = dynamic_cast<QWidget *>(target);
+    if (Q_UNLIKELY(!widget))
+        return false;
+
+    // only shortcuts of concern are bound in the main window
+    if (Q_UNLIKELY(!widget->window()->metaObject()->inherits(&QMainWindow::staticMetaObject)))
+        return false;
+
+    const QKeyEvent *keyEvent = static_cast<QKeyEvent *>(e);
+    const QKeySequence keySeq(keyEvent->modifiers() | keyEvent->key());
+
+    // widget needs to to allow its own shortcuts, for example, on the "Enter" key of DkExplorer
+    for (QAction *a : widget->actions()) {
+        if (QKeySequence::ExactMatch == a->shortcut().matches(keySeq)) {
+            qDebug() << "[shortcuts] " << target->metaObject()->className() << "allowing own action:" << a->text() << keySeq;
+            return false;
+        }
+    }
+
+    // Override the keys/widgets that conflict
+    // - To verify the keys, look up the widget source code in Qt (https://codebrowser.dev)
+    // - Do not reserve left/right generally; for viewport shortcuts and we do not scroll horizontally, usually
+    // - Widgets with text input already override keys
+    // - Some widget keys use QKeySequence::StandardKey instead of Qt::Key,
+    //   which can be different across platforms
+    bool reserved = false;
+    const QMetaObject *reservedType = nullptr; // object type that defined the reservation
+    QString reservedName; // QObject::objectName()
+
+    // if the widget inherits one of these classes, look for conflicts
+    static const struct {
+        const QMetaObject *type;
+        const QVector<QKeySequence> keys;
+    } reservedKeys[] = {
+        // this comes before QAbstractItemView or else - as a subclass - it is never checked
+        {&QTreeView::staticMetaObject,
+         {
+             // omit left/right
+             Qt::Key_Up,
+             Qt::Key_Down,
+             Qt::SHIFT | Qt::Key_Right, // expand
+             Qt::SHIFT | Qt::Key_Left, // collapse
+             Qt::Key_PageUp,
+             Qt::Key_PageDown,
+             Qt::Key_Home,
+             Qt::Key_End,
+             Qt::Key_Asterisk, // expand recursive
+             Qt::Key_Plus, // expand (alt)
+             Qt::Key_Minus, // collapse (alt)
+         }},
+        {&QAbstractItemView::staticMetaObject,
+         {
+             // omit left/right
+             Qt::Key_Up,
+             Qt::Key_Down,
+             Qt::Key_PageUp,
+             Qt::Key_PageDown,
+             Qt::Key_Home,
+             Qt::Key_End,
+         }},
+        {&QAbstractScrollArea::staticMetaObject,
+         {
+             // omit left/right
+             Qt::Key_Up,
+             Qt::Key_Down,
+             QKeySequence::MoveToNextPage,
+             QKeySequence::MoveToPreviousPage,
+         }},
+        {&QAbstractSpinBox::staticMetaObject,
+         {
+             Qt::Key_Up,
+             Qt::Key_Down,
+             Qt::Key_PageUp,
+             Qt::Key_PageDown,
+         }},
+        {&QAbstractSlider::staticMetaObject,
+         {
+             Qt::Key_Left,
+             Qt::Key_Right,
+             Qt::Key_Up,
+             Qt::Key_Down,
+             Qt::Key_PageUp,
+             Qt::Key_PageDown,
+             Qt::Key_Home,
+             Qt::Key_End,
+         }},
+    };
+
+    {
+        // keys we reserved with reserveKeys() first take priority
+        auto &map = qAsConst(mReservedKeys); // TODO: c++17 std::as_const
+        auto it = map.find(widget->objectName());
+        if (it != map.end()) {
+            if (it.value().contains(keySeq)) {
+                reservedType = widget->metaObject();
+                reservedName = widget->objectName();
+                reserved = true;
+            } else {
+                qDebug() << "[shortcuts]" << target->metaObject()->className() << target->objectName() << "allowing shortcut" << keySeq;
+                return false;
+            }
+        }
+    }
+
+    if (!reserved) {
+        for (auto &r : reservedKeys)
+            if (widget->metaObject()->inherits(r.type)) {
+                reservedType = r.type;
+                if (r.keys.contains(keySeq))
+                    reserved = true;
+                break;
+            }
+    }
+
+    // filename characters can be used to jump around in item views
+    if (!reserved && (reservedType == &QTreeView::staticMetaObject || reservedType == &QAbstractItemView::staticMetaObject)) {
+        const QString text = keyEvent->text();
+        if (!text.isEmpty() && keyEvent->modifiers() == Qt::NoModifier) {
+            if (text[0].isLower() || text[0].isNumber())
+                reserved = true;
+        }
+    }
+
+    // we have a conflict with global shortcut, do not allow it
+    if (reserved) {
+        qDebug() << "[shortcuts] " << target->metaObject()->className() << target->objectName() << "blocking" << keySeq << "reserved by"
+                 << reservedType->className() << reservedName;
+        e->accept();
+        return true;
+    }
+
+    return false;
+}
+
+bool DkActionEventFilter::eventFilter(QObject *target, QEvent *event)
+{
+    (void)target;
+
+    if (Q_LIKELY(event->type() != QEvent::ShortcutOverride && event->type() != QEvent::KeyPress))
+        return false;
+
+    QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);
+
+    int key = keyEvent->modifiers() | keyEvent->key();
+    for (auto *a : qAsConst(mActions)) // TODO: c++17 std::as_const()
+        if (a->isEnabled() && QKeySequence::ExactMatch == a->shortcut().matches(key)) {
+            if (event->type() == QEvent::ShortcutOverride)
+                event->accept();
+            else if (event->type() == QEvent::KeyPress)
+                a->trigger();
+            return true;
+        }
+
+    return false;
+}
+
+}

--- a/ImageLounge/src/DkGui/DkShortcuts.h
+++ b/ImageLounge/src/DkGui/DkShortcuts.h
@@ -1,0 +1,122 @@
+/*******************************************************************************************************
+ DkShortcuts.h
+ Created on:	03.28.2025
+
+ nomacs is a fast and small image viewer with the capability of synchronizing multiple instances
+
+ Copyright (C) 2025 Scrubs <scrubbbbs@gmail.com>
+
+ This file is part of nomacs.
+
+ nomacs is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ nomacs is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+ *******************************************************************************************************/
+#pragma once
+
+#pragma warning(push, 0) // no warnings from includes - begin
+#include <QHash>
+#include <QKeySequence>
+#include <QObject>
+#include <QVector>
+#pragma warning(pop) // no warnings from includes - end
+
+#ifndef DllCoreExport
+#ifdef DK_CORE_DLL_EXPORT
+#define DllCoreExport Q_DECL_EXPORT
+#elif DK_DLL_IMPORT
+#define DllCoreExport Q_DECL_IMPORT
+#else
+#define DllCoreExport Q_DECL_IMPORT
+#endif
+#endif
+
+class QAction;
+
+namespace nmc
+{
+
+/**
+ * Allows using global shortcut context for most nomacs shortcuts, but without
+ * breaking widgets that have default keys, or use keyPressEvent() etc which
+ * are not customizable by the user.
+ */
+class DllCoreExport DkShortcutEventFilter : public QObject
+{
+    Q_DISABLE_COPY_MOVE(DkShortcutEventFilter)
+
+public:
+    static DkShortcutEventFilter *instance();
+
+    /**
+     * Reserve keys to prevent shortcuts from taking them, or release keys back to shortcuts
+     *
+     * @param target event receiving key press events
+     * @param keys   list of shortcuts to reserve, replacing any default/existing reservation
+     *
+     * @note target is identified by QObject::objectName()
+     *
+     * @details When a widget uses key events (not recommended, use actions!),
+     * it should call this function to reserve that key. Which will prevent
+     * any shortcuts from stealing it.
+     *
+     * By default, keys are reserved based on the widget type,
+     * e.g. QTreeView reserves up/down arrows as that is hard-coded into Qt
+     **/
+    static void reserveKeys(const QWidget *target, const QVector<QKeySequence> &keys = {});
+
+protected:
+    DkShortcutEventFilter()
+        : QObject()
+    {
+    }
+
+    bool eventFilter(QObject *target, QEvent *e);
+
+    QHash<QString, QVector<QKeySequence>> mReservedKeys;
+};
+
+/**
+ * Allows a widget to bind actions that supercede global actions,
+ * without the dreaded "ambiguous shortcut" warning from Qt.
+ *
+ * This would be used for widgets that cannot use DkActionManager
+ * for some reason but still would like to use actions.
+ *
+ * Alternatively, widgets can use keyPressEvent() and reserveKeys()
+ */
+class DllCoreExport DkActionEventFilter : public QObject
+{
+public:
+    DkActionEventFilter(QObject *parent)
+        : QObject(parent)
+    {
+    }
+
+    void addAction(QAction *action)
+    {
+        mActions.append(action);
+    }
+
+    void clearActions()
+    {
+        mActions.clear();
+    }
+
+protected:
+    bool eventFilter(QObject *target, QEvent *e) override;
+
+    QList<QAction *> mActions;
+};
+
+}

--- a/ImageLounge/src/DkGui/DkShortcuts.h
+++ b/ImageLounge/src/DkGui/DkShortcuts.h
@@ -116,7 +116,7 @@ public:
 protected:
     bool eventFilter(QObject *target, QEvent *e) override;
 
-    QList<QAction *> mActions;
+    QVector<QAction *> mActions;
 };
 
 }

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -33,6 +33,7 @@
 #include "DkMessageBox.h"
 #include "DkNoMacs.h"
 #include "DkSettings.h"
+#include "DkShortcuts.h"
 #include "DkStatusBar.h"
 #include "DkThumbs.h"
 #include "DkTimer.h"
@@ -1065,6 +1066,18 @@ DkThumbScene::DkThumbScene(QWidget *parent /* = 0 */)
     : QGraphicsScene(parent)
 {
     setObjectName("DkThumbWidget");
+
+    DkShortcutEventFilter::reserveKeys(parent,
+                                       {
+                                           Qt::Key_Up,
+                                           Qt::Key_Down,
+                                           Qt::Key_Left,
+                                           Qt::Key_Right,
+                                           Qt::SHIFT | Qt::Key_Up,
+                                           Qt::SHIFT | Qt::Key_Down,
+                                           Qt::SHIFT | Qt::Key_Left,
+                                           Qt::SHIFT | Qt::Key_Right,
+                                       });
 }
 
 void DkThumbScene::updateLayout()

--- a/ImageLounge/src/DkGui/DkViewPort.cpp
+++ b/ImageLounge/src/DkGui/DkViewPort.cpp
@@ -119,24 +119,10 @@ DkViewPort::DkViewPort(QWidget *parent)
     mPaintLayout->addWidget(mNavigationWidget);
     // TODO: if visible, currently mNavigationWidget eats all mouse events that are supposed for control widget
 
-    // add actions
+    // add actions that cannot be found in the main menu
     DkActionManager &am = DkActionManager::instance();
-    addActions(am.fileActions().toList());
-    addActions(am.viewActions().toList());
-    addActions(am.editActions().toList());
-    addActions(am.manipulatorActions().toList());
-    addActions(am.sortActions().toList());
-    addActions(am.toolsActions().toList());
-    addActions(am.panelActions().toList());
-    addActions(am.syncActions().toList());
-    addActions(am.pluginActions().toList());
-    addActions(am.helpActions().toList());
     addActions(am.hiddenActions().toList());
-
     addActions(am.openWithActions().toList());
-#ifdef WITH_PLUGINS
-    addActions(am.pluginActionManager()->pluginDummyActions().toList());
-#endif
 
     connect(&mImgStorage, &DkImageStorage::infoSignal, this, &DkViewPort::infoSignal);
 

--- a/ImageLounge/src/DkGui/DkWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkWidgets.cpp
@@ -444,11 +444,13 @@ void DkBrowseExplorer::createLayout()
     mRootPathLabel = new DkElidedLabel(rootPathWidget, "");
 
     auto browseButton = new QPushButton(tr("Browse"));
+    browseButton->setFocusPolicy(Qt::ClickFocus);
     connect(browseButton, &QPushButton::clicked, this, &DkBrowseExplorer::browseClicked);
 
     auto scrollButton = new QToolButton();
     scrollButton->setIcon(DkImage::loadIcon(":/nomacs/img/scroll-to-current.svg"));
     scrollButton->setToolTip(tr("Scroll to current file"));
+    scrollButton->setFocusPolicy(Qt::ClickFocus);
     connect(scrollButton, &QPushButton::clicked, this, &DkBrowseExplorer::scrollToCurrentClicked);
 
     rpLayout->setContentsMargins(4, 2, 2, 2);
@@ -516,6 +518,7 @@ void DkExplorer::createLayout()
     mFileTree->setModel(mSortModel);
     mFileTree->setDragEnabled(true);
     mFileTree->setAcceptDrops(true);
+    mFileTree->setFocusPolicy(Qt::ClickFocus);
 
     // by default descendingOrder is set
     mFileTree->header()->setSortIndicator(0, Qt::AscendingOrder);

--- a/ImageLounge/src/DkGui/DkWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkWidgets.cpp
@@ -2160,6 +2160,10 @@ void DkCropWidget::createToolbar()
 {
     cropToolbar = new DkCropToolBar(tr("Crop Toolbar"), this);
 
+    // crop toolbar will be reparented, which messes up shortcut resolution
+    for (QAction *a : cropToolbar->actions())
+        this->addAction(a);
+
     connect(cropToolbar, &DkCropToolBar::updateRectSignal, this, &DkCropWidget::setRect);
 
     connect(cropToolbar, &DkCropToolBar::cropSignal, this, &DkCropWidget::crop);

--- a/ImageLounge/src/main.cpp
+++ b/ImageLounge/src/main.cpp
@@ -68,6 +68,7 @@
 #include "DkPong.h"
 #include "DkProcess.h"
 #include "DkSettings.h"
+#include "DkShortcuts.h"
 #include "DkThemeManager.h"
 #include "DkTimer.h"
 #include "DkUtils.h"
@@ -406,6 +407,8 @@ int main(int argc, char *argv[])
     app.installEventFilter(osxEventFilter);
     QObject::connect(osxEventFilter, &nmc::DkNomacsOSXEventFilter::loadFile, w, &nmc::DkNoMacs::loadFile);
 #endif
+
+    app.installEventFilter(nmc::DkShortcutEventFilter::instance());
 
     int rVal = -1;
     try {


### PR DESCRIPTION
See commit messages.

Summary:

Shortcut activation problems can be fixed by removing `setShortcutContext(Qt::WidgetAndChidrenShortcut)`. This flag requires widget focus for the shortcut to activate. Which is why we have to click in the main view for most shortcuts to work. I have been able to remove most instances of this and it fixes most of the activation issues.

However it leaves us with new issues to resolve:

---------------------------------------------
- [x] Conflicts with built-in keys

There are Qt controls that use built-in keys that might be defined in a shortcut; these shortcuts need to be "overridden" explicitly, for example pressing the "e" key when explorer has focus should not hide the explorer, it should jump to the next file/folder starting with "e". Mostly this is QTreeView, and the fix is to add a handler for QEvent::ShortCutOverride.

------------------------------------------
- [x] Ambiguous shortcuts. 

These come from swidgets that define their own QAction outside of menus and/or toolbars. These are resolved by:
  + Using the new `DkActionEventHandler` to bypass Qt shortcuts system for those actions
  + Allowing shortcut to be resolved via `DkShortcutEventHandler` which has a method to resolve the ambiguity. In some case actions will have to be copied around to give them higher priority.

--------------------------------------
- [x] Conflicts with plugins

For example control-Z in paint-on-image. This is address in two ways
 + disabling certain actions while the plugin is active
 + they can rely on the ambiguous resolution mechanism
 