### PR TITLE
fixes compilation when LIBHEIF is enabled

### DIFF
--- a/ImageLounge/CMakeLists.txt
+++ b/ImageLounge/CMakeLists.txt
@@ -360,7 +360,7 @@ ELSE()
     MESSAGE(STATUS " nomacs will be compiled with plugin support .................. NO")
 ENDIF()
 
-IF(libheif_FOUND)
+IF(LIBHEIF_FOUND)
     MESSAGE(STATUS " nomacs will be compiled with HEIF support .................... YES")
 ELSE()
     MESSAGE(STATUS " nomacs will be compiled with HEIF support .................... NO")

--- a/ImageLounge/cmake/Unix.cmake
+++ b/ImageLounge/cmake/Unix.cmake
@@ -71,6 +71,19 @@ if(ENABLE_RAW)
     endif()
 endif(ENABLE_RAW)
 
+# Search for HEIF support
+unset(LIBHEIF_FOUND CACHE)
+if(ENABLE_HEIF)
+    pkg_check_modules(LIBHEIF libheif>=1.3.0)
+
+    if(NOT LIBHEIF_FOUND)
+        message(FATAL_ERROR "libheif not found. It's mandatory when ENABLE_HEIF is enabled.")
+    else()
+        add_definitions(-DWITH_LIBHEIF)
+    endif()
+endif(ENABLE_HEIF)
+
+
 #search for multi-layer tiff
 unset(TIFF_INCLUDE_DIR CACHE)
 unset(TIFF_LIBRARY CACHE)


### PR DESCRIPTION

When enables 
`-DENABLE_HEIF=ON`

still its showing 
`nomacs will be compiled with HEIF support .................... NO`