### PR TITLE
Dock usability improvements

### DIFF
--- a/ImageLounge/src/DkGui/DkBaseWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkBaseWidgets.cpp
@@ -32,6 +32,7 @@
 
 #pragma warning(push, 0) // no warnings from includes - begin
 #include <QAction>
+#include <QCloseEvent>
 #include <QComboBox>
 #include <QDebug>
 #include <QEvent>
@@ -595,9 +596,14 @@ void DkDockWidget::setVisible(bool visible, bool saveSetting)
 
 void DkDockWidget::closeEvent(QCloseEvent *event)
 {
-    setVisible(false);
+    if (isFloating()) {
+        setFloating(false);
+        event->ignore();
+    } else {
+        setVisible(false);
 
-    QDockWidget::closeEvent(event);
+        QDockWidget::closeEvent(event);
+    }
 }
 
 Qt::DockWidgetArea DkDockWidget::getDockLocationSettings(const Qt::DockWidgetArea &defaultArea) const

--- a/ImageLounge/src/DkGui/DkMetaDataWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkMetaDataWidgets.cpp
@@ -440,8 +440,10 @@ void DkMetaDataDock::updateEntries()
     mModel = new DkMetaDataModel(this);
     if (!mImgC) {
         mProxyModel->setSourceModel(mModel);
+        mThumbNailLabel->hide();
         return;
     }
+    mThumbNailLabel->show();
     mModel->addMetaData(mImgC->getMetaData());
     mProxyModel->setSourceModel(mModel);
 


### PR DESCRIPTION
- Closing a detached dock window will now reattach it instead of closing it. Previously (it seems) there was absolutely no way to reattach a dock without closing the app entirely. (If this causes other usability issues, I can attempt to do it differently too.)
- The metadata dock will no longer display a thumb of the previously loaded image when a directory (thumb) view is currently open. (Actually I do not see the usefulness of this thumb even when an image is open, but I am sure it was added for a reason.)
