### PR TITLE
Improve fade/animation behavior

### DIFF
--- a/ImageLounge/src/DkCore/DkSettings.cpp
+++ b/ImageLounge/src/DkCore/DkSettings.cpp
@@ -467,6 +467,7 @@ void DkSettings::load(QSettings &settings, bool defaults)
     display_p.defaultForegroundColor = settings.value("defaultForegroundColor", display_p.defaultForegroundColor).toBool();
     display_p.defaultIconColor = settings.value("defaultIconColor", display_p.defaultIconColor).toBool();
     display_p.interpolateZoomLevel = settings.value("interpolateZoomlevel", display_p.interpolateZoomLevel).toInt();
+    display_p.animateWidgets = settings.value("animateWidgets", display_p.animateWidgets).toBool();
 
     settings.endGroup();
     // MetaData Settings --------------------------------------------------------------------
@@ -738,6 +739,8 @@ void DkSettings::save(QSettings &settings, bool force)
         settings.setValue("defaultIconColor", display_p.defaultIconColor);
     if (force || display_p.interpolateZoomLevel != display_d.interpolateZoomLevel)
         settings.setValue("interpolateZoomlevel", display_p.interpolateZoomLevel);
+    if (force || display_p.animateWidgets != display_d.animateWidgets)
+        settings.setValue("animateWidgets", display_p.animateWidgets);
 
     settings.endGroup();
     // MetaData Settings --------------------------------------------------------------------

--- a/ImageLounge/src/DkCore/DkSettings.cpp
+++ b/ImageLounge/src/DkCore/DkSettings.cpp
@@ -933,7 +933,6 @@ void DkSettings::setToDefaultSettings()
     display_p.defaultIconColor = true;
     display_p.interpolateZoomLevel = 200;
     display_p.animateWidgets = true;
-    display_p.suspendWidgetAnimation = false;
 
     slideShow_p.filter = 0;
     slideShow_p.time = 3.0;

--- a/ImageLounge/src/DkCore/DkSettings.cpp
+++ b/ImageLounge/src/DkCore/DkSettings.cpp
@@ -933,6 +933,7 @@ void DkSettings::setToDefaultSettings()
     display_p.defaultIconColor = true;
     display_p.interpolateZoomLevel = 200;
     display_p.animateWidgets = true;
+    display_p.suspendWidgetAnimation = false;
 
     slideShow_p.filter = 0;
     slideShow_p.time = 3.0;

--- a/ImageLounge/src/DkCore/DkSettings.cpp
+++ b/ImageLounge/src/DkCore/DkSettings.cpp
@@ -929,6 +929,7 @@ void DkSettings::setToDefaultSettings()
     display_p.defaultForegroundColor = true;
     display_p.defaultIconColor = true;
     display_p.interpolateZoomLevel = 200;
+    display_p.animateWidgets = true;
 
     slideShow_p.filter = 0;
     slideShow_p.time = 3.0;

--- a/ImageLounge/src/DkCore/DkSettings.h
+++ b/ImageLounge/src/DkCore/DkSettings.h
@@ -254,7 +254,6 @@ public:
 
         int histogramStyle;
         bool animateWidgets; // animate hide/show of widgets/panels/etc
-        bool suspendWidgetAnimation; // temporarily stop animation globally
     };
 
     struct Global {

--- a/ImageLounge/src/DkCore/DkSettings.h
+++ b/ImageLounge/src/DkCore/DkSettings.h
@@ -254,6 +254,7 @@ public:
 
         int histogramStyle;
         bool animateWidgets; // animate hide/show of widgets/panels/etc
+        bool suspendWidgetAnimation; // temporarily stop animation globally
     };
 
     struct Global {

--- a/ImageLounge/src/DkCore/DkSettings.h
+++ b/ImageLounge/src/DkCore/DkSettings.h
@@ -253,6 +253,7 @@ public:
         float animationDuration;
 
         int histogramStyle;
+        bool animateWidgets; // animate hide/show of widgets/panels/etc
     };
 
     struct Global {

--- a/ImageLounge/src/DkGui/DkBaseWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkBaseWidgets.cpp
@@ -53,6 +53,17 @@ DkWidget::DkWidget(QWidget *parent, Qt::WindowFlags flags)
 {
 }
 
+void DkWidget::paintEvent(QPaintEvent *event)
+{
+    // fixes stylesheets which are not applied to custom widgets
+    QStyleOption opt;
+    opt.initFrom(this);
+    QPainter p(this);
+    style()->drawPrimitive(QStyle::PE_Widget, &opt, &p, this);
+
+    QWidget::paintEvent(event);
+}
+
 DkFadeHelper::DkFadeHelper(QWidget *widget)
     : mWidget(widget)
 {
@@ -215,17 +226,6 @@ DkFadeWidget::DkFadeWidget(QWidget *parent, Qt::WindowFlags flags)
 void DkFadeWidget::init()
 {
     setMouseTracking(true);
-}
-
-void DkFadeWidget::paintEvent(QPaintEvent *event)
-{
-    // fixes stylesheets which are not applied to custom widgets
-    QStyleOption opt;
-    opt.initFrom(this);
-    QPainter p(this);
-    style()->drawPrimitive(QStyle::PE_Widget, &opt, &p, this);
-
-    QWidget::paintEvent(event);
 }
 
 // DkNamedWidget --------------------------------------------------------------------

--- a/ImageLounge/src/DkGui/DkBaseWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkBaseWidgets.cpp
@@ -64,6 +64,8 @@ void DkWidget::paintEvent(QPaintEvent *event)
     QWidget::paintEvent(event);
 }
 
+bool DkFadeHelper::mGloballyEnabled = true;
+
 DkFadeHelper::DkFadeHelper(QWidget *widget)
     : mWidget(widget)
 {
@@ -95,7 +97,7 @@ bool DkFadeHelper::isFadeEnabled() const
 {
     if (!DkSettingsManager::param().display().animateWidgets) // permanent setting
         return false;
-    if (DkSettingsManager::param().display().suspendWidgetAnimation) // temporary setting
+    if (!mGloballyEnabled) // temporary setting
         return false;
     return mEnabled;
 }

--- a/ImageLounge/src/DkGui/DkBaseWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkBaseWidgets.cpp
@@ -248,12 +248,6 @@ void DkLabel::init()
     updateStyleSheet();
 }
 
-void DkLabel::hide()
-{
-    mTime = 0;
-    QLabel::hide();
-}
-
 void DkLabel::setText(const QString &msg, int time)
 {
     mText = msg;
@@ -286,6 +280,13 @@ void DkLabel::showTimed(int time)
         mTimer.start(time);
 }
 
+void DkLabel::setVisible(bool visible)
+{
+    if (!visible)
+        mTimer.stop();
+    QLabel::setVisible(visible);
+}
+
 QString DkLabel::getText()
 {
     return mText;
@@ -303,7 +304,6 @@ void DkLabel::setFontSize(int fontSize)
 */
 void DkLabel::stop()
 {
-    mTimer.stop();
     hide();
 }
 

--- a/ImageLounge/src/DkGui/DkBaseWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkBaseWidgets.cpp
@@ -204,6 +204,8 @@ bool DkFadeHelper::isParentAnimating() const
 }
 
 // -------------------------------------------------------------------- DkFadeWidget
+template class DkFadeMixin<DkWidget>;
+
 DkFadeWidget::DkFadeWidget(QWidget *parent, Qt::WindowFlags flags)
     : DkFadeMixin<DkWidget>(parent, flags)
 {
@@ -424,6 +426,8 @@ int DkElidedLabel::minimumWidth()
 }
 
 // DkFadeLabel --------------------------------------------------------------------
+template class DkFadeMixin<DkLabel>;
+
 DkFadeLabel::DkFadeLabel(const QString &text, QWidget *parent)
     : DkFadeMixin(text, parent)
 {

--- a/ImageLounge/src/DkGui/DkBaseWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkBaseWidgets.cpp
@@ -90,14 +90,6 @@ void DkFadeHelper::fade(bool show, bool saveSetting)
         return;
     }
 
-    if (show && mShowing)
-        return;
-    if (!show && mHiding)
-        return;
-
-    if (!show && mWidget->isHidden())
-        return;
-
     if (mDisplayBits && saveSetting) {
         int bit = DkSettingsManager::param().app().currentAppMode;
         mDisplayBits->setBit(bit, show);
@@ -111,6 +103,18 @@ void DkFadeHelper::fade(bool show, bool saveSetting)
     }
 
     bool inProgress = mShowing | mHiding;
+
+    // no-op conditions
+    if (!show && mWidget->isHidden())
+        return;
+    if (show && mWidget->isVisible() && !inProgress)
+        return;
+
+    // skip if we are going in the right direction
+    if (show && mShowing)
+        return;
+    if (!show && mHiding)
+        return;
 
     if (show) {
         mShowing = true;

--- a/ImageLounge/src/DkGui/DkBaseWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkBaseWidgets.cpp
@@ -203,7 +203,7 @@ QString DkNamedWidget::name() const
 }
 
 // DkLabel --------------------------------------------------------------------
-DkLabel::DkLabel(QWidget *parent, const QString &text)
+DkLabel::DkLabel(const QString &text, QWidget *parent)
     : QLabel(text, parent)
 {
     setMouseTracking(true);
@@ -338,8 +338,8 @@ void DkLabel::setTextToLabel()
     }
 }
 
-DkLabelBg::DkLabelBg(QWidget *parent, const QString &text)
-    : DkLabel(parent, text)
+DkLabelBg::DkLabelBg(const QString &text, QWidget *parent)
+    : DkLabel(text, parent)
 {
     setAttribute(Qt::WA_TransparentForMouseEvents); // labels should forward mouse events
     setObjectName("DkLabelBg");

--- a/ImageLounge/src/DkGui/DkBaseWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkBaseWidgets.cpp
@@ -230,7 +230,7 @@ void DkFadeWidget::paintEvent(QPaintEvent *event)
 
 // DkNamedWidget --------------------------------------------------------------------
 DkNamedWidget::DkNamedWidget(const QString &name, QWidget *parent)
-    : DkFadeWidget(parent)
+    : DkWidget(parent)
 {
     mName = name;
 }

--- a/ImageLounge/src/DkGui/DkBaseWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkBaseWidgets.cpp
@@ -80,6 +80,13 @@ bool DkFadeHelper::getCurrentDisplaySetting()
     return mDisplayBits->testBit(DkSettingsManager::param().app().currentAppMode);
 }
 
+bool DkFadeHelper::isFadeEnabled() const
+{
+    if (!DkSettingsManager::param().display().animateWidgets)
+        return false;
+    return mEnabled;
+}
+
 void DkFadeHelper::fade(bool show, bool saveSetting)
 {
     qDebug().nospace() << "[fade] " << mWidget->metaObject()->className() << " show=" << show << " save=" << saveSetting << " showing=" << mShowing

--- a/ImageLounge/src/DkGui/DkBaseWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkBaseWidgets.cpp
@@ -82,7 +82,9 @@ bool DkFadeHelper::getCurrentDisplaySetting()
 
 bool DkFadeHelper::isFadeEnabled() const
 {
-    if (!DkSettingsManager::param().display().animateWidgets)
+    if (!DkSettingsManager::param().display().animateWidgets) // permanent setting
+        return false;
+    if (DkSettingsManager::param().display().suspendWidgetAnimation) // temporary setting
         return false;
     return mEnabled;
 }

--- a/ImageLounge/src/DkGui/DkBaseWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkBaseWidgets.cpp
@@ -85,11 +85,6 @@ void DkFadeHelper::fade(bool show, bool saveSetting)
     qDebug().nospace() << "[fade] " << mWidget->metaObject()->className() << " show=" << show << " save=" << saveSetting << " showing=" << mShowing
                        << " hiding=" << mHiding << " visible=" << mWidget->isVisible();
 
-    if (mBlocked) {
-        qDebug() << "[fade]" << mWidget->metaObject()->className() << "visibility is blocked";
-        return;
-    }
-
     if (mDisplayBits && saveSetting) {
         int bit = DkSettingsManager::param().app().currentAppMode;
         mDisplayBits->setBit(bit, show);

--- a/ImageLounge/src/DkGui/DkBaseWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkBaseWidgets.cpp
@@ -110,15 +110,19 @@ void DkFadeHelper::fade(bool show, bool saveSetting)
         mAction->blockSignals(false);
     }
 
+    bool inProgress = mShowing | mHiding;
+
     if (show) {
         mShowing = true;
         mHiding = false;
         if (mWidget->isHidden()) {
             mOpacityEffect->setEnabled(true);
-            mOpacityEffect->setOpacity(0);
+            mOpacityEffect->setOpacity(0.0);
             setWidgetVisible(true);
         }
-        animateOpacity();
+
+        if (!inProgress)
+            animateOpacity();
     } else {
         mShowing = false;
         mHiding = true;
@@ -127,7 +131,9 @@ void DkFadeHelper::fade(bool show, bool saveSetting)
             mOpacityEffect->setEnabled(true);
             mOpacityEffect->setOpacity(1.0);
         }
-        animateOpacity();
+
+        if (!inProgress)
+            animateOpacity();
     }
 }
 

--- a/ImageLounge/src/DkGui/DkBaseWidgets.h
+++ b/ImageLounge/src/DkGui/DkBaseWidgets.h
@@ -59,6 +59,9 @@ class DllCoreExport DkWidget : public QWidget
 
 public:
     DkWidget(QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags());
+
+protected:
+    void paintEvent(QPaintEvent *event) override;
 };
 
 // non-specialized functions for the mixin
@@ -238,7 +241,6 @@ public:
 protected:
     // functions
     void init();
-    void paintEvent(QPaintEvent *event) override;
 };
 
 extern template class DkFadeMixin<DkWidget>; // speed up compilation/linking

--- a/ImageLounge/src/DkGui/DkBaseWidgets.h
+++ b/ImageLounge/src/DkGui/DkBaseWidgets.h
@@ -53,6 +53,7 @@ class QComboBox;
 
 namespace nmc
 {
+// base for custom widgets
 class DllCoreExport DkWidget : public QWidget
 {
     Q_OBJECT
@@ -64,7 +65,7 @@ protected:
     void paintEvent(QPaintEvent *event) override;
 };
 
-// non-specialized functions for the mixin
+// non-specialized functions for DkFadeMixin
 class DllCoreExport DkFadeHelper
 {
     Q_DISABLE_COPY_MOVE(DkFadeHelper);
@@ -152,8 +153,7 @@ private:
     QBitArray *mDisplayBits = nullptr; // pointer to DkSettings visiblity bits for widget
 };
 
-// mixin pattern to allow QWidget::setVisible to
-// fade a widget in/out. Also can manage visiblity settings and actions
+// common fade behavior for widgets, implemented as mixin to support any QWidget type
 template<class QWidgetBase>
 class DkFadeMixin : public QWidgetBase, public DkFadeHelper
 {
@@ -233,6 +233,7 @@ protected:
     }
 };
 
+// widget that can fade in/out on QWidget::setVisible
 class DllCoreExport DkFadeWidget : public DkFadeMixin<DkWidget>
 {
     Q_OBJECT
@@ -258,6 +259,9 @@ protected:
 
 extern template class DkFadeMixin<DkWidget>; // speed up compilation/linking
 
+// widget with name() method to represent the displayed name (e.g. prefs tab label)
+// as opposed to objectName() which should be used for identification in QSS, etc
+// FIXME: this class is only used twice and could be replaced with QObject::setProperty()
 class DllCoreExport DkNamedWidget : public DkWidget
 {
     Q_OBJECT
@@ -271,6 +275,7 @@ protected:
     QString mName;
 };
 
+// label to show temporarily when text content changes (notifications etc)
 class DllCoreExport DkLabel : public QLabel
 {
     Q_OBJECT
@@ -322,6 +327,7 @@ protected:
     virtual void updateStyleSheet();
 };
 
+// label for long string we don't want to wrap around or scroll
 class DllCoreExport DkElidedLabel : public QLabel
 {
     Q_OBJECT
@@ -355,12 +361,7 @@ public:
     virtual ~DkLabelBg(){};
 };
 
-/**
- * This label fakes the DkFadeWidget behavior.
- * (allows for registering actions + fades in and out)
- * we need this class too, since we cannot derive from DkLabel & DkFadeWidget
- * at the same time -> both have QObject as common base class.
- **/
+// label widget that can fade in/out on QWidget::setVisible()
 class DkFadeLabel : public DkFadeMixin<DkLabel>
 {
     Q_OBJECT

--- a/ImageLounge/src/DkGui/DkBaseWidgets.h
+++ b/ImageLounge/src/DkGui/DkBaseWidgets.h
@@ -130,14 +130,16 @@ public:
     }
 
     // overload for text widgets
-    DkFadeMixin(const QString &text, QWidget *parent, Qt::WindowFlags flags)
-        : QWidgetBase(text, parent, flags)
+    template<typename T>
+    DkFadeMixin(const T &arg0, QWidget *parent, Qt::WindowFlags flags)
+        : QWidgetBase(arg0, parent, flags)
         , DkFadeHelper(this)
     {
     }
 
-    DkFadeMixin(const QString &text, QWidget *parent)
-        : QWidgetBase(text, parent)
+    template<typename T>
+    DkFadeMixin(const T &arg0, QWidget *parent)
+        : QWidgetBase(arg0, parent)
         , DkFadeHelper(this)
     {
     }

--- a/ImageLounge/src/DkGui/DkBaseWidgets.h
+++ b/ImageLounge/src/DkGui/DkBaseWidgets.h
@@ -372,8 +372,11 @@ public:
     static bool testDisplaySettings(const QBitArray &displaySettingsBits);
     Qt::DockWidgetArea getDockLocationSettings(const Qt::DockWidgetArea &defaultArea) const;
 
-public slots:
-    virtual void setVisible(bool visible, bool saveSetting = true);
+    void setVisible(bool visible) override
+    {
+        setVisible(visible, true);
+    }
+    virtual void setVisible(bool visible, bool saveSetting);
 
 protected:
     virtual void closeEvent(QCloseEvent *event) override;

--- a/ImageLounge/src/DkGui/DkBaseWidgets.h
+++ b/ImageLounge/src/DkGui/DkBaseWidgets.h
@@ -86,10 +86,7 @@ public:
     bool getCurrentDisplaySetting();
 
     // check if animation is currently enabled (may consider user settings)
-    bool isFadeEnabled() const
-    {
-        return mEnabled;
-    }
+    bool isFadeEnabled() const;
 
     // disable/enable animation of this widget, regardless of any user settings
     // will not affect fades that are in progress (call show/hide/etc for that)

--- a/ImageLounge/src/DkGui/DkBaseWidgets.h
+++ b/ImageLounge/src/DkGui/DkBaseWidgets.h
@@ -99,7 +99,6 @@ private:
     QWidget *mWidget; // widget we are showing/hiding
     QGraphicsOpacityEffect *mOpacityEffect;
 
-    bool mBlocked = false;
     bool mShowing = false;
     bool mHiding = false;
 

--- a/ImageLounge/src/DkGui/DkBaseWidgets.h
+++ b/ImageLounge/src/DkGui/DkBaseWidgets.h
@@ -179,6 +179,18 @@ public:
     //
 
     // if saveSetting=true then set the bound setting
+    //
+    // NOTE: when subclasses of DkFadeMixin override setVisible, they should *normally*:
+    //   1) call the superclass setVisible() immediately
+    //   2) check for recursive call with mSetWidgetVisible and skip the function body,
+    //      this indicates a recursion that is trying to bubble up to QWidget::setVisible()
+    //
+    // failure to do this may have unexpected behavior as the function body will
+    // be repeated on every call to setVisible()
+    //
+    // to avoid these pitfalls, override showEvent()/hideEvent() instead of setVisible()
+    // where possible
+    //
     virtual void setVisible(bool visible, bool saveSetting)
     {
         if (mSetWidgetVisible)

--- a/ImageLounge/src/DkGui/DkBaseWidgets.h
+++ b/ImageLounge/src/DkGui/DkBaseWidgets.h
@@ -76,13 +76,6 @@ public:
         mAction = action;
     }
 
-    // prevents fade() from having any effect or visibility change (TODO: what for?)
-    void block(bool blocked)
-    {
-        mBlocked = blocked;
-        setWidgetVisible(false);
-    }
-
     // binds a per-appmode setting to visibility changes
     void setDisplaySettings(QBitArray *displayBits)
     {

--- a/ImageLounge/src/DkGui/DkBaseWidgets.h
+++ b/ImageLounge/src/DkGui/DkBaseWidgets.h
@@ -145,30 +145,24 @@ class DkFadeMixin : public QWidgetBase, public DkFadeHelper
 public:
     DkFadeMixin() = delete;
 
-    // we need a few constructors for different widget types
-    DkFadeMixin(QWidget *parent, Qt::WindowFlags flags)
-        : QWidgetBase(parent, flags)
+    // handle 1-3 argument widget constructors
+    template<typename T, typename U, typename V>
+    DkFadeMixin(T arg0, U arg1, V arg2)
+        : QWidgetBase(arg0, arg1, arg2)
         , DkFadeHelper(this)
     {
     }
 
-    DkFadeMixin(QWidget *parent)
-        : QWidgetBase(parent)
-        , DkFadeHelper(this)
-    {
-    }
-
-    // overload for text widgets
-    template<typename T>
-    DkFadeMixin(const T &arg0, QWidget *parent, Qt::WindowFlags flags)
-        : QWidgetBase(arg0, parent, flags)
+    template<typename T, typename U>
+    DkFadeMixin(T arg0, U arg1)
+        : QWidgetBase(arg0, arg1)
         , DkFadeHelper(this)
     {
     }
 
     template<typename T>
-    DkFadeMixin(const T &arg0, QWidget *parent)
-        : QWidgetBase(arg0, parent)
+    DkFadeMixin(T arg0)
+        : QWidgetBase(arg0)
         , DkFadeHelper(this)
     {
     }
@@ -246,6 +240,8 @@ protected:
     void init();
     void paintEvent(QPaintEvent *event) override;
 };
+
+extern template class DkFadeMixin<DkWidget>; // speed up compilation/linking
 
 class DllCoreExport DkNamedWidget : public DkFadeWidget
 {
@@ -384,6 +380,8 @@ protected:
     QBitArray *displaySettingsBits;
     QAction *mAction = 0;
 };
+
+extern template class DkFadeMixin<DkLabel>;
 
 class DllCoreExport DkResizableScrollArea : public QScrollArea
 {

--- a/ImageLounge/src/DkGui/DkBaseWidgets.h
+++ b/ImageLounge/src/DkGui/DkBaseWidgets.h
@@ -236,8 +236,7 @@ public:
         updateStyleSheet();
     };
 
-public slots:
-    virtual void hide();
+    void setVisible(bool) override;
 
 protected:
     QWidget *mParent;

--- a/ImageLounge/src/DkGui/DkBaseWidgets.h
+++ b/ImageLounge/src/DkGui/DkBaseWidgets.h
@@ -222,7 +222,7 @@ class DllCoreExport DkLabel : public QLabel
     Q_OBJECT
 
 public:
-    DkLabel(QWidget *parent = 0, const QString &text = QString());
+    DkLabel(const QString &text = QString(), QWidget *parent = 0);
     virtual ~DkLabel();
 
     virtual void showTimed(int time = 3000);
@@ -298,7 +298,7 @@ class DkLabelBg : public DkLabel
     Q_OBJECT
 
 public:
-    DkLabelBg(QWidget *parent = 0, const QString &text = QString());
+    DkLabelBg(const QString &text = QString(), QWidget *parent = 0);
     virtual ~DkLabelBg(){};
 };
 
@@ -313,7 +313,7 @@ class DkFadeLabel : public DkFadeMixin<DkLabel>
     Q_OBJECT
 
 public:
-    DkFadeLabel(QWidget *parent = 0, const QString &text = QString());
+    DkFadeLabel(const QString &text = QString(), QWidget *parent = 0);
 };
 
 class DllCoreExport DkDockWidget : public QDockWidget

--- a/ImageLounge/src/DkGui/DkBaseWidgets.h
+++ b/ImageLounge/src/DkGui/DkBaseWidgets.h
@@ -243,7 +243,7 @@ protected:
 
 extern template class DkFadeMixin<DkWidget>; // speed up compilation/linking
 
-class DllCoreExport DkNamedWidget : public DkFadeWidget
+class DllCoreExport DkNamedWidget : public DkWidget
 {
     Q_OBJECT
 

--- a/ImageLounge/src/DkGui/DkBaseWidgets.h
+++ b/ImageLounge/src/DkGui/DkBaseWidgets.h
@@ -70,6 +70,17 @@ class DllCoreExport DkFadeHelper
     Q_DISABLE_COPY_MOVE(DkFadeHelper);
 
 public:
+    // globally disable animations, independent of user setting
+    static void enableAnimations(bool enable)
+    {
+        mGloballyEnabled = enable;
+    }
+
+    static bool animationsEnabled()
+    {
+        return mGloballyEnabled;
+    }
+
     DkFadeHelper() = delete;
     DkFadeHelper(QWidget *w);
 
@@ -127,6 +138,8 @@ private:
     {
         mTimerId = mWidget->startTimer(20);
     }
+
+    static bool mGloballyEnabled;
 
     QWidget *mWidget; // widget we are showing/hiding
     QGraphicsOpacityEffect *mOpacityEffect;

--- a/ImageLounge/src/DkGui/DkBatch.cpp
+++ b/ImageLounge/src/DkGui/DkBatch.cpp
@@ -352,7 +352,6 @@ void DkBatchInput::createLayout()
     mResultTextEdit->setVisible(false);
 
     mThumbScrollWidget = new DkThumbScrollWidget(this);
-    mThumbScrollWidget->setFadeEnabled(false);
     mThumbScrollWidget->getThumbWidget()->setImageLoader(mLoader);
 
     // add explorer
@@ -2424,7 +2423,7 @@ void DkBatchInfoWidget::setInfo(const QString &message, const InfoMode &mode)
 
 // Batch Widget --------------------------------------------------------------------
 DkBatchWidget::DkBatchWidget(const QString &currentDirectory, QWidget *parent /* = 0 */)
-    : DkFadeWidget(parent)
+    : DkWidget(parent)
 {
     mCurrentDirectory = currentDirectory;
     mBatchProcessing = new DkBatchProcessing(DkBatchConfig(), this);

--- a/ImageLounge/src/DkGui/DkBatch.cpp
+++ b/ImageLounge/src/DkGui/DkBatch.cpp
@@ -352,7 +352,7 @@ void DkBatchInput::createLayout()
     mResultTextEdit->setVisible(false);
 
     mThumbScrollWidget = new DkThumbScrollWidget(this);
-    mThumbScrollWidget->setVisible(true);
+    mThumbScrollWidget->setFadeEnabled(false);
     mThumbScrollWidget->getThumbWidget()->setImageLoader(mLoader);
 
     // add explorer

--- a/ImageLounge/src/DkGui/DkBatch.cpp
+++ b/ImageLounge/src/DkGui/DkBatch.cpp
@@ -3006,8 +3006,11 @@ void DkBatchWidget::loadProfile(const QString &profilePath)
 
 void DkBatchWidget::applyDefault()
 {
-    for (DkBatchContainer *bc : mWidgets)
-        bc->batchContent()->applyDefault();
+    for (DkBatchContainer *w : mWidgets) {
+        if (!w)
+            continue;
+        w->batchContent()->applyDefault();
+    }
 }
 
 void DkBatchWidget::widgetChanged()

--- a/ImageLounge/src/DkGui/DkBatch.cpp
+++ b/ImageLounge/src/DkGui/DkBatch.cpp
@@ -2325,7 +2325,7 @@ QRect DkBatchTransformWidget::cropRect() const
 
 // Batch Buttons --------------------------------------------------------------------
 DkBatchButtonsWidget::DkBatchButtonsWidget(QWidget *parent)
-    : DkFadeWidget(parent)
+    : DkWidget(parent)
 {
     createLayout();
     setPaused();

--- a/ImageLounge/src/DkGui/DkBatch.cpp
+++ b/ImageLounge/src/DkGui/DkBatch.cpp
@@ -410,12 +410,6 @@ void DkBatchInput::updateDir(QVector<QSharedPointer<DkImageContainerT>> thumbs)
     emit updateDirSignal(thumbs);
 }
 
-void DkBatchInput::setVisible(bool visible)
-{
-    QWidget::setVisible(visible);
-    mThumbScrollWidget->getThumbWidget()->updateLayout();
-}
-
 void DkBatchInput::browse()
 {
     // load system default open dialog

--- a/ImageLounge/src/DkGui/DkBatch.h
+++ b/ImageLounge/src/DkGui/DkBatch.h
@@ -561,7 +561,7 @@ protected:
     QDoubleSpinBox *mResizeSbPercent;
 };
 
-class DkBatchButtonsWidget : public DkFadeWidget
+class DkBatchButtonsWidget : public DkWidget
 {
     Q_OBJECT
 

--- a/ImageLounge/src/DkGui/DkBatch.h
+++ b/ImageLounge/src/DkGui/DkBatch.h
@@ -228,7 +228,6 @@ public slots:
     void setDir(const QString &dirPath);
     void browse();
     void updateDir(QVector<QSharedPointer<DkImageContainerT>>);
-    void setVisible(bool visible) override;
     void parameterChanged();
     void selectionChanged();
     void setFileInfo(QFileInfo file);

--- a/ImageLounge/src/DkGui/DkBatch.h
+++ b/ImageLounge/src/DkGui/DkBatch.h
@@ -607,7 +607,7 @@ protected:
     QLabel *mIcon = 0;
 };
 
-class DkBatchWidget : public DkFadeWidget
+class DkBatchWidget : public DkWidget
 {
     Q_OBJECT
 

--- a/ImageLounge/src/DkGui/DkControlWidget.cpp
+++ b/ImageLounge/src/DkGui/DkControlWidget.cpp
@@ -79,8 +79,8 @@ DkControlWidget::DkControlWidget(DkViewPort *parent, Qt::WindowFlags flags)
     mDelayedInfo = new DkDelayedMessage(this); // TODO: make a nice constructor
 
     // info labels
-    mBottomLabel = new DkLabelBg(this, "");
-    mBottomLeftLabel = new DkLabelBg(this, "");
+    mBottomLabel = new DkLabelBg("", this);
+    mBottomLeftLabel = new DkLabelBg("", this);
 
     // wheel label
     QPixmap wp = QPixmap(":/nomacs/img/thumbs-move.svg");

--- a/ImageLounge/src/DkGui/DkControlWidget.cpp
+++ b/ImageLounge/src/DkGui/DkControlWidget.cpp
@@ -756,7 +756,14 @@ void DkControlWidget::updateRating(int rating)
 
 void DkControlWidget::imagePresenceChanged(bool imagePresent)
 {
+    (void)imagePresent;
+
+    // disable animations while building initial view or image is lost
+    DkSettingsManager::param().display().suspendWidgetAnimation = true;
+
     showWidgetsSettings();
+
+    DkSettingsManager::param().display().suspendWidgetAnimation = false;
 }
 
 void DkControlWidget::setFullScreen(bool fullscreen)

--- a/ImageLounge/src/DkGui/DkControlWidget.cpp
+++ b/ImageLounge/src/DkGui/DkControlWidget.cpp
@@ -758,7 +758,7 @@ void DkControlWidget::updateRating(int rating)
     metaDataInfo->setRating(rating);
 }
 
-void DkControlWidget::imageLoaded(bool)
+void DkControlWidget::imagePresenceChanged(bool imagePresent)
 {
     showWidgetsSettings();
 }

--- a/ImageLounge/src/DkGui/DkControlWidget.cpp
+++ b/ImageLounge/src/DkGui/DkControlWidget.cpp
@@ -376,6 +376,10 @@ void DkControlWidget::showWidgetsSettings()
     showHistogram(mHistogram->getCurrentDisplaySetting());
     showCommentWidget(mCommentWidget->getCurrentDisplaySetting());
     showScroller(mFolderScroll->getCurrentDisplaySetting());
+
+    // don't show player while playing and switching modes
+    if (!mPlayer->isPlaying())
+        showPlayer(mPlayer->getCurrentDisplaySetting());
 }
 
 void DkControlWidget::toggleHUD(bool hide)
@@ -767,8 +771,8 @@ void DkControlWidget::setFullScreen(bool fullscreen)
 {
     showWidgetsSettings();
 
-    if (DkSettingsManager::param().slideShow().showPlayer && fullscreen && !mPlayer->isVisible())
-        mPlayer->show(3000);
+    if (DkSettingsManager::param().slideShow().showPlayer && fullscreen && !mPlayer->getCurrentDisplaySetting() && !mPlayer->isPlaying())
+        mPlayer->showTemporarily();
 }
 
 DkOverview *DkControlWidget::getOverview() const

--- a/ImageLounge/src/DkGui/DkControlWidget.cpp
+++ b/ImageLounge/src/DkGui/DkControlWidget.cpp
@@ -759,11 +759,11 @@ void DkControlWidget::imagePresenceChanged(bool imagePresent)
     (void)imagePresent;
 
     // disable animations while building initial view or image is lost
-    DkSettingsManager::param().display().suspendWidgetAnimation = true;
+    DkFadeHelper::enableAnimations(false);
 
     showWidgetsSettings();
 
-    DkSettingsManager::param().display().suspendWidgetAnimation = false;
+    DkFadeHelper::enableAnimations(true);
 }
 
 void DkControlWidget::setFullScreen(bool fullscreen)

--- a/ImageLounge/src/DkGui/DkControlWidget.cpp
+++ b/ImageLounge/src/DkGui/DkControlWidget.cpp
@@ -70,9 +70,10 @@ DkControlWidget::DkControlWidget(DkViewPort *parent, Qt::WindowFlags flags)
 
     mFolderScroll = new DkFolderScrollBar(this);
 
-    // file info - overview
+    // brief file info + ratingR
     mFileInfoLabel = new DkFileInfoLabel(this);
-    mRatingLabel = new DkRatingLabelBg(2, this, flags);
+
+    // notes
     mCommentWidget = new DkCommentWidget(this);
 
     // delayed info
@@ -124,7 +125,6 @@ void DkControlWidget::init()
     // some adjustments
     mBottomLabel->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
     mBottomLeftLabel->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
-    mRatingLabel->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
     mZoomWidget->setContentsMargins(10, 10, 0, 0);
     mCropWidget->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding);
     mCommentWidget->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding);
@@ -186,7 +186,6 @@ void DkControlWidget::init()
     rw->setMinimumSize(0, 0);
     QBoxLayout *rLayout = new QBoxLayout(QBoxLayout::RightToLeft, rw);
     rLayout->setContentsMargins(0, 0, 0, 17);
-    rLayout->addWidget(mRatingLabel);
     rLayout->addStretch();
 
     // file info
@@ -288,7 +287,6 @@ void DkControlWidget::connectWidgets()
 
     // rating
     connect(mFileInfoLabel->getRatingLabel(), &DkRatingLabel::newRatingSignal, this, &DkControlWidget::updateRating);
-    connect(mRatingLabel, &DkRatingLabelBg::newRatingSignal, this, &DkControlWidget::updateRating);
 
     // playing
     connect(mPlayer, &DkPlayer::previousSignal, mViewport, &DkViewPort::loadPrevFileFast);
@@ -372,7 +370,6 @@ void DkControlWidget::showWidgetsSettings()
     showPreview(mFilePreview->getCurrentDisplaySetting());
     showMetaData(mMetaDataInfo->getCurrentDisplaySetting());
     showFileInfo(mFileInfoLabel->getCurrentDisplaySetting());
-    showPlayer(mPlayer->getCurrentDisplaySetting());
     showHistogram(mHistogram->getCurrentDisplaySetting());
     showCommentWidget(mCommentWidget->getCurrentDisplaySetting());
     showScroller(mFolderScroll->getCurrentDisplaySetting());
@@ -441,13 +438,10 @@ void DkControlWidget::showFileInfo(bool visible)
     if (!mFileInfoLabel)
         return;
 
-    if (visible && !mFileInfoLabel->isVisible()) {
+    if (visible && !mFileInfoLabel->isVisible())
         mFileInfoLabel->show();
-        mRatingLabel->block(mFileInfoLabel->isVisible());
-    } else if (!visible && mFileInfoLabel->isVisible()) {
+    else if (!visible && mFileInfoLabel->isVisible())
         mFileInfoLabel->hide(!mViewport->getImage().isNull()); // do not save settings if we have no image in the viewport
-        mRatingLabel->block(false);
-    }
 }
 
 void DkControlWidget::showPlayer(bool visible)
@@ -752,8 +746,6 @@ void DkControlWidget::updateRating(int rating)
 {
     if (!mImgC)
         return;
-
-    mRatingLabel->setRating(rating);
 
     if (mFileInfoLabel)
         mFileInfoLabel->updateRating(rating);

--- a/ImageLounge/src/DkGui/DkControlWidget.h
+++ b/ImageLounge/src/DkGui/DkControlWidget.h
@@ -65,7 +65,6 @@ class DkCropWidget;
 class DkZoomWidget;
 class DkPlayer;
 class DkFolderScrollBar;
-class DkRatingLabelBg;
 class DkDelayedMessage;
 class DkFileInfoLabel;
 class DkHistogram;

--- a/ImageLounge/src/DkGui/DkControlWidget.h
+++ b/ImageLounge/src/DkGui/DkControlWidget.h
@@ -139,7 +139,7 @@ public slots:
     void setInfo(const QString &msg, int time = 3000, int location = bottom_left_label);
     void updateRating(int rating);
 
-    void imageLoaded(bool loaded);
+    void imagePresenceChanged(bool imagePresent);
 
     void update();
 

--- a/ImageLounge/src/DkGui/DkControlWidget.h
+++ b/ImageLounge/src/DkGui/DkControlWidget.h
@@ -185,7 +185,6 @@ protected:
 
     DkFolderScrollBar *mFolderScroll;
     DkFileInfoLabel *mFileInfoLabel;
-    DkRatingLabelBg *mRatingLabel;
 
     DkDelayedMessage *mDelayedInfo;
 

--- a/ImageLounge/src/DkGui/DkManipulatorWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkManipulatorWidgets.cpp
@@ -49,7 +49,7 @@ namespace nmc
 {
 // DkManipulatorWidget --------------------------------------------------------------------
 DkManipulatorWidget::DkManipulatorWidget(QWidget *parent)
-    : DkFadeWidget(parent)
+    : DkWidget(parent)
 {
     // create widgets
     DkActionManager &am = DkActionManager::instance();

--- a/ImageLounge/src/DkGui/DkManipulatorWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkManipulatorWidgets.cpp
@@ -214,9 +214,10 @@ void DkEditDock::setImage(QSharedPointer<DkImageContainerT> imgC)
 
 // DkManipulatorWidget --------------------------------------------------------------------
 DkBaseManipulatorWidget::DkBaseManipulatorWidget(QSharedPointer<DkBaseManipulatorExt> manipulator, QWidget *parent)
-    : DkFadeWidget(parent)
+    : DkWidget(parent)
 {
     mBaseManipulator = manipulator;
+    setVisible(false);
 }
 
 QSharedPointer<DkBaseManipulatorExt> DkBaseManipulatorWidget::baseManipulator() const

--- a/ImageLounge/src/DkGui/DkManipulatorWidgets.h
+++ b/ImageLounge/src/DkGui/DkManipulatorWidgets.h
@@ -53,7 +53,7 @@ namespace nmc
 
 // nomacs defines
 
-class DkBaseManipulatorWidget : public DkFadeWidget
+class DkBaseManipulatorWidget : public DkWidget
 {
     Q_OBJECT
 

--- a/ImageLounge/src/DkGui/DkManipulatorWidgets.h
+++ b/ImageLounge/src/DkGui/DkManipulatorWidgets.h
@@ -224,7 +224,7 @@ private:
 };
 
 // dock --------------------------------------------------------------------
-class DkManipulatorWidget : public DkFadeWidget
+class DkManipulatorWidget : public DkWidget
 {
     Q_OBJECT
 

--- a/ImageLounge/src/DkGui/DkMetaDataWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkMetaDataWidgets.cpp
@@ -1054,6 +1054,8 @@ void DkMetaDataHUD::contextMenuEvent(QContextMenuEvent *event)
 void DkMetaDataHUD::setVisible(bool visible, bool saveSetting /* = true */)
 {
     DkFadeWidget::setVisible(visible, saveSetting);
+    if (mSetWidgetVisible)
+        return; // prevent recursion via fade()
 
     updateMetaData(mMetaData);
 }

--- a/ImageLounge/src/DkGui/DkMetaDataWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkMetaDataWidgets.cpp
@@ -1161,7 +1161,7 @@ void DkCommentTextEdit::paintEvent(QPaintEvent *e)
 
 // DkCommentWidget --------------------------------------------------------------------
 DkCommentWidget::DkCommentWidget(QWidget *parent /* = 0 */, Qt::WindowFlags /* = 0 */)
-    : DkFadeLabel(parent)
+    : DkFadeLabel("", parent)
 {
     createLayout();
 }

--- a/ImageLounge/src/DkGui/DkNoMacs.cpp
+++ b/ImageLounge/src/DkGui/DkNoMacs.cpp
@@ -620,7 +620,7 @@ void DkNoMacs::enterFullScreen()
     setUpdatesEnabled(false);
 
     // disable animations for panels to stop layout change immediately after switch
-    DkSettingsManager::param().display().suspendWidgetAnimation = true;
+    DkFadeHelper::enableAnimations(false);
 
     int appMode = DkSettingsManager::param().app().currentAppMode;
     appMode = DkSettings::fullscreenMode(appMode);
@@ -640,7 +640,7 @@ void DkNoMacs::enterFullScreen()
     if (getTabWidget()->getViewPort())
         getTabWidget()->getViewPort()->setFullScreen(true);
 
-    DkSettingsManager::param().display().suspendWidgetAnimation = false;
+    DkFadeHelper::enableAnimations(true);
     setUpdatesEnabled(true);
 
     showFullScreen();
@@ -655,8 +655,7 @@ void DkNoMacs::exitFullScreen()
 {
     if (isFullScreen()) {
         setUpdatesEnabled(false);
-
-        DkSettingsManager::param().display().suspendWidgetAnimation = true;
+        DkFadeHelper::enableAnimations(false);
 
         int appMode = DkSettingsManager::param().app().currentAppMode;
         if (!DkSettings::modeIsFullscreen(appMode))
@@ -681,7 +680,7 @@ void DkNoMacs::exitFullScreen()
         if (getTabWidget()->getViewPort())
             getTabWidget()->getViewPort()->setFullScreen(false);
 
-        DkSettingsManager::param().display().suspendWidgetAnimation = false;
+        DkFadeHelper::enableAnimations(true);
         setUpdatesEnabled(true);
 
         qInfo() << "before exit fullscreen appMode:" << appMode << "geometry:" << geometry() << "normalGeometry:" << normalGeometry()

--- a/ImageLounge/src/DkGui/DkNoMacs.cpp
+++ b/ImageLounge/src/DkGui/DkNoMacs.cpp
@@ -619,6 +619,9 @@ void DkNoMacs::enterFullScreen()
 {
     setUpdatesEnabled(false);
 
+    // disable animations for panels to stop layout change immediately after switch
+    DkSettingsManager::param().display().suspendWidgetAnimation = true;
+
     int appMode = DkSettingsManager::param().app().currentAppMode;
     appMode = DkSettings::fullscreenMode(appMode);
     DkSettingsManager::param().app().currentAppMode = appMode;
@@ -637,6 +640,7 @@ void DkNoMacs::enterFullScreen()
     if (getTabWidget()->getViewPort())
         getTabWidget()->getViewPort()->setFullScreen(true);
 
+    DkSettingsManager::param().display().suspendWidgetAnimation = false;
     setUpdatesEnabled(true);
 
     showFullScreen();
@@ -651,6 +655,8 @@ void DkNoMacs::exitFullScreen()
 {
     if (isFullScreen()) {
         setUpdatesEnabled(false);
+
+        DkSettingsManager::param().display().suspendWidgetAnimation = true;
 
         int appMode = DkSettingsManager::param().app().currentAppMode;
         if (!DkSettings::modeIsFullscreen(appMode))
@@ -675,6 +681,7 @@ void DkNoMacs::exitFullScreen()
         if (getTabWidget()->getViewPort())
             getTabWidget()->getViewPort()->setFullScreen(false);
 
+        DkSettingsManager::param().display().suspendWidgetAnimation = false;
         setUpdatesEnabled(true);
 
         qInfo() << "before exit fullscreen appMode:" << appMode << "geometry:" << geometry() << "normalGeometry:" << normalGeometry()

--- a/ImageLounge/src/DkGui/DkPreferenceWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkPreferenceWidgets.cpp
@@ -67,7 +67,7 @@ namespace nmc
 {
 
 DkPreferenceWidget::DkPreferenceWidget(QWidget *parent)
-    : DkFadeWidget(parent)
+    : DkWidget(parent)
 {
     createLayout();
 

--- a/ImageLounge/src/DkGui/DkPreferenceWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkPreferenceWidgets.cpp
@@ -448,6 +448,13 @@ void DkGeneralPreference::createLayout()
     cbShowBgImage->setChecked(DkSettingsManager::param().global().showBgImage);
     connect(cbShowBgImage, &QCheckBox::toggled, this, &DkGeneralPreference::onShowBgImageToggled);
 
+    QCheckBox *cbEnableAnimation = new QCheckBox(tr("Enable Animations"), this);
+    cbEnableAnimation->setToolTip(tr("If checked, enable animations on user interface components."));
+    cbEnableAnimation->setChecked(DkSettingsManager::param().display().animateWidgets);
+    connect(cbEnableAnimation, &QCheckBox::toggled, [](bool enabled) {
+        DkSettingsManager::param().display().animateWidgets = enabled;
+    });
+
     QCheckBox *cbSwitchModifier = new QCheckBox(tr("Switch CTRL with ALT"), this);
     cbSwitchModifier->setToolTip(tr("If checked, CTRL + Mouse is switched with ALT + Mouse."));
     cbSwitchModifier->setChecked(DkSettingsManager::param().sync().switchModifier);
@@ -483,6 +490,7 @@ void DkGeneralPreference::createLayout()
     generalGroup->addWidget(cbCloseOnMiddleMouse);
     generalGroup->addWidget(cbCheckForUpdates);
     generalGroup->addWidget(cbShowBgImage);
+    generalGroup->addWidget(cbEnableAnimation);
 
     // language
     QComboBox *languageCombo = new QComboBox(this);

--- a/ImageLounge/src/DkGui/DkPreferenceWidgets.h
+++ b/ImageLounge/src/DkGui/DkPreferenceWidgets.h
@@ -90,7 +90,7 @@ protected:
     QIcon mIcon;
 };
 
-class DllCoreExport DkPreferenceWidget : public DkFadeWidget
+class DllCoreExport DkPreferenceWidget : public DkWidget
 {
     Q_OBJECT
 

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -2241,7 +2241,7 @@ void DkRecentDirWidget::leaveEvent(QEvent *event)
 
 // -------------------------------------------------------------------- DkRecentFilesEntry
 DkRecentFilesWidget::DkRecentFilesWidget(QWidget *parent)
-    : DkFadeWidget(parent)
+    : DkWidget(parent)
 {
     createLayout();
     setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding);
@@ -2251,8 +2251,13 @@ void DkRecentFilesWidget::setVisible(bool visible)
 {
     if (visible)
         updateList();
+    if (mAction) {
+        mAction->blockSignals(true);
+        mAction->setChecked(visible);
+        mAction->blockSignals(false);
+    }
 
-    DkFadeWidget::setVisible(visible);
+    DkWidget::setVisible(visible);
 }
 
 void DkRecentFilesWidget::createLayout()

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -826,9 +826,11 @@ void DkFilePreview::updateThumbs(QVector<QSharedPointer<DkImageContainerT>> thum
 
 void DkFilePreview::setVisible(bool visible, bool saveSettings)
 {
-    emit showThumbsDockSignal(visible);
-
     DkFadeWidget::setVisible(visible, saveSettings);
+    if (mSetWidgetVisible)
+        return; // prevent recursion via fade()
+
+    emit showThumbsDockSignal(visible);
 }
 
 // DkThumbLabel --------------------------------------------------------------------
@@ -1976,9 +1978,11 @@ void DkThumbScrollWidget::setDir(const QString &dirPath)
 
 void DkThumbScrollWidget::setVisible(bool visible)
 {
-    connectToActions(visible);
-
     DkFadeWidget::setVisible(visible);
+    if (mSetWidgetVisible)
+        return; // prevent recursion via fade()
+
+    connectToActions(visible);
 
     if (visible) {
         mThumbsScene->updateThumbLabels();

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -1816,7 +1816,7 @@ void DkThumbsView::fetchThumbs()
 
 // DkThumbScrollWidget --------------------------------------------------------------------
 DkThumbScrollWidget::DkThumbScrollWidget(QWidget *parent /* = 0 */, Qt::WindowFlags flags /* = 0 */)
-    : DkFadeWidget(parent, flags)
+    : DkWidget(parent, flags)
 {
     // TODO: is this name required elsewhere?
     setObjectName("DkThumbScrollWidget");
@@ -1978,10 +1978,6 @@ void DkThumbScrollWidget::setDir(const QString &dirPath)
 
 void DkThumbScrollWidget::setVisible(bool visible)
 {
-    DkFadeWidget::setVisible(visible);
-    if (mSetWidgetVisible)
-        return; // prevent recursion via fade()
-
     connectToActions(visible);
 
     if (visible) {
@@ -1989,6 +1985,14 @@ void DkThumbScrollWidget::setVisible(bool visible)
         mFilterEdit->setText("");
     } else
         mThumbsScene->cancelLoading();
+
+    if (mAction) {
+        mAction->blockSignals(true);
+        mAction->setChecked(visible);
+        mAction->blockSignals(false);
+    }
+
+    DkWidget::setVisible(visible);
 }
 
 void DkThumbScrollWidget::connectToActions(bool activate)
@@ -2044,7 +2048,7 @@ void DkThumbScrollWidget::resizeEvent(QResizeEvent *event)
     if (event->oldSize().width() != event->size().width() && isVisible())
         mThumbsScene->updateLayout();
 
-    DkFadeWidget::resizeEvent(event);
+    DkWidget::resizeEvent(event);
 }
 
 void DkThumbScrollWidget::contextMenuEvent(QContextMenuEvent *event)
@@ -2117,7 +2121,7 @@ void DkThumbPreviewLabel::mousePressEvent(QMouseEvent *ev)
 
 // -------------------------------------------------------------------- DkRecentFilesEntry
 DkRecentDirWidget::DkRecentDirWidget(const DkRecentDir &rde, QWidget *parent)
-    : DkFadeWidget(parent)
+    : DkWidget(parent)
 {
     mRecentDir = rde;
 
@@ -2224,7 +2228,7 @@ void DkRecentDirWidget::mousePressEvent(QMouseEvent *event)
         emit loadFileSignal(mRecentDir.firstFilePath(), event->modifiers() == Qt::ControlModifier);
     }
 
-    DkFadeWidget::mousePressEvent(event);
+    DkWidget::mousePressEvent(event);
 }
 
 void DkRecentDirWidget::enterEvent(DkEnterEvent *event)
@@ -2232,7 +2236,7 @@ void DkRecentDirWidget::enterEvent(DkEnterEvent *event)
     for (auto b : mButtons)
         b->show();
 
-    DkFadeWidget::enterEvent(event);
+    DkWidget::enterEvent(event);
 }
 
 void DkRecentDirWidget::leaveEvent(QEvent *event)
@@ -2240,7 +2244,7 @@ void DkRecentDirWidget::leaveEvent(QEvent *event)
     for (auto b : mButtons)
         b->hide();
 
-    DkFadeWidget::leaveEvent(event);
+    DkWidget::leaveEvent(event);
 }
 
 // -------------------------------------------------------------------- DkRecentFilesEntry

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.h
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.h
@@ -317,7 +317,7 @@ protected:
     int lastShiftIdx;
 };
 
-class DllCoreExport DkThumbScrollWidget : public DkFadeWidget
+class DllCoreExport DkThumbScrollWidget : public DkWidget
 {
     Q_OBJECT
 
@@ -331,6 +331,10 @@ public:
     };
 
     void clear();
+    void registerAction(QAction *action)
+    {
+        mAction = action;
+    }
 
 public slots:
     virtual void setVisible(bool visible) override;
@@ -360,6 +364,7 @@ protected:
     QMenu *mContextMenu = 0;
     QToolBar *mToolbar = 0;
     QLineEdit *mFilterEdit = 0;
+    QAction *mAction = 0;
 };
 
 class DkRecentDir
@@ -418,7 +423,7 @@ protected:
     int mThumbSize = 100;
 };
 
-class DllCoreExport DkRecentDirWidget : public DkFadeWidget
+class DllCoreExport DkRecentDirWidget : public DkWidget
 {
     Q_OBJECT
 

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.h
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.h
@@ -455,12 +455,17 @@ protected:
     void leaveEvent(QEvent *event) override;
 };
 
-class DllCoreExport DkRecentFilesWidget : public DkFadeWidget
+class DllCoreExport DkRecentFilesWidget : public DkWidget
 {
     Q_OBJECT
 
 public:
     DkRecentFilesWidget(QWidget *parent = 0);
+
+    void registerAction(QAction *action)
+    {
+        mAction = action;
+    }
 
 signals:
     void loadFileSignal(const QString &filePath, bool newTab);
@@ -474,7 +479,10 @@ protected:
     void createLayout();
     void updateList();
 
-    QScrollArea *mScrollArea;
+    QScrollArea *mScrollArea = nullptr;
+
+private:
+    QAction *mAction = nullptr;
 };
 
 }

--- a/ImageLounge/src/DkGui/DkViewPort.cpp
+++ b/ImageLounge/src/DkGui/DkViewPort.cpp
@@ -318,6 +318,8 @@ void DkViewPort::setImage(QImage newImg)
 
     mController->getOverview()->setImage(QImage()); // clear overview
 
+    bool wasImageLoaded = !mImgStorage.isEmpty();
+    bool isImageLoaded = !newImg.isNull();
     mImgStorage.setImage(newImg);
 
     if (mLoader->hasMovie() && !mLoader->isEdited())
@@ -328,7 +330,9 @@ void DkViewPort::setImage(QImage newImg)
     mImgRect = QRectF(QPoint(), getImageSize());
 
     DkActionManager::instance().enableImageActions(!newImg.isNull());
-    mController->imageLoaded(!newImg.isNull());
+
+    if (wasImageLoaded ^ isImageLoaded)
+        mController->imagePresenceChanged(isImageLoaded);
 
     double oldZoom = mWorldMatrix.m11(); // *mImgMatrix.m11();
 

--- a/ImageLounge/src/DkGui/DkWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkWidgets.cpp
@@ -1012,61 +1012,7 @@ void DkRatingLabel::init()
     connect(mStars[rating_5], &DkButton::released, this, &DkRatingLabel::rating5);
 }
 
-// DkRatingLabelBg --------------------------------------------------------------------
-DkRatingLabelBg::DkRatingLabelBg(int rating, QWidget *parent, Qt::WindowFlags flags)
-    : DkRatingLabel(rating, parent, flags)
-{
-    setCursor(Qt::ArrowCursor);
-
-    mHideTimer = new QTimer(this);
-    mHideTimer->setInterval(mTimeToDisplay);
-    mHideTimer->setSingleShot(true);
-
-    // we want a margin
-    mLayout->setContentsMargins(10, 4, 10, 4);
-    mLayout->setSpacing(4);
-
-    DkActionManager &am = DkActionManager::instance();
-
-    // TODO: replace this with a for loop?
-    connect(am.action(DkActionManager::sc_star_rating_0), &QAction::triggered, this, &DkRatingLabel::rating0);
-    mStars[rating_1]->addAction(am.action(DkActionManager::sc_star_rating_1));
-    connect(am.action(DkActionManager::sc_star_rating_1), &QAction::triggered, this, &DkRatingLabel::rating1);
-    mStars[rating_2]->addAction(am.action(DkActionManager::sc_star_rating_2));
-    connect(am.action(DkActionManager::sc_star_rating_2), &QAction::triggered, this, &DkRatingLabel::rating2);
-    mStars[rating_3]->addAction(am.action(DkActionManager::sc_star_rating_3));
-    connect(am.action(DkActionManager::sc_star_rating_3), &QAction::triggered, this, &DkRatingLabel::rating3);
-    mStars[rating_4]->addAction(am.action(DkActionManager::sc_star_rating_4));
-    connect(am.action(DkActionManager::sc_star_rating_4), &QAction::triggered, this, &DkRatingLabel::rating4);
-    mStars[rating_5]->addAction(am.action(DkActionManager::sc_star_rating_5));
-    connect(am.action(DkActionManager::sc_star_rating_5), &QAction::triggered, this, &DkRatingLabel::rating5);
-
-    connect(mHideTimer, &QTimer::timeout, this, [this]() {
-        this->hide();
-    });
-}
-
-DkRatingLabelBg::~DkRatingLabelBg()
-{
-}
-
-void DkRatingLabelBg::changeRating(int newRating)
-{
-    DkRatingLabel::changeRating(newRating);
-    show();
-    mHideTimer->start();
-}
-
-void DkRatingLabelBg::paintEvent(QPaintEvent *event)
-{
-    QPainter painter(this);
-    painter.fillRect(QRect(QPoint(), this->size()), DkSettingsManager::param().display().hudBgColor);
-    painter.end();
-
-    DkRatingLabel::paintEvent(event);
-}
-
-// title info --------------------------------------------------------------------
+// title info + star label -------------------------------------------------------
 DkFileInfoLabel::DkFileInfoLabel(QWidget *parent)
     : DkFadeLabel("", parent)
 {

--- a/ImageLounge/src/DkGui/DkWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkWidgets.cpp
@@ -767,7 +767,7 @@ QTransform DkOverview::getScaledImageMatrix()
 
 // DkZoomWidget --------------------------------------------------------------------
 DkZoomWidget::DkZoomWidget(QWidget *parent)
-    : DkFadeLabel(parent)
+    : DkFadeLabel("", parent)
 {
     mAutoHide = false;
     setObjectName("DkZoomWidget");
@@ -1087,7 +1087,7 @@ void DkRatingLabelBg::paintEvent(QPaintEvent *event)
 
 // title info --------------------------------------------------------------------
 DkFileInfoLabel::DkFileInfoLabel(QWidget *parent)
-    : DkFadeLabel(parent)
+    : DkFadeLabel("", parent)
 {
     setObjectName("DkFileInfoLabel");
     setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Minimum);

--- a/ImageLounge/src/DkGui/DkWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkWidgets.cpp
@@ -769,7 +769,6 @@ QTransform DkOverview::getScaledImageMatrix()
 DkZoomWidget::DkZoomWidget(QWidget *parent)
     : DkFadeLabel("", parent)
 {
-    mAutoHide = false;
     setObjectName("DkZoomWidget");
     createLayout();
 
@@ -817,7 +816,6 @@ void DkZoomWidget::createLayout()
 void DkZoomWidget::onSbZoomValueChanged(double zoomLevel)
 {
     updateZoom((float)zoomLevel);
-    mAutoHide = false;
     emit zoomSignal(zoomLevel / 100.0);
 }
 
@@ -826,7 +824,6 @@ void DkZoomWidget::onSlZoomValueChanged(int zoomLevel)
     double level = (zoomLevel > 50) ? (zoomLevel - 50.0) / 50.0 * mSbZoom->maximum() + 200.0 : zoomLevel * 4.0;
     if (level < 0.2)
         level = 0.2;
-    mAutoHide = false;
     updateZoom(level);
     emit zoomSignal(level / 100.0);
 }
@@ -846,22 +843,6 @@ void DkZoomWidget::updateZoom(double zoomLevel)
 DkOverview *DkZoomWidget::getOverview() const
 {
     return mOverview;
-}
-
-void DkZoomWidget::setVisible(bool visible, bool autoHide /* = false */)
-{
-    if (!isVisible() && visible)
-        this->mAutoHide = autoHide;
-
-    if (!visible)
-        autoHide = false;
-
-    DkFadeLabel::setVisible(visible, true);
-}
-
-bool DkZoomWidget::isAutoHide() const
-{
-    return mAutoHide;
 }
 
 // DkButton --------------------------------------------------------------------

--- a/ImageLounge/src/DkGui/DkWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkWidgets.cpp
@@ -161,7 +161,7 @@ void DkFolderScrollBar::init()
 
 // DkThumbsSaver --------------------------------------------------------------------
 DkThumbsSaver::DkThumbsSaver(QWidget *parent)
-    : DkFadeWidget(parent)
+    : DkWidget(parent)
 {
     mStop = false;
     mNumSaved = 0;

--- a/ImageLounge/src/DkGui/DkWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkWidgets.cpp
@@ -100,6 +100,7 @@
 
 namespace nmc
 {
+template class DkFadeMixin<QSlider>;
 
 // DkFolderScrollBar --------------------------------------------------------------------
 DkFolderScrollBar::DkFolderScrollBar(QWidget *parent)

--- a/ImageLounge/src/DkGui/DkWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkWidgets.cpp
@@ -2885,7 +2885,7 @@ void DkTabEntryWidget::paintEvent(QPaintEvent *event)
 
 // -------------------------------------------------------------------- DkDisplayWidget
 DkDisplayWidget::DkDisplayWidget(QWidget *parent)
-    : DkFadeWidget(parent)
+    : DkWidget(parent)
 {
     createLayout();
     updateLayout();
@@ -2926,7 +2926,7 @@ void DkDisplayWidget::setCurrentIndex(int index)
 
 void DkDisplayWidget::resizeEvent(QResizeEvent *event)
 {
-    DkFadeWidget::resizeEvent(event);
+    DkWidget::resizeEvent(event);
     updateLayout();
 }
 

--- a/ImageLounge/src/DkGui/DkWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkWidgets.cpp
@@ -1279,7 +1279,7 @@ void DkPlayer::init()
     hideTimer->setInterval(timeToDisplayPlayer);
     hideTimer->setSingleShot(true);
     connect(hideTimer, &QTimer::timeout, this, [this]() {
-        this->hide();
+        this->hide(false); // do not save setting when showing/hiding temporarily
     });
 
     connect(DkActionManager::instance().action(DkActionManager::menu_view_slideshow), &QAction::triggered, this, &DkPlayer::togglePlay);
@@ -1294,14 +1294,15 @@ void DkPlayer::play(bool play)
 
     if (play) {
         displayTimer->start();
-        hideTimer->start();
+        showTemporarily();
     } else
         displayTimer->stop();
 }
 
 void DkPlayer::togglePlay()
 {
-    show();
+    hideTimer->stop();
+    showTemporarily(!playing);
     playing = !playing;
     playButton->click();
 }
@@ -1342,21 +1343,13 @@ void DkPlayer::setTimeToDisplay(int ms)
     displayTimer->setInterval(ms);
 }
 
-void DkPlayer::show(int ms)
+void DkPlayer::showTemporarily(bool autoHide)
 {
-    if (ms > 0 && !hideTimer->isActive()) {
-        hideTimer->setInterval(ms);
+    if (autoHide)
         hideTimer->start();
-    }
 
-    // bool showPlayer = getCurrentDisplaySetting();
-
-    // automatic showing, don't store it in the display bits
+    // automatic showing, don't save visibility setting
     DkFadeWidget::show(false);
-
-    // if (ms > 0 && mDisplaySettingsBits && mDisplaySettingsBits->size() > DkSettingsManager::param().app().currentAppMode) {
-    // mDisplaySettingsBits->setBit(DkSettingsManager::param().app().currentAppMode, showPlayer);
-    // }
 }
 
 // -------------------------------------------------------------------- DkHudNavigation

--- a/ImageLounge/src/DkGui/DkWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkWidgets.cpp
@@ -962,7 +962,7 @@ void DkButton::leaveEvent(QEvent *)
 
 // star label --------------------------------------------------------------------
 DkRatingLabel::DkRatingLabel(int rating, QWidget *parent, Qt::WindowFlags flags)
-    : DkFadeWidget(parent, flags)
+    : DkWidget(parent, flags)
 {
     setObjectName("DkRatingLabel");
     mRating = rating;

--- a/ImageLounge/src/DkGui/DkWidgets.h
+++ b/ImageLounge/src/DkGui/DkWidgets.h
@@ -259,7 +259,7 @@ public slots:
     void autoNext();
     void next();
     void previous();
-    virtual void show(int ms = 0);
+    void showTemporarily(bool autoHide = true);
     bool isPlaying() const;
 
 protected:

--- a/ImageLounge/src/DkGui/DkWidgets.h
+++ b/ImageLounge/src/DkGui/DkWidgets.h
@@ -103,7 +103,7 @@ protected:
     QPixmap createSelectedEffect(QPixmap *pm);
 };
 
-class DkRatingLabel : public DkFadeWidget
+class DkRatingLabel : public DkWidget
 {
     Q_OBJECT
 

--- a/ImageLounge/src/DkGui/DkWidgets.h
+++ b/ImageLounge/src/DkGui/DkWidgets.h
@@ -301,7 +301,7 @@ protected:
     QPushButton *mNextButton;
 };
 
-class DkFolderScrollBar : public QSlider
+class DkFolderScrollBar : public DkFadeMixin<QSlider>
 {
     Q_OBJECT
 
@@ -311,20 +311,8 @@ public:
 
     virtual void setValue(int i);
 
-    void registerAction(QAction *action);
-    void block(bool blocked);
-    void setDisplaySettings(QBitArray *displayBits);
-    bool getCurrentDisplaySetting();
-
 public slots:
     void updateDir(QVector<QSharedPointer<DkImageContainerT>> images);
-
-    virtual void show(bool saveSettings = true);
-    virtual void hide(bool saveSettings = true);
-    virtual void setVisible(bool visible, bool saveSettings = true);
-
-    void animateOpacityUp();
-    void animateOpacityDown();
 
     void updateFile(int idx);
 
@@ -337,13 +325,7 @@ protected:
     void mouseReleaseEvent(QMouseEvent *event) override;
 
     QColor mBgCol;
-    bool mBlocked = false;
-    bool mHiding = false;
-    bool mShowing = false;
     bool mMouseDown = false;
-
-    QGraphicsOpacityEffect *mOpacityEffect = 0;
-    QBitArray *mDisplaySettingsBits = 0;
 
     void init();
 };

--- a/ImageLounge/src/DkGui/DkWidgets.h
+++ b/ImageLounge/src/DkGui/DkWidgets.h
@@ -981,7 +981,7 @@ protected:
     void paintEvent(QPaintEvent *event) override;
 };
 
-class DllCoreExport DkDisplayWidget : public DkFadeWidget
+class DllCoreExport DkDisplayWidget : public DkWidget
 {
     Q_OBJECT
 

--- a/ImageLounge/src/DkGui/DkWidgets.h
+++ b/ImageLounge/src/DkGui/DkWidgets.h
@@ -313,6 +313,8 @@ protected:
     void init();
 };
 
+extern template class DkFadeMixin<QSlider>;
+
 // this class is one of the first batch processing classes -> move them to a new file in the (near) future
 class DkThumbsSaver : public DkWidget
 {

--- a/ImageLounge/src/DkGui/DkWidgets.h
+++ b/ImageLounge/src/DkGui/DkWidgets.h
@@ -187,23 +187,6 @@ protected:
     virtual void init();
 };
 
-class DkRatingLabelBg : public DkRatingLabel
-{
-    Q_OBJECT
-
-public:
-    DkRatingLabelBg(int rating = 0, QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags());
-    ~DkRatingLabelBg();
-
-    void changeRating(int newRating) override;
-
-protected:
-    QTimer *mHideTimer;
-    int mTimeToDisplay = 4000;
-
-    virtual void paintEvent(QPaintEvent *event) override;
-};
-
 class DkFileInfoLabel : public DkFadeLabel
 {
     Q_OBJECT

--- a/ImageLounge/src/DkGui/DkWidgets.h
+++ b/ImageLounge/src/DkGui/DkWidgets.h
@@ -108,17 +108,7 @@ class DkRatingLabel : public DkWidget
     Q_OBJECT
 
 public:
-    enum {
-        rating_1,
-        rating_2,
-        rating_3,
-        rating_4,
-        rating_5,
-        rating_0, // no image for that one
-    };
-
     DkRatingLabel(int rating = 0, QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags());
-    ~DkRatingLabel(){};
 
     void setRating(int rating)
     {
@@ -126,7 +116,7 @@ public:
         updateRating();
     };
 
-    virtual void changeRating(int newRating)
+    void changeRating(int newRating)
     {
         mRating = newRating;
         updateRating();
@@ -139,52 +129,14 @@ public:
     };
 
 signals:
-    void newRatingSignal(int rating = 0);
-
-public slots:
-    void rating0()
-    {
-        changeRating(0);
-    };
-
-    void rating1()
-    {
-        changeRating(1);
-    };
-
-    void rating2()
-    {
-        changeRating(2);
-    };
-
-    void rating3()
-    {
-        changeRating(3);
-    };
-
-    void rating4()
-    {
-        changeRating(4);
-    };
-
-    void rating5()
-    {
-        changeRating(5);
-    };
+    void newRatingSignal(int rating);
 
 protected:
     QVector<DkButton *> mStars;
-    QBoxLayout *mLayout = 0;
     int mRating = 0;
 
-    void updateRating()
-    {
-        for (int idx = 0; idx < mStars.size(); idx++) {
-            mStars[idx]->setChecked(idx < mRating);
-        }
-    };
-
-    virtual void init();
+    void updateRating();
+    void init();
 };
 
 class DkFileInfoLabel : public DkFadeLabel

--- a/ImageLounge/src/DkGui/DkWidgets.h
+++ b/ImageLounge/src/DkGui/DkWidgets.h
@@ -331,7 +331,7 @@ protected:
 };
 
 // this class is one of the first batch processing classes -> move them to a new file in the (near) future
-class DkThumbsSaver : public DkFadeWidget
+class DkThumbsSaver : public DkWidget
 {
     Q_OBJECT
 

--- a/ImageLounge/src/DkGui/DkWidgets.h
+++ b/ImageLounge/src/DkGui/DkWidgets.h
@@ -505,14 +505,10 @@ public:
 
     DkOverview *getOverview() const;
 
-    bool isAutoHide() const;
-
 signals:
     void zoomSignal(double zoomLevel);
 
 public slots:
-    virtual void setVisible(bool visible, bool autoHide = false);
-
     void updateZoom(double zoomLevel);
     void onSbZoomValueChanged(double zoomLevel);
     void onSlZoomValueChanged(int zoomLevel);
@@ -523,7 +519,6 @@ protected:
     DkOverview *mOverview = 0;
     QSlider *mSlZoom = 0;
     QDoubleSpinBox *mSbZoom = 0;
-    bool mAutoHide = false;
 };
 
 class DkTransformRect : public DkWidget

--- a/ImageLounge/src/stylesheet.css
+++ b/ImageLounge/src/stylesheet.css
@@ -745,8 +745,10 @@ QPushButton#displayButton:checked {
 	border: 1px solid HIGHLIGHT_COLOR;
 }
 
-/* picks the wrong color on system theme; doesn't seem to be needed anymore
+/* fix background showing through if thumbs ribbon pinned to top and
+   activating one of these widgets whilst thumbs grid is visible */
+nmc--DkPreferenceWidget,
+nmc--DkBatchWidget,
 QToolBar {
-    background-color: BACKGROUND_COLOR;
+    background-color: palette(window);
 }
-*/


### PR DESCRIPTION
In this PR I am aiming to improve the fade/animation part of nomacs UI with a couple of objectives.
- [x] refactor DkFadeWidget and friends which share a lot of common code
- [x] #922 
- [x] be able to disable animations in some situations like when when switching modes or window is first created.

TODO: Decide if we should be fading things we did not before. The following are now fading because behavior was masked before. I think I am ok with all of this but the animation could be a bit quicker
- [x] settings/batch pages on show/hide (removed fade)
- [x] settings/batch tabs on show/hide (removed fade)
- [x] thumbs panel (Shift+T) (removed fade)
- [x] recent files (removed fade)
- [x] crop widget (C) (RETAINED)

Full list of widgets now fading:
![image](https://github.com/user-attachments/assets/f79603d6-cdd3-48c9-9706-b4004239ad5c)
