### PR TITLE
Theme Reliability Issues

### DIFF
--- a/ImageLounge/src/DkCore/DkSettings.cpp
+++ b/ImageLounge/src/DkCore/DkSettings.cpp
@@ -326,6 +326,7 @@ void DkSettings::load(QSettings &settings, bool defaults)
 {
     applyDefaultsFromFile(); // copies entries from "default.ini" to the user settings file
     setToDefaultSettings();
+    display_default = display_p;
     qInfoClean() << "loading settings from: " << settings.fileName();
 
     settings.beginGroup("AppSettings");

--- a/ImageLounge/src/DkCore/DkSettings.h
+++ b/ImageLounge/src/DkCore/DkSettings.h
@@ -368,13 +368,14 @@ public:
 
     const Display &defaultDisplay() const
     {
-        return display_d;
+        return display_default;
     }
 
 protected:
     QStringList scamDataDesc;
     QStringList sdescriptionDesc;
 
+    // current settings
     App app_p;
     Global global_p;
     Display display_p;
@@ -383,6 +384,7 @@ protected:
     MetaData meta_p;
     Resources resources_p;
 
+    // saved settings
     App app_d;
     Global global_d;
     Display display_d;
@@ -390,6 +392,9 @@ protected:
     Sync sync_d;
     MetaData meta_d;
     Resources resources_d;
+
+    // app defaults
+    Display display_default;
 
     void init();
 

--- a/ImageLounge/src/DkCore/DkThemeManager.cpp
+++ b/ImageLounge/src/DkCore/DkThemeManager.cpp
@@ -650,7 +650,16 @@ void DkThemeManager::applyTheme()
             display.iconColor = QColor(136, 0, 125);
     }
 
-    const QFileInfo themeFileInfo(themeDir(), getCurrentThemeName());
+    QFileInfo themeFileInfo(themeDir(), getCurrentThemeName());
+    if (!themeFileInfo.exists()) {
+        qWarning() << "[theme] file missing, reverting to default:" << themeFileInfo.absoluteFilePath();
+        setCurrentTheme(DkSettingsManager::param().defaultDisplay().themeName);
+        themeFileInfo = QFileInfo(themeDir(), getCurrentThemeName());
+    }
+    if (!themeFileInfo.exists()) {
+        qWarning() << "[theme] default theme missing:" << themeFileInfo.absoluteFilePath();
+        themeFileInfo.setFile(":/nomacs/stylesheet.css");
+    }
     cssString += preprocess(readFile(themeFileInfo.absoluteFilePath()));
 
     const ColorBinding colors = cssColors(); // must follow css preprocessing (or you get the defaults)


### PR DESCRIPTION
If no stylesheet is loaded nomacs is UI is broken pretty badly at this point and also can have weird bugs that one wouldn't think are theme related (image redraw bug #1284 ). This is a quick PR to address some of those cases.

- Reverts to the default theme file if saved theme name is invalid, file was deleted etc.
- If the default theme is not found due to broken packages etc at least load the internal stylesheet so things are not too badly broken
- Support mixed line endings in theme files