### PR TITLE
fix(batch): segfault on close with thumbs selection

### DIFF
--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -1826,6 +1826,14 @@ DkThumbScrollWidget::DkThumbScrollWidget(QWidget *parent /* = 0 */, Qt::WindowFl
     enableSelectionActions();
 }
 
+DkThumbScrollWidget::~DkThumbScrollWidget()
+{
+    // ~QGraphicsScene will emit selectionChanged() while being destructed.
+    // this gives a segfault or assertion failure (debug builds) and seems
+    // to be a Qt bug IMO.
+    mThumbsScene->disconnect();
+}
+
 void DkThumbScrollWidget::createToolbar()
 {
     mToolbar = new QToolBar(tr("Thumb Preview Toolbar"), this);

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.h
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.h
@@ -323,6 +323,7 @@ class DllCoreExport DkThumbScrollWidget : public DkFadeWidget
 
 public:
     DkThumbScrollWidget(QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags());
+    ~DkThumbScrollWidget();
 
     DkThumbScene *getThumbWidget()
     {


### PR DESCRIPTION
Prevent selectionChanged() signal from firing in the destruct chain of ~DkThumbsScene->QGraphicsScene->QGraphicsItem. There appears to be a Qt bug that allows this to happen.

Fixes: #1301

