### PR TITLE
Directory view usability fixes

### DIFF
--- a/ImageLounge/src/DkCore/DkImageLoader.cpp
+++ b/ImageLounge/src/DkCore/DkImageLoader.cpp
@@ -276,11 +276,6 @@ bool DkImageLoader::loadDir(const QString &newDirPath, bool scanRecursive)
             files = getFilteredFileInfoList(mCurrentDir,
                                             mFolderFilterString); // this line takes seconds if you have lots of files and slow loading (e.g. network)
 
-        if (files.empty()) {
-            emit showInfoSignal(tr("%1 \n does not contain any image").arg(mCurrentDir), 4000); // stop showing
-            return false;
-        }
-
         // ok new folder, this should speed-up loading
         mImages.clear();
 

--- a/ImageLounge/src/DkGui/DkCentralWidget.cpp
+++ b/ImageLounge/src/DkGui/DkCentralWidget.cpp
@@ -842,6 +842,7 @@ void DkCentralWidget::showThumbView(bool show)
 
             connect(tw, &DkThumbScrollWidget::updateDirSignal, tabInfo->getImageLoader().data(), &DkImageLoader::loadDirRecursive, Qt::UniqueConnection);
             connect(tw, &DkThumbScrollWidget::filterChangedSignal, tabInfo->getImageLoader().data(), &DkImageLoader::setFolderFilter, Qt::UniqueConnection);
+            emit thumbViewLoadedSignal(tabInfo->getImageLoader().data()->getDirPath());
         }
 
     } else {

--- a/ImageLounge/src/DkGui/DkCentralWidget.h
+++ b/ImageLounge/src/DkGui/DkCentralWidget.h
@@ -146,6 +146,7 @@ public:
 signals:
     void imageUpdatedSignal(QSharedPointer<DkImageContainerT>) const;
     void imageHasGPSSignal(bool) const;
+    void thumbViewLoadedSignal(const QString &) const;
 
 public slots:
     void imageLoaded(QSharedPointer<DkImageContainerT> img);

--- a/ImageLounge/src/DkGui/DkMetaDataWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkMetaDataWidgets.cpp
@@ -436,11 +436,12 @@ void DkMetaDataDock::updateEntries()
     for (int idx = 0; idx < nr; idx++)
         getExpandedItemNames(mProxyModel->index(idx, 0, QModelIndex()), mExpandedNames);
 
-    if (!mImgC)
-        return;
-
     mModel->deleteLater();
     mModel = new DkMetaDataModel(this);
+    if (!mImgC) {
+        mProxyModel->setSourceModel(mModel);
+        return;
+    }
     mModel->addMetaData(mImgC->getMetaData());
     mProxyModel->setSourceModel(mModel);
 

--- a/ImageLounge/src/DkGui/DkNoMacs.cpp
+++ b/ImageLounge/src/DkGui/DkNoMacs.cpp
@@ -1858,7 +1858,7 @@ void DkNoMacs::setWindowTitle(const QString &filePath, const QSize &size, bool e
             bar->setMessage("", DkStatusBar::status_time_info); // hide label
 
         if (fInfo.exists())
-            bar->setMessage(DkUtils::readableByte((float)fInfo.size()), DkStatusBar::status_filesize_info);
+            bar->setMessage(DkUtils::readableByte(fInfo.size()), DkStatusBar::status_filesize_info);
         else
             bar->setMessage("", DkStatusBar::status_filesize_info);
     }

--- a/ImageLounge/src/DkGui/DkNoMacs.cpp
+++ b/ImageLounge/src/DkGui/DkNoMacs.cpp
@@ -211,7 +211,9 @@ void DkNoMacs::init()
 
     // connections to the image loader
     connect(getTabWidget(), &DkCentralWidget::imageUpdatedSignal, this, QOverload<QSharedPointer<DkImageContainerT>>::of(&DkNoMacs::setWindowTitle));
-    connect(getTabWidget(), &DkCentralWidget::thumbViewLoadedSignal, this, &DkNoMacs::setWindowTitleDirectory);
+    connect(getTabWidget(), &DkCentralWidget::thumbViewLoadedSignal, this, [this](const QString &path) {
+        setWindowTitle(path);
+    });
 
     DkActionManager::instance().enableMovieActions(false);
 
@@ -1789,11 +1791,6 @@ void DkNoMacs::setWindowTitle(QSharedPointer<DkImageContainerT> imgC)
     }
 
     setWindowTitle(imgC->filePath(), imgC->image().size(), imgC->isEdited(), imgC->getTitleAttribute());
-}
-
-void DkNoMacs::setWindowTitleDirectory(const QString &directory)
-{
-    setWindowTitle(directory, QSize(), false, QString());
 }
 
 void DkNoMacs::setWindowTitle(const QString &filePath, const QSize &size, bool edited, const QString &attr)

--- a/ImageLounge/src/DkGui/DkNoMacs.h
+++ b/ImageLounge/src/DkGui/DkNoMacs.h
@@ -168,7 +168,6 @@ public slots:
     void bugReport();
     void loadRecursion();
     void setWindowTitle(QSharedPointer<DkImageContainerT> imgC);
-    void setWindowTitleDirectory(const QString &directory);
     void setWindowTitle(const QString &filePath, const QSize &size = QSize(), bool edited = false, const QString &attr = QString());
     void showOpacityDialog();
     void opacityUp();

--- a/ImageLounge/src/DkGui/DkNoMacs.h
+++ b/ImageLounge/src/DkGui/DkNoMacs.h
@@ -168,6 +168,7 @@ public slots:
     void bugReport();
     void loadRecursion();
     void setWindowTitle(QSharedPointer<DkImageContainerT> imgC);
+    void setWindowTitleDirectory(const QString &directory);
     void setWindowTitle(const QString &filePath, const QSize &size = QSize(), bool edited = false, const QString &attr = QString());
     void showOpacityDialog();
     void opacityUp();


### PR DESCRIPTION
Various improvements to usability of the directory ("thumb") view, as follows:
- It is now possible to load directories without images from the explorer, this will now show an empty view instead of the images that were in the previous dir.
- Loading the directory view no longer displays information in the statusbar and metadata explorer that was about the previously loaded image. Instead it displays the file name and file size of the image currently selected or hovered over, as applicable.
- Loading the directory view now changes the titlebar to the directory that is loaded.