### PR TITLE
Theme Fixes

### DIFF
--- a/ImageLounge/src/DkCore/DkMessageBox.h
+++ b/ImageLounge/src/DkCore/DkMessageBox.h
@@ -67,6 +67,6 @@ protected:
 
     void createLayout(QMessageBox::Icon userIcon, const QString &userText, QMessageBox::StandardButtons buttons);
     void updateSize();
+    QPixmap msgBoxStandardIcon(QMessageBox::Icon icon);
 };
-
 }

--- a/ImageLounge/src/DkCore/DkSettings.cpp
+++ b/ImageLounge/src/DkCore/DkSettings.cpp
@@ -502,6 +502,7 @@ void DkSettings::load(QSettings &settings, bool defaults)
     slideShow_p.moveSpeed = settings.value("moveSpeed", slideShow_p.moveSpeed).toFloat();
     slideShow_p.backgroundColor = QColor::fromRgba(
         settings.value("backgroundColorRGBA", slideShow_p.backgroundColor.rgba()).toInt());
+    slideShow_p.defaultBgdColor = settings.value("defaultBackgroundColor", slideShow_p.defaultBgdColor).toBool();
     slideShow_p.silentFullscreen = settings.value("silentFullscreen", slideShow_p.silentFullscreen).toBool();
     QBitArray tmpDisplay = settings.value("display", slideShow_p.display).toBitArray();
 
@@ -789,6 +790,8 @@ void DkSettings::save(QSettings &settings, bool force)
         settings.setValue("display", slideShow_p.display);
     if (force || slideShow_p.backgroundColor != slideShow_d.backgroundColor)
         settings.setValue("backgroundColorRGBA", slideShow_p.backgroundColor.rgba());
+    if (force || slideShow_p.defaultBgdColor != slideShow_d.defaultBgdColor)
+        settings.setValue("defaultBackgroundColor", slideShow_p.defaultBgdColor);
     if (force || slideShow_p.silentFullscreen != slideShow_d.silentFullscreen)
         settings.setValue("silentFullscreen", slideShow_p.silentFullscreen);
 
@@ -964,6 +967,7 @@ void DkSettings::setToDefaultSettings()
     slideShow_p.moveSpeed = 0; // TODO: set to 1 for finishing slideshow
     slideShow_p.display = QBitArray(display_end, true);
     slideShow_p.backgroundColor = QColor(51, 51, 51, 255);
+    slideShow_p.defaultBgdColor = true;
     slideShow_p.silentFullscreen = true;
 
     meta_p.saveExifOrientation = true;

--- a/ImageLounge/src/DkCore/DkSettings.cpp
+++ b/ImageLounge/src/DkCore/DkSettings.cpp
@@ -448,6 +448,10 @@ void DkSettings::load(QSettings &settings, bool defaults)
         settings.value("highlightColorRGBA", display_p.highlightColor.rgba()).toInt());
     display_p.hudBgColor = QColor::fromRgba(settings.value("bgColorWidgetRGBA", display_p.hudBgColor.rgba()).toInt());
     display_p.hudFgdColor = QColor::fromRgba(settings.value("fontColorRGBA", display_p.hudFgdColor.rgba()).toInt());
+    display_p.hudHighlightColor = QColor::fromRgba(
+        settings.value("hudHighlightColorRGBA", display_p.hudHighlightColor.rgba()).toInt());
+    display_p.hudHighlightLightColor = QColor::fromRgba(
+        settings.value("hudHighlightLightColorRGBA", display_p.hudHighlightLightColor.rgba()).toInt());
     display_p.bgColor = QColor::fromRgba(settings.value("bgColorNoMacsRGBA", display_p.bgColor.rgba()).toInt());
     display_p.fgColor = QColor::fromRgba(settings.value("fgColorNoMacsRGBA", display_p.fgColor.rgba()).toInt());
     display_p.iconColor = QColor::fromRgba(settings.value("iconColorRGBA", display_p.iconColor.rgba()).toInt());
@@ -699,6 +703,10 @@ void DkSettings::save(QSettings &settings, bool force)
         settings.setValue("bgColorWidgetRGBA", display_p.hudBgColor.rgba());
     if (force || display_p.hudFgdColor != display_d.hudFgdColor)
         settings.setValue("fontColorRGBA", display_p.hudFgdColor.rgba());
+    if (force || display_p.hudHighlightColor != display_d.hudHighlightColor)
+        settings.setValue("hudHighlightColorRGBA", display_p.hudHighlightColor.rgba());
+    if (force || display_p.hudHighlightLightColor != display_d.hudHighlightLightColor)
+        settings.setValue("hudHighlightLightColorRGBA", display_p.hudHighlightLightColor.rgba());
     if (force || display_p.bgColor != display_d.bgColor)
         settings.setValue("bgColorNoMacsRGBA", display_p.bgColor.rgba());
     if (force || display_p.fgColor != display_d.fgColor)
@@ -920,6 +928,8 @@ void DkSettings::setToDefaultSettings()
     display_p.highlightColor = QColor(0, 204, 255);
     display_p.hudBgColor = QColor(0, 0, 0, 100);
     display_p.hudFgdColor = QColor(255, 255, 255);
+    display_p.hudHighlightColor = QColor(0, 0, 0, 153);
+    display_p.hudHighlightLightColor = QColor(80, 80, 80, 100);
     display_p.bgColor = QColor(100, 100, 100, 255);
     display_p.fgColor = QColor(0, 0, 0, 255);
     display_p.iconColor = QColor(100, 100, 100, 255);

--- a/ImageLounge/src/DkCore/DkSettings.h
+++ b/ImageLounge/src/DkCore/DkSettings.h
@@ -222,6 +222,8 @@ public:
         QColor hudFgdColor;
         QColor iconColor;
         QColor fgColor;
+        QColor hudHighlightColor;
+        QColor hudHighlightLightColor;
 
         // theme colors, cannot be modified by user; only valid after applyTheme()
         QColor themeFgdColor;

--- a/ImageLounge/src/DkCore/DkSettings.h
+++ b/ImageLounge/src/DkCore/DkSettings.h
@@ -299,6 +299,8 @@ public:
         bool silentFullscreen;
         QBitArray display;
         QColor backgroundColor;
+        bool defaultBgdColor;
+        QColor themeBgdColor;
         float moveSpeed;
     };
     struct Sync {

--- a/ImageLounge/src/DkCore/DkThemeManager.cpp
+++ b/ImageLounge/src/DkCore/DkThemeManager.cpp
@@ -658,6 +658,11 @@ void DkThemeManager::applyTheme()
             display.iconColor = display.themeIconColor;
         if (app.privateMode) // show pink icons if nomacs is in private mode; overrides user icon color
             display.iconColor = QColor(136, 0, 125);
+
+        auto &slideShow = DkSettingsManager::param().slideShow();
+        slideShow.themeBgdColor = QColor(51, 51, 51);
+        if (slideShow.defaultBgdColor)
+            slideShow.backgroundColor = slideShow.themeBgdColor;
     }
 
     QFileInfo themeFileInfo(themeDir(), getCurrentThemeName());
@@ -758,10 +763,11 @@ void DkThemeManager::applyTheme()
     DkPalette::printColor("themeIconColor", d.themeIconColor);
     DkPalette::printColor("iconColor", d.iconColor, d.defaultIconColor);
     DkPalette::printColor("bgColorFrameless", d.bgColorFrameless);
+    DkPalette::printColor("slideshow/themeBgdColor", DkSettingsManager::param().slideShow().themeBgdColor);
+    DkPalette::printColor("slideshow/bgColor", DkSettingsManager::param().slideShow().backgroundColor);
     DkPalette::printColor("highlightColor", d.highlightColor);
     DkPalette::printColor("hudBgColor", d.hudBgColor);
     DkPalette::printColor("hudFgdColor", d.hudFgdColor);
-    DkPalette::printColor("slideshowColor", DkSettingsManager::param().slideShow().backgroundColor);
 
     qDebug("-------palette---------");
     palette.print();
@@ -925,6 +931,7 @@ QString DkThemeManager::preprocess(const QString &cssString) const
         }
 
         auto &dpy = DkSettingsManager::param().display();
+        auto &slideShow = DkSettingsManager::param().slideShow();
         const auto &app = DkSettingsManager::param().app();
 
         if (name == "BACKGROUND_COLOR") {
@@ -949,6 +956,10 @@ QString DkThemeManager::preprocess(const QString &cssString) const
             dpy.themeIconColor = color;
             if (dpy.defaultIconColor && !app.privateMode)
                 dpy.iconColor = color;
+        } else if (name == "SLIDESHOW_COLOR") {
+            slideShow.themeBgdColor = color;
+            if (slideShow.defaultBgdColor)
+                slideShow.backgroundColor = color;
         } else
             qWarning() << "[theme] unknown color name" << name << color;
     };

--- a/ImageLounge/src/DkCore/DkThemeManager.cpp
+++ b/ImageLounge/src/DkCore/DkThemeManager.cpp
@@ -891,6 +891,10 @@ QString DkThemeManager::preprocess(const QString &cssString) const
             dpy.hudBgColor = color;
         else if (name == "HUD_FOREGROUND_COLOR")
             dpy.hudFgdColor = color;
+        else if (name == "HUD_HIGHLIGHT_COLOR")
+            dpy.hudHighlightColor = color;
+        else if (name == "HUD_HIGHLIGHT_LIGHT")
+            dpy.hudHighlightLightColor = color;
         else if (name == "ICON_COLOR") {
             dpy.themeIconColor = color;
             if (dpy.defaultIconColor && !app.privateMode)
@@ -1117,7 +1121,10 @@ DkThemeManager::ColorBinding DkThemeManager::cssColors() const
     QColor highlightAlpha = d.highlightColor;
     highlightAlpha.setAlpha(150);
 
-    return {{"HIGHLIGHT_COLOR", d.highlightColor}, // note the order, BACKGROUND_COLOR must follow *_BACKGROUND_COLOR
+    // note the order, BACKGROUND_COLOR must follow *_BACKGROUND_COLOR
+    return {{"HUD_HIGHLIGHT_COLOR", d.hudHighlightColor},
+            {"HUD_HIGHLIGHT_LIGHT", d.hudHighlightLightColor},
+            {"HIGHLIGHT_COLOR", d.highlightColor},
             {"HIGHLIGHT_LIGHT", highlightAlpha},
             {"HUD_BACKGROUND_COLOR", d.hudBgColor},
             {"HUD_FOREGROUND_COLOR", d.hudFgdColor},

--- a/ImageLounge/src/DkCore/DkThemeManager.h
+++ b/ImageLounge/src/DkCore/DkThemeManager.h
@@ -104,6 +104,11 @@ public:
     void applyTheme();
 
     /**
+     * @brief restyle certain widgets quickly without reapplying the theme
+     */
+    void unpolish(QObject *rootObject);
+
+    /**
      * @param themeName internal theme name (no spaces, file extension)
      * @return human-readable theme name (spaces, no file extension)
      */

--- a/ImageLounge/src/DkCore/DkThemeManager.h
+++ b/ImageLounge/src/DkCore/DkThemeManager.h
@@ -28,6 +28,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <QColor>
 #include <QObject>
+#include <QSet>
 
 #include "nmc_config.h"
 
@@ -135,6 +136,7 @@ signals:
 
 protected:
     DkThemeManager();
+    ~DkThemeManager();
 
     struct Color {
         const char *name;
@@ -174,7 +176,7 @@ protected:
      * @param binding result of bindColors()
      * @return stylesheet ready for color replacement
      */
-    QString replaceMacros(const QString &cssString, const ColorBinding &colors) const;
+    QString replaceMacros(const QString &cssString, const ColorBinding &colors);
 
     /**
      * @brief replace color constants with nomacs settings
@@ -207,5 +209,7 @@ protected:
     QString mDefaultStyle; // style plugin at startup
     bool mOurPaletteChange = false; // if true, ignore palette change events
     int mTimerId = -1;
+    QString mTempDirPath{}; // per-instance subdirectory in nomacs tempdir
+    QSet<QString> mTempFiles{}; // colorized svgs
 };
 }

--- a/ImageLounge/src/DkCore/DkUtils.cpp
+++ b/ImageLounge/src/DkCore/DkUtils.cpp
@@ -44,6 +44,7 @@
 #include <QMainWindow>
 #include <QMimeDatabase>
 #include <QMouseEvent>
+#include <QRandomGenerator>
 #include <QRegularExpression>
 #include <QSemaphore>
 #include <QStandardPaths>
@@ -469,6 +470,19 @@ QString DkUtils::getAppDataPath()
         qWarning() << "I could not create" << appPath;
 
     return appPath;
+}
+
+QString DkUtils::randomString(int length)
+{
+    static constexpr QStringView chars{u"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"};
+
+    QString result;
+    result.reserve(length);
+
+    for (int i = 0; i < length; ++i)
+        result += chars[QRandomGenerator::global()->bounded(chars.size())];
+
+    return result;
 }
 
 QString DkUtils::getTemporaryDirPath()

--- a/ImageLounge/src/DkCore/DkUtils.h
+++ b/ImageLounge/src/DkCore/DkUtils.h
@@ -400,6 +400,7 @@ public:
     static QString resolveFraction(const QString &frac);
     static std::wstring qStringToStdWString(const QString &str);
     static QString stdWStringToQString(const std::wstring &str);
+    static QString randomString(int length);
 
     static std::string stringTrim(const std::string str)
     {

--- a/ImageLounge/src/DkGui/DkNoMacs.cpp
+++ b/ImageLounge/src/DkGui/DkNoMacs.cpp
@@ -45,6 +45,7 @@
 #include "DkQuickAccess.h"
 #include "DkSettings.h"
 #include "DkStatusBar.h"
+#include "DkThemeManager.h"
 #include "DkThumbsWidgets.h"
 #include "DkTimer.h"
 #include "DkToolbars.h"
@@ -646,7 +647,7 @@ void DkNoMacs::enterFullScreen()
     qInfo() << "after enter fullscreen appMode:" << appMode << "geometry:" << geometry()
             << "normalGeometry:" << normalGeometry() << "windowState:" << windowState();
 
-    update();
+    DkThemeManager::instance().unpolish(this);
 }
 
 void DkNoMacs::exitFullScreen()
@@ -692,7 +693,7 @@ void DkNoMacs::exitFullScreen()
         qInfo() << "after exit fullscreen appMode:" << appMode << "geometry:" << geometry()
                 << "normalGeometry:" << normalGeometry() << "windowState:" << windowState();
 
-        update(); // if no resize is triggered, the viewport won't change its color
+        DkThemeManager::instance().unpolish(this);
     }
 }
 

--- a/ImageLounge/src/DkGui/DkPreferenceWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkPreferenceWidgets.cpp
@@ -291,13 +291,13 @@ void DkGeneralPreference::createLayout()
 
     struct {
         const QString caption;
-        const bool restartRequired; // TODO: everying using icons must connect a theme change signal!
+        const bool restartRequired;
         const QColor *themeColor; // setting: system palette or theme css
         QColor *userColor; // setting: user modified color
         bool *isThemeColor; // setting: true if user modified a color
         DkColorChooser *chooser = nullptr;
     } colors[] =
-        {{tr("Icon Color"), true, &display.themeIconColor, &display.iconColor, &display.defaultIconColor},
+        {{tr("Icon Color"), false, &display.themeIconColor, &display.iconColor, &display.defaultIconColor},
          {tr("Foreground Color"), false, &display.themeFgdColor, &display.fgColor, &display.defaultForegroundColor},
          {tr("Background Color"), false, &display.themeBgdColor, &display.bgColor, &display.defaultBackgroundColor},
          {tr("Fullscreen Color"), false, &defaultSlideShowColor, &slideshow.backgroundColor, &noSetting}};

--- a/ImageLounge/src/DkGui/DkPreferenceWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkPreferenceWidgets.cpp
@@ -286,19 +286,17 @@ void DkGeneralPreference::createLayout()
     auto &display = DkSettingsManager::param().display();
     auto &slideshow = DkSettingsManager::param().slideShow();
 
-    static bool noSetting = true; // TODO: defaultSlideShowColor
-    static const QColor defaultSlideShowColor(51, 51, 51); // TODO: themeSlideShowColor
-
     struct {
         const QString caption;
         const QColor *themeColor; // setting: system palette or theme css
         QColor *userColor; // setting: user modified color
         bool *isThemeColor; // setting: true if user modified a color
         DkColorChooser *chooser = nullptr;
-    } colors[] = {{tr("Icon Color"), &display.themeIconColor, &display.iconColor, &display.defaultIconColor},
-                  {tr("Foreground Color"), &display.themeFgdColor, &display.fgColor, &display.defaultForegroundColor},
-                  {tr("Background Color"), &display.themeBgdColor, &display.bgColor, &display.defaultBackgroundColor},
-                  {tr("Fullscreen Color"), &defaultSlideShowColor, &slideshow.backgroundColor, &noSetting}};
+    } colors[] =
+        {{tr("Icon Color"), &display.themeIconColor, &display.iconColor, &display.defaultIconColor},
+         {tr("Foreground Color"), &display.themeFgdColor, &display.fgColor, &display.defaultForegroundColor},
+         {tr("Background Color"), &display.themeBgdColor, &display.bgColor, &display.defaultBackgroundColor},
+         {tr("Fullscreen Color"), &slideshow.themeBgdColor, &slideshow.backgroundColor, &slideshow.defaultBgdColor}};
 
     for (auto &c : colors) {
         c.chooser = new DkColorChooser(*c.themeColor, c.caption, this);

--- a/ImageLounge/src/DkGui/DkPreferenceWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkPreferenceWidgets.cpp
@@ -291,16 +291,14 @@ void DkGeneralPreference::createLayout()
 
     struct {
         const QString caption;
-        const bool restartRequired;
         const QColor *themeColor; // setting: system palette or theme css
         QColor *userColor; // setting: user modified color
         bool *isThemeColor; // setting: true if user modified a color
         DkColorChooser *chooser = nullptr;
-    } colors[] =
-        {{tr("Icon Color"), false, &display.themeIconColor, &display.iconColor, &display.defaultIconColor},
-         {tr("Foreground Color"), false, &display.themeFgdColor, &display.fgColor, &display.defaultForegroundColor},
-         {tr("Background Color"), false, &display.themeBgdColor, &display.bgColor, &display.defaultBackgroundColor},
-         {tr("Fullscreen Color"), false, &defaultSlideShowColor, &slideshow.backgroundColor, &noSetting}};
+    } colors[] = {{tr("Icon Color"), &display.themeIconColor, &display.iconColor, &display.defaultIconColor},
+                  {tr("Foreground Color"), &display.themeFgdColor, &display.fgColor, &display.defaultForegroundColor},
+                  {tr("Background Color"), &display.themeBgdColor, &display.bgColor, &display.defaultBackgroundColor},
+                  {tr("Fullscreen Color"), &defaultSlideShowColor, &slideshow.backgroundColor, &noSetting}};
 
     for (auto &c : colors) {
         c.chooser = new DkColorChooser(*c.themeColor, c.caption, this);
@@ -311,12 +309,9 @@ void DkGeneralPreference::createLayout()
         connect(c.chooser, &DkColorChooser::colorReset, this, [c]() {
             *c.isThemeColor = true;
         });
-        connect(c.chooser, &DkColorChooser::colorChanged, this, [this, c](const QColor &color) {
+        connect(c.chooser, &DkColorChooser::colorChanged, this, [c](const QColor &color) {
             *c.userColor = *c.isThemeColor ? *c.themeColor : color;
-            if (c.restartRequired)
-                emit infoSignal(restartText);
-            else
-                DkThemeManager::instance().applyTheme();
+            DkThemeManager::instance().applyTheme();
         });
         connect(&tm, &DkThemeManager::themeApplied, this, [c] {
             c.chooser->setDefaultColor(*c.themeColor); // reset uses new color

--- a/ImageLounge/src/DkGui/DkWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkWidgets.cpp
@@ -31,6 +31,7 @@
 #include "DkDialog.h"
 #include "DkImageContainer.h"
 #include "DkImageStorage.h"
+#include "DkMath.h"
 #include "DkSettings.h"
 #include "DkStatusBar.h"
 #include "DkThumbs.h"
@@ -2578,22 +2579,8 @@ void DkProgressBar::paintEvent(QPaintEvent *)
 
     QPainter p(this);
     style()->drawPrimitive(QStyle::PE_Widget, &opt, &p, this);
-    p.setPen(Qt::NoPen);
 
-    if (parentWidget() && DkUtils::getMainWindow()->isFullScreen())
-        p.setBackground(DkSettingsManager::param().slideShow().backgroundColor);
-
-    p.setBrush(DkSettingsManager::param().display().highlightColor);
-
-    if (value() != minimum()) {
-        int rv = qRound((value() - minimum()) / (double)(maximum() - minimum()) * width());
-
-        // draw the current status bar
-        QRect r(QPoint(), size());
-        r.setRight(rv);
-
-        p.drawRect(r);
-    }
+    QColor pointColor = opt.palette.color(QPalette::WindowText);
 
     bool stillVisible = false;
 
@@ -2604,7 +2591,8 @@ void DkProgressBar::paintEvent(QPaintEvent *)
         QRect r(QPoint(), QSize(height(), height()));
         r.moveLeft(qRound(pt * width()));
 
-        p.drawRect(r);
+        p.setOpacity(std::sin(pt * CV_PI));
+        p.fillRect(r, pointColor);
 
         if (pt < 0.99)
             stillVisible = true;
@@ -2620,7 +2608,7 @@ void DkProgressBar::initPoints()
 
     int m = 7;
     for (int idx = 1; idx < m; idx++) {
-        mPoints.append((double)idx / m * 0.1);
+        mPoints.append((double)idx / m * 0.05);
     }
 }
 

--- a/ImageLounge/src/stylesheet.css
+++ b/ImageLounge/src/stylesheet.css
@@ -183,8 +183,11 @@ QGraphicsView#DkThumbsView {
 	border: none;
 }
 
-/* FIXME: the stylesheet is not reevaluted when entering/leaving fullscreen,
-          so it keeps the background it started with */
+QMainWindow {
+    /* re-evaluate style when fullScreen change does unpolish() */
+    qproperty-whatsThis: "on-unpolish:recompute-style";
+}
+
 QMainWindow[fullScreen="false"] QGraphicsView#DkThumbsView {
     background-color: BACKGROUND_COLOR;
 }
@@ -525,6 +528,8 @@ nmc--DkGroupWidget QLabel {
 
 nmc--DkProgressBar {
     max-height: 8px;
+    /* re-evaluate style when fullScreen change does unpolish() */
+    qproperty-whatsThis: "on-unpolish:recompute-style";
 }
 
 QMainWindow[fullScreen="false"] nmc--DkProgressBar {

--- a/ImageLounge/src/stylesheet.css
+++ b/ImageLounge/src/stylesheet.css
@@ -133,6 +133,12 @@ QPushButton#DkPlayerButton:pressed {
     background-color: HUD_HIGHLIGHT_LIGHT;
 }
 
+QPushButton#hudNavigationButton:focus,
+QPushButton#DkPlayerButton:focus {
+    outline: none;
+    border: none;
+}
+
 QPushButton#hudNavigationButton {
     border: none;
 

--- a/ImageLounge/src/stylesheet.css
+++ b/ImageLounge/src/stylesheet.css
@@ -524,7 +524,27 @@ nmc--DkGroupWidget QLabel {
 */
 
 nmc--DkProgressBar {
-	max-height: 3px;
+    max-height: 8px;
+}
+
+QMainWindow[fullScreen="false"] nmc--DkProgressBar {
+    color: FOREGROUND_COLOR;
+    background-color: BACKGROUND_COLOR;
+}
+
+QMainWindow[fullScreen="true"] nmc--DkProgressBar {
+    color: HUD_FOREGROUND_COLOR;
+    background-color: SLIDESHOW_COLOR;
+}
+
+nmc--DkNoMacsFrameless[fullScreen="false"] nmc--DkProgressBar {
+    color: HUD_FOREGROUND_COLOR;
+    background-color: HUD_BACKGROUND_COLOR;
+}
+
+nmc--DkNoMacsFrameless[fullScreen="true"] nmc--DkProgressBar {
+    color: HUD_FOREGROUND_COLOR;
+    background-color: HUD_BACKGROUND_COLOR;
 }
 
 /* plugins */

--- a/ImageLounge/src/stylesheet.css
+++ b/ImageLounge/src/stylesheet.css
@@ -279,13 +279,13 @@ QPushButton#DkSplashCopyInfoButton:hover {
   background-color: #ddd;
 }
 
-QLineEdit#DkWarningEdit {
-	color: #000;
-}
-
 QLabel#DkDecentInfo[warning="true"],
 QLineEdit#DkWarningEdit[error="true"] {
-	color: #9f1d1d;
+/* nomacs-if-colorscheme-eq-dark */
+    color: #ff5353;
+/* nomacs-else */
+    color: #9f1d1d;
+/* nomacs-endif */
 }
 
 QListView#resultListView[empty="true"] {

--- a/ImageLounge/src/stylesheet.css
+++ b/ImageLounge/src/stylesheet.css
@@ -125,12 +125,12 @@ QPushButton#DkPlayerButton {
 
 QPushButton#hudNavigationButton:hover,
 QPushButton#DkPlayerButton:hover{
-	background-color: rgba(0,0,0,.6);
+    background-color: HUD_HIGHLIGHT_COLOR;
 } 
 
 QPushButton#hudNavigationButton:pressed,
 QPushButton#DkPlayerButton:pressed {
-	background-color: HIGHLIGHT_LIGHT;
+    background-color: HUD_HIGHLIGHT_LIGHT;
 }
 
 QPushButton#hudNavigationButton {

--- a/ImageLounge/src/stylesheet.css
+++ b/ImageLounge/src/stylesheet.css
@@ -708,18 +708,6 @@ QPushButton#remove {
 	padding: 4px;
 }
 
-QPushButton#load_dir:hover,
-QPushButton#pin:hover,
-QPushButton#remove:hover {
-	background-color: HIGHLIGHT_LIGHT;
-} 
-
-QPushButton#load_dir:pressed,
-QPushButton#pin:pressed,
-QPushButton#remove:pressed {
-	background-color: HIGHLIGHT_LIGHT;
-}
-
 nmc--DkThumbPreviewLabel {
 	padding: 1px;
 }

--- a/ImageLounge/src/stylesheet.css
+++ b/ImageLounge/src/stylesheet.css
@@ -90,21 +90,13 @@ QPushButton#flatWhite:pressed {
 	background-color: rgba(255,255,255,.4);
 }
 
-/* nomacs-if-colorscheme-eq-dark */
 QTabBar::close-button {
-  image: url(:/nomacs/img/close-white.svg);
+  image: nomacsColorize(:/nomacs/img/close.svg);
 }
+
 QTabBar::close-button:hover {
-  image: url(:/nomacs/img/close-white-hover.svg);
+  image: nomacsColorize(:/nomacs/img/close-hover.svg);
 }
-/* nomacs-else */
-QTabBar::close-button {
-  image: url(:/nomacs/img/close.svg);
-}
-QTabBar::close-button:hover {
-  image: url(:/nomacs/img/close-hover.svg);
-}
-/* nomacs-endif */
 
 /* prevent transparent background in central widgets,
    dock widgets/status bar is handled by paintEvent() */
@@ -645,7 +637,7 @@ nmc--DkBaseManipulatorWidget#darkManipulator QComboBox {
 }
 
 nmc--DkBaseManipulatorWidget#darkManipulator QComboBox::drop-down {
-	image: url(:/nomacs/img/down-white.svg);
+    image: nomacsColorize(:/nomacs/img/down.svg,white);
 	border: none;
 	width: 16px;
 	height: 16px;

--- a/ImageLounge/src/themes/Dark-Theme.css
+++ b/ImageLounge/src/themes/Dark-Theme.css
@@ -5,6 +5,7 @@
 /* nomacs-color HIGHLIGHT_COLOR      #0066bb   */
 /* nomacs-color HUD_BACKGROUND_COLOR #aa000000 */
 /* nomacs-color HUD_FOREGROUND_COLOR #ddd      */
+/* nomacs-color SLIDESHOW_COLOR      #333      */
 
 /* nomacs-include ":/nomacs/stylesheet.css" */
 

--- a/ImageLounge/src/themes/Dark-Theme.css
+++ b/ImageLounge/src/themes/Dark-Theme.css
@@ -79,7 +79,7 @@ QCheckBox::indicator {
 }
 
 QCheckBox::indicator:checked {
-    image: url(:/nomacs/img/check-white.svg);
+    image: nomacsColorize(:/nomacs/img/check.svg);
 }
 
 QRadioButton::indicator {
@@ -98,7 +98,7 @@ QRadioButton::indicator {
 
 QRadioButton::indicator:checked
 {
-    image: url(:/nomacs/img/radio-checked-white.svg);
+    image: nomacsColorize(:/nomacs/img/radio-checked.svg);
 }
 
 QCheckBox::indicator:pressed,
@@ -169,7 +169,7 @@ QComboBox QListView::item:hover {
 }
 
 QComboBox::drop-down {
-    image: url(:/nomacs/img/down-white.svg);
+    image: nomacsColorize(:/nomacs/img/down.svg);
     subcontrol-position: right center;
     border: none;
     background-color: none;
@@ -221,27 +221,30 @@ QDoubleSpinBox::down-button:pressed {
 
 QSpinBox::up-arrow,
 QDoubleSpinBox::up-arrow {
-    image: url(:/nomacs/img/up-white.svg);
+    image: nomacsColorize(:/nomacs/img/up.svg);
     width:1.0em;
     height:0.5em;
 }
 
 QSpinBox::down-arrow,
 QDoubleSpinBox::down-arrow {
-    image: url(:/nomacs/img/down-white.svg);
+    image: nomacsColorize(:/nomacs/img/down.svg);
     width:1.0em;
     height:0.5em;
 }
 
 QSpinBox::up-arrow:disabled,
 QSpinBox::up-arrow:off,
+QDoubleSpinBox::up-arrow:disabled,
+QDoubleSpinBox::up-arrow:off {
+    image: nomacsColorize(:/nomacs/img/up.svg,nomacsBlend(BACKGROUND_COLOR,255,255,255,100));
+}
+
 QSpinBox::down-arrow:disabled,
 QSpinBox::down-arrow:off,
-QDoubleSpinBox::up-arrow:disabled,
-QDoubleSpinBox::up-arrow:off,
 QDoubleSpinBox::down-arrow:disabled,
 QDoubleSpinBox::down-arrow:off {
-    image: none; /* lazy but avoids making two more svgs */
+    image: nomacsColorize(:/nomacs/img/down.svg,nomacsBlend(BACKGROUND_COLOR,255,255,255,100));
 }
 
 QToolBar {
@@ -259,11 +262,11 @@ QToolBar::separator {
 }
 
 QTabBar::close-button {
-    image: url(:/nomacs/img/close-white.svg);
+    image: nomacsColorize(:/nomacs/img/close.svg);
 }
 
 QTabBar::close-button:hover {
-    image: url(:/nomacs/img/close-white-hover.svg);
+    image: nomacsColorize(:/nomacs/img/close-hover.svg);
 }
 
 QTabBar::tab {
@@ -531,7 +534,7 @@ QPushButton#infoButton {
 }
 
 #DkEditDock #darkManipulator QCheckBox::indicator:checked {
-    image: url(:/nomacs/img/check-white.svg);
+    image: nomacsColorize(:/nomacs/img/check.svg,white);
 }
 
 #DkEditDock #darkManipulator QComboBox QAbstractItemView {

--- a/ImageLounge/src/themes/Dark-Theme.css
+++ b/ImageLounge/src/themes/Dark-Theme.css
@@ -110,6 +110,22 @@ QDialogButtonBox {
     dialogbuttonbox-buttons-have-icons: 0;
 }
 
+QGroupBox {
+    border: 1px solid rgba(255,255,255,30); /* == button border */
+    margin-top: 0.5em; /* center title with top border */
+    margin-left: 3px; /* line up left border with title */
+    margin-right: 3px; /* match left */
+    margin-bottom: 1px; /* top margin is large, give back space at the bottom */
+    padding: 6px 4px 4px 4px; /* extra padding at the top for the title */
+}
+
+QGroupBox::title {
+    subcontrol-origin: margin;
+    subcontrol-position: top left;
+    padding: 0; /* place as far left as we can */
+    margin: 0;
+}
+
 QHeaderView,
 QHeaderView::section {
     background-color: rgba(0, 0, 0, 30);

--- a/ImageLounge/src/themes/Light-Theme.css
+++ b/ImageLounge/src/themes/Light-Theme.css
@@ -119,6 +119,22 @@ QDialogButtonBox {
     dialogbuttonbox-buttons-have-icons: 0;
 }
 
+QGroupBox {
+    border: 1px solid rgba(0,0,0,60); /* == button border */
+    margin-top: 0.5em; /* center title with top border */
+    margin-left: 3px; /* line up left border with title */
+    margin-right: 3px; /* match left */
+    margin-bottom: 1px; /* top margin is large, give back space at the bottom */
+    padding: 6px 4px 4px 4px; /* extra padding at the top for the title */
+}
+
+QGroupBox::title {
+    subcontrol-origin: margin;
+    subcontrol-position: top left;
+    padding: 0; /* place as far left as we can */
+    margin: 0;
+}
+
 QHeaderView,
 QHeaderView::section {
     background-color: rgba(0, 0, 0, 30);

--- a/ImageLounge/src/themes/Light-Theme.css
+++ b/ImageLounge/src/themes/Light-Theme.css
@@ -5,6 +5,7 @@
 /* nomacs-color HIGHLIGHT_COLOR      #0088ff   */
 /* nomacs-color HUD_BACKGROUND_COLOR #88000000 */
 /* nomacs-color HUD_FOREGROUND_COLOR #fff      */
+/* nomacs-color SLIDESHOW_COLOR      #333      */
 
 /* nomacs-include ":/nomacs/stylesheet.css" */
 

--- a/ImageLounge/src/themes/Light-Theme.css
+++ b/ImageLounge/src/themes/Light-Theme.css
@@ -81,7 +81,7 @@ QCheckBox::indicator {
 }
 
 QCheckBox::indicator:checked {
-    image: url(:/nomacs/img/check.svg);
+    image: nomacsColorize(:/nomacs/img/check.svg);
 }
 
 /*
@@ -107,7 +107,7 @@ QRadioButton::indicator {
 }
 
 QRadioButton::indicator:checked {
-    image: url(:/nomacs/img/radio-checked.svg);
+    image: nomacsColorize(:/nomacs/img/radio-checked.svg);
 }
 
 QCheckBox::indicator:pressed,
@@ -180,7 +180,7 @@ QComboBox QListView::item:hover {
 }
 
 QComboBox::drop-down {
-    image: url(:/nomacs/img/down.svg);
+    image: nomacsColorize(:/nomacs/img/down.svg);
     subcontrol-position: right center;
     border: none;
     background-color: none;
@@ -232,27 +232,30 @@ QDoubleSpinBox::down-button:pressed {
 
 QSpinBox::up-arrow,
 QDoubleSpinBox::up-arrow {
-    image: url(:/nomacs/img/up.svg);
+    image: nomacsColorize(:/nomacs/img/up.svg);
     width:1.0em;
     height:0.5em;
 }
 
 QSpinBox::down-arrow,
 QDoubleSpinBox::down-arrow {
-    image: url(:/nomacs/img/down.svg);
+    image: nomacsColorize(:/nomacs/img/down.svg);
     width:1.0em;
     height:0.5em;
 }
 
 QSpinBox::up-arrow:disabled,
 QSpinBox::up-arrow:off,
+QDoubleSpinBox::up-arrow:disabled,
+QDoubleSpinBox::up-arrow:off {
+    image: nomacsColorize(:/nomacs/img/up.svg,nomacsBlend(BACKGROUND_COLOR,0,0,0,60));
+}
+
 QSpinBox::down-arrow:disabled,
 QSpinBox::down-arrow:off,
-QDoubleSpinBox::up-arrow:disabled,
-QDoubleSpinBox::up-arrow:off,
 QDoubleSpinBox::down-arrow:disabled,
-QDoubleSpinBox::down-arrow:off{
-    image: none; /* lazy but avoids making two more svgs */
+QDoubleSpinBox::down-arrow:off {
+    image: nomacsColorize(:/nomacs/img/down.svg,nomacsBlend(BACKGROUND_COLOR,0,0,0,60));
 }
 
 QToolBar {
@@ -521,7 +524,7 @@ QPushButton#infoButton {
 }
 
 #DkEditDock #darkManipulator QCheckBox::indicator:checked {
-    image: url(:/nomacs/img/check-white.svg);
+    image: nomacsColorize(:/nomacs/img/check.svg,white);
 }
 
 #DkEditDock #darkManipulator QComboBox QAbstractItemView {


### PR DESCRIPTION

Print dialog before/after
<img width="969" height="1027" alt="print-dialog-before" src="https://github.com/user-attachments/assets/e3f576f8-b642-407c-b40c-4025b96d40c4" />
After:
<img width="984" height="1080" alt="print-dialog-after" src="https://github.com/user-attachments/assets/8e07902d-8f44-46ba-9741-dba810aebd54" />

Progress bar before/after

https://github.com/user-attachments/assets/afc9b3ea-1fa3-4dfe-9e3d-b515a1ac90d5

https://github.com/user-attachments/assets/9f4e874a-ab90-4461-9807-cc079be38b2e

Directory edit text before/after
<img width="772" height="277" alt="dir-edit-before" src="https://github.com/user-attachments/assets/e11f5e61-5312-4273-9194-3d520b44e0cd" />
<img width="858" height="293" alt="dir-edit-after" src="https://github.com/user-attachments/assets/b121fc62-58f1-4a15-af68-5e269d2aa037" />

Messagebox before/after
<img width="558" height="274" alt="msgbox-before" src="https://github.com/user-attachments/assets/dd9a47f0-540e-4b3c-9b47-f837c0d5c18e" />
<img width="558" height="274" alt="msgbox-after" src="https://github.com/user-attachments/assets/c216a529-2ed3-4d16-84ff-d325b9fb4c31" />
