### PR TITLE
High Quality Thumbnails

### DIFF
--- a/ImageLounge/src/DkCore/DkBasicWidgets.cpp
+++ b/ImageLounge/src/DkCore/DkBasicWidgets.cpp
@@ -130,6 +130,12 @@ void DkSlider::setMaximum(int maxValue)
     maxValLabel->setText(QString::number(maxValue));
 }
 
+void DkSlider::setRange(int min, int max)
+{
+    setMinimum(min);
+    setMaximum(max);
+}
+
 void DkSlider::setTickInterval(int ticValue)
 {
     slider->setTickInterval(ticValue);
@@ -138,6 +144,11 @@ void DkSlider::setTickInterval(int ticValue)
 int DkSlider::value() const
 {
     return slider->value();
+}
+
+void DkSlider::setValueSuffix(const QString &format)
+{
+    sliderBox->setSuffix(format);
 }
 
 void DkSlider::setFocus(Qt::FocusReason reason)

--- a/ImageLounge/src/DkCore/DkBasicWidgets.h
+++ b/ImageLounge/src/DkCore/DkBasicWidgets.h
@@ -56,10 +56,11 @@ public:
     QSlider *getSlider() const;
     void setMinimum(int minValue);
     void setMaximum(int maxValue);
+    void setRange(int min, int max);
     void setTickInterval(int ticValue);
     int value() const;
+    void setValueSuffix(const QString &format);
     void setFocus(Qt::FocusReason reason);
-
 public slots:
     void setValue(int value);
 

--- a/ImageLounge/src/DkCore/DkCachedThumb.cpp
+++ b/ImageLounge/src/DkCore/DkCachedThumb.cpp
@@ -4,6 +4,7 @@
 #include "DkTimer.h"
 #include "DkUtils.h"
 
+#include <QBuffer>
 #include <QCryptographicHash>
 #include <QDir>
 #include <QSaveFile>
@@ -357,26 +358,29 @@ void DkCachedThumb::save(const QImage &img, int loadedBinSize)
     Q_ASSERT(!thumb.colorSpace().isValid() || thumb.colorSpace() == QColorSpace{QColorSpace::SRgb});
     thumb.setColorSpace({}); // prevent libpng "warning: iCCP: known incorrect sRGB profile"
 
-    // Write to a temporary and atomic swap to prevent thumb corruption (other processes or cleanup function)
-    QSaveFile f(cacheFilePath);
-    if (f.open(QFile::WriteOnly | QFile::Truncate)) {
-        const char *format = "png";
-        int quality = 50;
-        if (!sXdgCompliant && !DkImage::alphaChannelUsed(thumb)) {
-            // On Windows/macOS we don't need XDG compliance and can use JPEG thumbs
-            // Linux users also have this option if they don't care about sharing thumbs
-            format = "jpg";
-            quality = 90;
-        }
-        if (thumb.save(&f, format, quality)) {
-            if (f.commit()) {
+    const char *format = "png";
+    int quality = 50;
+    if (!sXdgCompliant && !DkImage::alphaChannelUsed(thumb)) {
+        // On Windows/macOS we don't need XDG compliance and can use JPEG thumbs
+        // Linux users also have this option if they don't care about sharing thumbs
+        format = "jpg";
+        quality = 90;
+    }
+
+    // We have many threads writing; compress to buffer for less disk fragmentation/syscalls
+    QByteArray data;
+    QBuffer buffer(&data);
+    if (thumb.save(&buffer, format, quality)) {
+        // Write to a temporary and atomic swap to prevent thumb corruption (other processes or cleanup function)
+        QSaveFile f(cacheFilePath);
+        if (f.open(QFile::WriteOnly | QFile::Truncate)) {
+            if (f.write(data) == data.length() && f.commit()) {
                 // qInfo() << "[CachedThumb] SAVED" << mFileInfo.fileName() << img.size() << "to" << thumb.size() << dt;
             }
         }
-    }
-
-    if (f.error() != QFile::NoError) {
-        qWarning() << "[CacheThumb] write failed:" << f.error() << f.errorString() << cacheFilePath;
+        if (f.error() != QFile::NoError) {
+            qWarning() << "[CacheThumb] write failed:" << f.error() << f.errorString() << cacheFilePath;
+        }
     }
 }
 

--- a/ImageLounge/src/DkCore/DkCachedThumb.cpp
+++ b/ImageLounge/src/DkCore/DkCachedThumb.cpp
@@ -5,6 +5,7 @@
 #include "DkUtils.h"
 
 #include <QBuffer>
+#include <QByteArrayView>
 #include <QCryptographicHash>
 #include <QDir>
 #include <QSaveFile>
@@ -35,14 +36,78 @@ static void disableContentIndexing(const QString &path)
 }
 #endif
 
+// check if cached thumb was written by nomacs, without decoding PNG image
+static bool isNomacsThumb(const QString &filename)
+{
+    // PNG uses big-endian, swap to little
+    static constexpr auto readUint32 = [](QFile &file) {
+        QByteArray buffer = file.read(4);
+        if (buffer.size() != 4) {
+            return 0u;
+        }
+        static_assert(Q_BYTE_ORDER == Q_LITTLE_ENDIAN);
+        return (static_cast<uint32_t>(buffer[0]) << 24) | (static_cast<uint32_t>(buffer[1]) << 16)
+            | (static_cast<uint32_t>(buffer[2]) << 8) | static_cast<uint32_t>(buffer[3]);
+    };
+
+    struct Comment {
+        QString key, value;
+    };
+
+    // read a chunk from the PNG file and return comment
+    static constexpr auto readChunk = [](QFile &file) -> std::optional<Comment> {
+        const uint32_t length = readUint32(file);
+        const QByteArray type = file.read(4);
+
+        if (type.length() != 4) {
+            return std::nullopt;
+        }
+
+        const QByteArray data = file.read(length);
+        (void)readUint32(file); // crc of chunk type
+
+        if (data.length() == length && type == "tEXt") {
+            // the key and value are separated by \0
+            QString comment = QString::fromLatin1(data);
+            int delim = comment.indexOf('\0');
+            if (delim >= 0) {
+                QString key = comment.mid(0, delim);
+                QString value = comment.mid(delim + 1);
+                return Comment{key, value};
+            }
+        }
+        return std::nullopt;
+    };
+
+    QFile file(filename);
+    if (!file.open(QIODevice::ReadOnly)) {
+        qDebug() << "Failed to open file!";
+        return false;
+    }
+
+    QByteArray signature = file.read(8);
+
+    static constexpr std::array<uint8_t, 8> kPngHeader = {0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A};
+    if (signature != QByteArrayView(kPngHeader.data(), kPngHeader.size())) {
+        return false;
+    }
+
+    while (!file.atEnd()) {
+        auto comment = readChunk(file);
+        if (comment && comment->key == "Software") {
+            return comment->value == "nomacs";
+        }
+    }
+
+    return false;
+}
+
 void DkCachedThumb::cleanup(bool deleteAll)
 {
+    const bool isSharedCache = isXdgCompliant();
     const auto maxUsedBytes = deleteAll
         ? 0
         : static_cast<qint64>(DkSettingsManager::param().resources().thumbDiskSpace) * 1024 * 1024;
-    if (maxUsedBytes <= 0 && isXdgCompliant()) {
-        return; // Don't clear a shared thumb directory
-    }
 
     DkTimer dt{};
     bool haveAtimeCheck = false;
@@ -61,6 +126,11 @@ void DkCachedThumb::cleanup(bool deleteAll)
     for (auto &d : dirs) {
         const QFileInfoList files = QDir(d.absoluteFilePath()).entryInfoList(QDir::Files);
         for (QFileInfo f : files) {
+            // Don't delete thumbs created by other software
+            if (isSharedCache && !isNomacsThumb(f.absoluteFilePath())) {
+                continue;
+            }
+
             // Try using atime, but not all filesystems support it
             // Fallback to last modified which should be the same as created/birthTime
             if (!haveAtimeCheck) {

--- a/ImageLounge/src/DkCore/DkCachedThumb.cpp
+++ b/ImageLounge/src/DkCore/DkCachedThumb.cpp
@@ -266,7 +266,6 @@ QImage DkCachedThumb::load()
         QString cacheFilePath = cacheHome() + u'/' + xdgBin.name + u'/' + mCacheFileName;
 
         if (!QFile::exists(cacheFilePath)) {
-            // qInfo() << "[CachedThumb] no file" << cacheFilePath;
             continue;
         }
 
@@ -275,24 +274,17 @@ QImage DkCachedThumb::load()
 
         QSize sz = reader.size();
         if (!sz.isValid()) {
-            // qInfo() << "[CachedThumb] no SIZE" << cacheFilePath;
             // another nomacs instance or system daemon may have deleted this out from under us
             continue;
         }
 
         if (xdgBin.size >= maxSize || isLargeEnough(sz)) {
-            // qInfo() << "[CachedThumb] FOUND" << mFileInfo.fileName() << sz << "for" << mSize << (int)mConstraint <<
-            // dt;
             bin = xdgBin;
             break;
         }
-
-        // qInfo() << "[CachedThumb] cache REJECT" << mFileInfo.fileName() << sz << "for" << mSize << (int)mConstraint;
     }
 
     if (bin.size <= 0) {
-        // qInfo() << "[CachedThumb] cache MISS" << mFileInfo.fileName() << mSize << (int)mConstraint << mUri
-        // << mCacheFileName << dt;
         reader.setDevice(nullptr); // Release open file, if any
         return {};
     }

--- a/ImageLounge/src/DkCore/DkCachedThumb.cpp
+++ b/ImageLounge/src/DkCore/DkCachedThumb.cpp
@@ -374,8 +374,9 @@ void DkCachedThumb::save(const QImage &img, int loadedBinSize)
     if (!isXdgCompliant() && !DkImage::alphaChannelUsed(thumb)) {
         // On Windows/macOS we don't need XDG compliance and can use JPEG thumbs
         // Linux users also have this option if they don't care about sharing thumbs
+        // Use highest quality since these will be resampled
         format = "jpg";
-        quality = 90;
+        quality = 100;
     }
 
     // We have many threads writing; compress to buffer for less disk fragmentation/syscalls

--- a/ImageLounge/src/DkCore/DkCachedThumb.cpp
+++ b/ImageLounge/src/DkCore/DkCachedThumb.cpp
@@ -69,7 +69,7 @@ static bool isNomacsThumb(const QString &filename)
         if (data.length() == length && type == "tEXt") {
             // the key and value are separated by \0
             QString comment = QString::fromLatin1(data);
-            int delim = comment.indexOf('\0');
+            int delim = comment.indexOf(QChar{'\0'});
             if (delim >= 0) {
                 QString key = comment.mid(0, delim);
                 QString value = comment.mid(delim + 1);

--- a/ImageLounge/src/DkCore/DkCachedThumb.cpp
+++ b/ImageLounge/src/DkCore/DkCachedThumb.cpp
@@ -49,8 +49,13 @@ void DkCachedThumb::cleanupSync()
     QFileInfoList allFiles;
     qint64 usedBytes = 0;
 
-    // TODO: ignore non-xdg folders and "fail" folder
-    const QFileInfoList dirs = QDir(cacheHome()).entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot);
+    // Ignore non-xdg folders and "fail" folder
+    QStringList dirNameFilters;
+    for (auto xdgBin : kXdgBins) {
+        dirNameFilters += xdgBin.name;
+    }
+
+    const QFileInfoList dirs = QDir(cacheHome()).entryInfoList(dirNameFilters, QDir::Dirs | QDir::NoDotAndDotDot);
     for (auto &d : dirs) {
         const QFileInfoList files = QDir(d.absoluteFilePath()).entryInfoList(QDir::Files);
         for (QFileInfo f : files) {

--- a/ImageLounge/src/DkCore/DkCachedThumb.cpp
+++ b/ImageLounge/src/DkCore/DkCachedThumb.cpp
@@ -301,12 +301,18 @@ QImage DkCachedThumb::load()
     if (!th.isNull()) {
         // Check the freshness of the thumb; no reason to delete it here since we will regenerate shortly
         QString uri = th.text(QStringLiteral("Thumb::URI"));
-        qint64 modTime = th.text(QStringLiteral("Thumb::MTime")).toLongLong();
-        qint64 size = th.text(QStringLiteral("Thumb::Size")).toLongLong();
-        if (uri == mUri && modTime == lastModified().toSecsSinceEpoch() && size == mFileInfo.size()) {
-            // qDebug() << "[CachedThumb] loaded" << mFileInfo.fileName() << th.size() << "for size" << mSize
-            // << "constraint" << (int)mConstraint;
 
+        // XDG spec says "seconds" but nothing about fractions of a second, so ignore
+        QString modStr = th.text(QStringLiteral("Thumb::MTime"));
+        auto dotIdx = modStr.indexOf(QChar(u'.'));
+        auto intPart = dotIdx < 0 ? QStringView{modStr} : QStringView{modStr}.first(dotIdx);
+        qint64 modTime = intPart.toLongLong();
+
+        // Size is not required to be present
+        QString sizeStr = th.text(QStringLiteral("Thumb::Size"));
+        qint64 size = sizeStr.isEmpty() ? -1 : sizeStr.toLongLong();
+
+        if (uri == mUri && modTime == lastModified().toSecsSinceEpoch() && (size < 0 || size == mFileInfo.size())) {
             // If thumb is larger than necessary, we can save a smaller thumb to the cache for next time
             save(th, bin.size);
 

--- a/ImageLounge/src/DkCore/DkCachedThumb.cpp
+++ b/ImageLounge/src/DkCore/DkCachedThumb.cpp
@@ -187,6 +187,8 @@ QFuture<void> &DkCachedThumb::cleanupJob()
 
 void DkCachedThumb::cleanupAsync()
 {
+    Q_ASSERT(QThread::currentThread() == qApp->thread());
+
     if (cleanupJob().isRunning()) {
         qWarning() << "[CachedThumb] cleanup in progress, try again later";
         return;
@@ -197,6 +199,8 @@ void DkCachedThumb::cleanupAsync()
 
 void DkCachedThumb::cleanupSync(bool deleteAll)
 {
+    Q_ASSERT(QThread::currentThread() == qApp->thread());
+
     while (cleanupJob().isRunning()) {
         qInfo() << "[CachedThumb] waiting for previous cleanup to finish...";
         QThread::msleep(1000);

--- a/ImageLounge/src/DkCore/DkCachedThumb.cpp
+++ b/ImageLounge/src/DkCore/DkCachedThumb.cpp
@@ -10,11 +10,33 @@
 #include <QStorageInfo>
 #include <QtConcurrentRun>
 
+#ifdef Q_OS_WIN
+#include <windows.h>
+#endif
+
 namespace nmc
 {
 
 static bool sXdgCompliant = true; // TODO: settings
 static int sMaxSize = 1024; // TODO: settings
+
+#ifdef Q_OS_WIN
+static void disableContentIndexing(const QString &path)
+{
+    std::wstring standardPath = path.toStdWString();
+    DWORD attributes = GetFileAttributesW(standardPath.c_str());
+
+    if (attributes == INVALID_FILE_ATTRIBUTES) {
+        return;
+    }
+    (void)SetFileAttributesW(standardPath.c_str(), attributes | FILE_ATTRIBUTE_NOT_CONTENT_INDEXED);
+}
+#else
+static void disableContentIndexing(const QString &path)
+{
+    Q_UNUSED(path)
+}
+#endif
 
 void DkCachedThumb::cleanupSync()
 {
@@ -287,6 +309,7 @@ void DkCachedThumb::save(const QImage &img, int loadedBinSize)
                 qWarning() << "[CachedThumb] cache disabled, failed to create cache dir" << cacheDirPath;
                 return;
             } else {
+                disableContentIndexing(cacheDirPath);
                 qInfo() << "[CachedThumb] cache directory created at" << cacheDirPath;
             }
         }

--- a/ImageLounge/src/DkCore/DkCachedThumb.cpp
+++ b/ImageLounge/src/DkCore/DkCachedThumb.cpp
@@ -35,9 +35,11 @@ static void disableContentIndexing(const QString &path)
 }
 #endif
 
-void DkCachedThumb::cleanupSync()
+void DkCachedThumb::cleanup(bool deleteAll)
 {
-    const auto maxUsedBytes = static_cast<qint64>(DkSettingsManager::param().resources().thumbDiskSpace) * 1024 * 1024;
+    const auto maxUsedBytes = deleteAll
+        ? 0
+        : static_cast<qint64>(DkSettingsManager::param().resources().thumbDiskSpace) * 1024 * 1024;
     if (maxUsedBytes <= 0 && isXdgCompliant()) {
         return; // Don't clear a shared thumb directory
     }
@@ -96,20 +98,41 @@ void DkCachedThumb::cleanupSync()
         }
     }
 
-    qInfo().noquote() << "[DkCachedThumb] cache cleanup:" << DkUtils::readableByte(usedBytes) << "used"
+    // cleanup empty directories
+    const QFileInfoList emptyDirs = QDir(cacheHome()).entryInfoList(dirNameFilters, QDir::Dirs | QDir::NoDotAndDotDot);
+    for (auto &d : dirs) {
+        QDir().rmdir(d.absoluteFilePath());
+    }
+    QDir().rmdir(cacheHome());
+
+    qInfo().noquote() << "[DkCachedThumb] cache cleanup:" << cacheHome() << DkUtils::readableByte(usedBytes) << "used"
                       << DkUtils::readableByte(freedBytes) << "reclaimed" << dt;
 }
 
-void DkCachedThumb::cleanup()
+QFuture<void> &DkCachedThumb::cleanupJob()
 {
     static QFuture<void> future{};
+    return future;
+}
 
-    if (future.isRunning()) {
+void DkCachedThumb::cleanupAsync()
+{
+    if (cleanupJob().isRunning()) {
         qWarning() << "[CachedThumb] cleanup in progress, try again later";
         return;
     }
 
-    future = QtConcurrent::run(&DkCachedThumb::cleanupSync);
+    cleanupJob() = QtConcurrent::run(&DkCachedThumb::cleanup, false);
+}
+
+void DkCachedThumb::cleanupSync(bool deleteAll)
+{
+    while (cleanupJob().isRunning()) {
+        qInfo() << "[CachedThumb] waiting for previous cleanup to finish...";
+        QThread::msleep(1000);
+    }
+
+    cleanup(deleteAll);
 }
 
 DkCachedThumb::DkCachedThumb(DkFileInfo &fileInfo, int size, ScaleConstraint constraint)

--- a/ImageLounge/src/DkCore/DkCachedThumb.cpp
+++ b/ImageLounge/src/DkCore/DkCachedThumb.cpp
@@ -17,10 +17,6 @@
 
 namespace nmc
 {
-
-static bool sXdgCompliant = true; // TODO: settings
-static int sMaxSize = 1024; // TODO: settings
-
 #ifdef Q_OS_WIN
 static void disableContentIndexing(const QString &path)
 {
@@ -41,7 +37,11 @@ static void disableContentIndexing(const QString &path)
 
 void DkCachedThumb::cleanupSync()
 {
-    const int maxUsedBytes = 1024 * 1024 * 1024; // TODO: settings
+    const auto maxUsedBytes = static_cast<qint64>(DkSettingsManager::param().resources().thumbDiskSpace) * 1024 * 1024;
+    if (maxUsedBytes <= 0 && isXdgCompliant()) {
+        return; // Don't clear a shared thumb directory
+    }
+
     DkTimer dt{};
     bool haveAtimeCheck = false;
     bool haveAtime = false;
@@ -130,8 +130,19 @@ DkCachedThumb::DkCachedThumb(DkFileInfo &fileInfo, int size, ScaleConstraint con
     //
     mUri = QUrl::fromLocalFile(fileInfo.path()).toEncoded();
     QByteArray hash = QCryptographicHash::hash(mUri, QCryptographicHash::Md5).toHex();
-    const char *suffix = sXdgCompliant ? ".png" : ".dat";
+    const char *suffix = isXdgCompliant() ? ".png" : ".dat";
     mCacheFileName = hash + suffix;
+}
+
+bool DkCachedThumb::isXdgCompliant()
+{
+    // Always use non-compliance mode on Windows and macOS as there are no
+    // other programs to share thumbnails with
+#if !defined(Q_OS_WIN) && !defined(Q_OS_MACOS)
+    return DkSettingsManager::param().resources().sharedThumbs;
+#else
+    return false;
+#endif
 }
 
 QImage DkCachedThumb::load()
@@ -142,6 +153,7 @@ QImage DkCachedThumb::load()
     // use it and also save the smaller size for later.
     XdgBin bin{};
     QImageReader reader{};
+    const int maxSize = DkSettingsManager::param().resources().maxThumbSize;
 
     for (auto &xdgBin : kXdgBins) {
         QString cacheFilePath = cacheHome() + u'/' + xdgBin.name + u'/' + mCacheFileName;
@@ -161,7 +173,7 @@ QImage DkCachedThumb::load()
             continue;
         }
 
-        if (xdgBin.size == sMaxSize || isLargeEnough(sz)) {
+        if (xdgBin.size >= maxSize || isLargeEnough(sz)) {
             // qInfo() << "[CachedThumb] FOUND" << mFileInfo.fileName() << sz << "for" << mSize << (int)mConstraint <<
             // dt;
             bin = xdgBin;
@@ -234,6 +246,7 @@ void DkCachedThumb::save(const QImage &img, int loadedBinSize)
     // Find the first xdg bin large enough for scale constraint
     XdgBin bin{};
     QString cacheDirPath{}, cacheFilePath{};
+    const int maxSize = DkSettingsManager::param().resources().maxThumbSize;
 
     for (auto &xdgBin : kXdgBins) {
         bin = xdgBin;
@@ -251,12 +264,10 @@ void DkCachedThumb::save(const QImage &img, int loadedBinSize)
         }
 
         QSize sz{xdgW, xdgH};
-        if (bin.size == sMaxSize || isLargeEnough(sz)) {
+        if (bin.size >= maxSize || isLargeEnough(sz)) {
             break;
         }
     }
-
-    Q_ASSERT(bin.size <= sMaxSize);
 
     // The image itself may be smaller than this bin, no need to cache it
     int imgDim = qMax(imgSize.width(), imgSize.height());
@@ -360,7 +371,7 @@ void DkCachedThumb::save(const QImage &img, int loadedBinSize)
 
     const char *format = "png";
     int quality = 50;
-    if (!sXdgCompliant && !DkImage::alphaChannelUsed(thumb)) {
+    if (!isXdgCompliant() && !DkImage::alphaChannelUsed(thumb)) {
         // On Windows/macOS we don't need XDG compliance and can use JPEG thumbs
         // Linux users also have this option if they don't care about sharing thumbs
         format = "jpg";
@@ -396,7 +407,7 @@ QString DkCachedThumb::cacheHome()
     if (path.isEmpty()) {
         path = QDir::homePath() + "/.cache";
     }
-    path += sXdgCompliant ? "/thumbnails" : "/nomacs/thumbnails";
+    path += isXdgCompliant() ? "/thumbnails" : "/nomacs/thumbnails";
 #endif
     return path;
 }

--- a/ImageLounge/src/DkCore/DkCachedThumb.cpp
+++ b/ImageLounge/src/DkCore/DkCachedThumb.cpp
@@ -402,7 +402,7 @@ void DkCachedThumb::save(const QImage &img, int loadedBinSize)
 
     // Release the job when we return
     struct OnReturn {
-        const QString &mCacheFilePath;
+        const QString mCacheFilePath;
         ~OnReturn()
         {
             QMutexLocker locker(&jobMutex);

--- a/ImageLounge/src/DkCore/DkCachedThumb.cpp
+++ b/ImageLounge/src/DkCore/DkCachedThumb.cpp
@@ -255,7 +255,12 @@ QImage DkCachedThumb::load()
     // use it and also save the smaller size for later.
     XdgBin bin{};
     QImageReader reader{};
-    const int maxSize = DkSettingsManager::param().resources().maxThumbSize;
+    int maxSize = DkSettingsManager::param().resources().maxThumbSize;
+    if (DkSettingsManager::param().display().highQualityThumbs) {
+        // In hq mode allow the next size up to be used, if needed to meet scale constraint
+        // This prevents blur of square thumbnails except very narrow images
+        maxSize = qMin(1024, maxSize * 2);
+    }
 
     for (auto &xdgBin : kXdgBins) {
         QString cacheFilePath = cacheHome() + u'/' + xdgBin.name + u'/' + mCacheFileName;
@@ -348,7 +353,10 @@ void DkCachedThumb::save(const QImage &img, int loadedBinSize)
     // Find the first xdg bin large enough for scale constraint
     XdgBin bin{};
     QString cacheDirPath{}, cacheFilePath{};
-    const int maxSize = DkSettingsManager::param().resources().maxThumbSize;
+    int maxSize = DkSettingsManager::param().resources().maxThumbSize;
+    if (DkSettingsManager::param().display().highQualityThumbs) {
+        maxSize = qMin(1024, maxSize * 2);
+    }
 
     for (auto &xdgBin : kXdgBins) {
         bin = xdgBin;

--- a/ImageLounge/src/DkCore/DkCachedThumb.cpp
+++ b/ImageLounge/src/DkCore/DkCachedThumb.cpp
@@ -1,0 +1,402 @@
+
+#include "DkCachedThumb.h"
+#include "DkSettings.h"
+#include "DkTimer.h"
+#include "DkUtils.h"
+
+#include <QCryptographicHash>
+#include <QDir>
+#include <QSaveFile>
+#include <QStorageInfo>
+#include <QtConcurrentRun>
+
+namespace nmc
+{
+
+static bool sXdgCompliant = true; // TODO: settings
+static int sMaxSize = 1024; // TODO: settings
+
+void DkCachedThumb::cleanupSync()
+{
+    const int maxUsedBytes = 1024 * 1024 * 1024; // TODO: settings
+    DkTimer dt{};
+    bool haveAtimeCheck = false;
+    bool haveAtime = false;
+
+    QFileInfoList allFiles;
+    qint64 usedBytes = 0;
+
+    // TODO: ignore non-xdg folders and "fail" folder
+    const QFileInfoList dirs = QDir(cacheHome()).entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot);
+    for (auto &d : dirs) {
+        const QFileInfoList files = QDir(d.absoluteFilePath()).entryInfoList(QDir::Files);
+        for (QFileInfo f : files) {
+            // Try using atime, but not all filesystems support it
+            // Fallback to last modified which should be the same as created/birthTime
+            if (!haveAtimeCheck) {
+                haveAtimeCheck = true;
+                QDateTime aTime = f.lastRead();
+                haveAtime = aTime.isValid();
+            }
+
+            usedBytes += f.size();
+            allFiles.emplaceBack(f);
+        }
+    }
+    qint64 freedBytes = 0;
+    if (usedBytes > maxUsedBytes) {
+        // sort in reverse, slightly faster removal from array
+        std::sort(allFiles.begin(), allFiles.end(), [&](QFileInfo &a, QFileInfo &b) {
+            QDateTime at = haveAtime ? a.lastRead() : a.lastModified();
+            QDateTime bt = haveAtime ? b.lastRead() : b.lastModified();
+            return bt < at;
+        });
+
+        qint64 toReclaim = usedBytes - maxUsedBytes;
+        while (toReclaim > 0 && !allFiles.isEmpty()) {
+            const QFileInfo f = allFiles.takeLast();
+            qint64 size = f.size();
+
+            // Note there is no synchronization with thumb loader/saver; but there should not be
+            // as a system service could also be managing the cache.
+            if (!QFile::remove(f.absoluteFilePath())) {
+                qWarning() << "[DkCachedThumb] failed to remove file:" << f.absoluteFilePath();
+            } else {
+                freedBytes += size;
+            }
+            toReclaim -= size;
+        }
+    }
+
+    qInfo().noquote() << "[DkCachedThumb] cache cleanup:" << DkUtils::readableByte(usedBytes) << "used"
+                      << DkUtils::readableByte(freedBytes) << "reclaimed" << dt;
+}
+
+void DkCachedThumb::cleanup()
+{
+    static QFuture<void> future{};
+
+    if (future.isRunning()) {
+        qWarning() << "[CachedThumb] cleanup in progress, try again later";
+        return;
+    }
+
+    future = QtConcurrent::run(&DkCachedThumb::cleanupSync);
+}
+
+DkCachedThumb::DkCachedThumb(DkFileInfo &fileInfo, int size, ScaleConstraint constraint)
+    : mFileInfo(fileInfo)
+    , mSize(size)
+    , mConstraint(constraint)
+{
+    //
+    // Different viewers/thumbnailers do not agree on what to do with the path/URI.
+    // This is a problem because if URIs don't match, the cache doesn't work between programs.
+    // The XDG spec wants a "canonical, minimally-encoded URI", but the majority
+    // use fully-encoded, non-canonical URI. So we'll do that as well
+    //
+    // KDE Thumbnails v2 (kio-extras): fully encoded URI, not canonical
+    // GNOME::Thumbnailfactory: fully encoded, not canonical
+    // Mate::ThumbnailFactory: fully encoded, not canonical
+    // geeqie: fully encoded, not canonical
+    // thunar: fully encoded, not canonical
+    //
+    // The outliers:
+    // gwenview: pretty encoded, not canonical
+    // photoqt: pretty encoded, canonical (symlinks resolved)
+    //
+    mUri = QUrl::fromLocalFile(fileInfo.path()).toEncoded();
+    QByteArray hash = QCryptographicHash::hash(mUri, QCryptographicHash::Md5).toHex();
+    const char *suffix = sXdgCompliant ? ".png" : ".dat";
+    mCacheFileName = hash + suffix;
+}
+
+QImage DkCachedThumb::load()
+{
+    DkTimer dt{};
+
+    // Find cached thumbnail satisfying scale constraint. If it is larger than we need, we'll
+    // use it and also save the smaller size for later.
+    XdgBin bin{};
+    QImageReader reader{};
+
+    for (auto &xdgBin : kXdgBins) {
+        QString cacheFilePath = cacheHome() + u'/' + xdgBin.name + u'/' + mCacheFileName;
+
+        if (!QFile::exists(cacheFilePath)) {
+            // qInfo() << "[CachedThumb] no file" << cacheFilePath;
+            continue;
+        }
+
+        // Read png header without fully decoding, to get the size of the thumb
+        reader.setFileName(cacheFilePath);
+
+        QSize sz = reader.size();
+        if (!sz.isValid()) {
+            // qInfo() << "[CachedThumb] no SIZE" << cacheFilePath;
+            // another nomacs instance or system daemon may have deleted this out from under us
+            continue;
+        }
+
+        if (xdgBin.size == sMaxSize || isLargeEnough(sz)) {
+            // qInfo() << "[CachedThumb] FOUND" << mFileInfo.fileName() << sz << "for" << mSize << (int)mConstraint <<
+            // dt;
+            bin = xdgBin;
+            break;
+        }
+
+        // qInfo() << "[CachedThumb] cache REJECT" << mFileInfo.fileName() << sz << "for" << mSize << (int)mConstraint;
+    }
+
+    if (bin.size <= 0) {
+        // qInfo() << "[CachedThumb] cache MISS" << mFileInfo.fileName() << mSize << (int)mConstraint << mUri
+        // << mCacheFileName << dt;
+        reader.setDevice(nullptr); // Release open file, if any
+        return {};
+    }
+
+    QImage th = reader.read();
+    if (!th.isNull()) {
+        // Check the freshness of the thumb; no reason to delete it here since we will regenerate shortly
+        QString uri = th.text(QStringLiteral("Thumb::URI"));
+        qint64 modTime = th.text(QStringLiteral("Thumb::MTime")).toLongLong();
+        qint64 size = th.text(QStringLiteral("Thumb::Size")).toLongLong();
+        if (uri == mUri && modTime == lastModified().toSecsSinceEpoch() && size == mFileInfo.size()) {
+            // qDebug() << "[CachedThumb] loaded" << mFileInfo.fileName() << th.size() << "for size" << mSize
+            // << "constraint" << (int)mConstraint;
+
+            // If thumb is larger than necessary, we can save a smaller thumb to the cache for next time
+            save(th, bin.size);
+
+            return th;
+        }
+    }
+
+    return {};
+}
+
+void DkCachedThumb::save(const QImage &img, int loadedBinSize)
+{
+    static bool cacheDisabled = false;
+    static QMutex jobMutex{}, dirMutex{}, countMutex{};
+    static int saveCount = 0;
+    static QSet<QString> jobs{};
+
+    DkTimer dt{};
+
+    Q_ASSERT(!img.isNull());
+
+    if (img.isNull()) {
+        return;
+    }
+
+    // If there is some filesystem problem we disable cache until restarting nomacs
+    if (cacheDisabled) {
+        return;
+    }
+
+    // Saving disabled in private mode
+    if (DkSettingsManager::param().app().privateMode) {
+        return;
+    }
+
+    // Prevent recursive caching
+    const QString cacheRoot = cacheHome();
+    if (mFileInfo.path().startsWith(cacheRoot)) {
+        return;
+    }
+
+    const QSize imgSize = img.size();
+
+    // Find the first xdg bin large enough for scale constraint
+    XdgBin bin{};
+    QString cacheDirPath{}, cacheFilePath{};
+
+    for (auto &xdgBin : kXdgBins) {
+        bin = xdgBin;
+        cacheDirPath = cacheRoot + u'/' + bin.name;
+        cacheFilePath = cacheDirPath + u'/' + mCacheFileName;
+
+        // get the xdg thumb size at this level - longest-side scaling
+        int xdgW, xdgH;
+        if (imgSize.width() > imgSize.height()) {
+            xdgW = bin.size;
+            xdgH = xdgW * imgSize.height() / imgSize.width();
+        } else {
+            xdgH = bin.size;
+            xdgW = xdgH * imgSize.width() / imgSize.height();
+        }
+
+        QSize sz{xdgW, xdgH};
+        if (bin.size == sMaxSize || isLargeEnough(sz)) {
+            break;
+        }
+    }
+
+    Q_ASSERT(bin.size <= sMaxSize);
+
+    // The image itself may be smaller than this bin, no need to cache it
+    int imgDim = qMax(imgSize.width(), imgSize.height());
+    if (imgDim < bin.size) {
+        // qInfo() << "[CachedThumb] SKIP save, too small" << mFileInfo.fileName() << imgSize << "bin:" << bin.size
+        // << "req:" << mSize << (int)mConstraint;
+        return;
+    }
+
+    // Allow caching a smaller thumbnail from a larger thumbnail.
+    // Since it is at least 2x larger, blur is minimal
+    if (loadedBinSize > 0 && bin.size >= loadedBinSize) {
+        return;
+    }
+
+    // Mod time is required for freshness check
+    const QDateTime modTime = lastModified();
+    if (!modTime.isValid()) {
+        qWarning() << "[CachedThumb] missing modtime, will not cache" << mFileInfo.path();
+        return;
+    }
+
+    // We are now entering the slow part of the process
+    // Multiple threads can request a thumbnail to the same bin; this should be rare, but in nomacs we
+    // have multiple views with thumbnails. There is no threat of corrupted files due to atomic swap,
+    // but this will waste cpu cycles.
+    {
+        QMutexLocker locker(&jobMutex);
+        if (jobs.contains(cacheFilePath)) {
+            return;
+        }
+        jobs.insert(cacheFilePath);
+    }
+
+    // Release the job when we return
+    struct OnReturn {
+        const QString &mCacheFilePath;
+        ~OnReturn()
+        {
+            QMutexLocker locker(&jobMutex);
+            jobs.remove(mCacheFilePath);
+        }
+    } removeJob{cacheFilePath};
+
+    // Create cache folder and any parent directories required
+    if (!QFileInfo::exists(cacheDirPath)) {
+        QMutexLocker locker(&dirMutex);
+        if (!QFileInfo::exists(cacheDirPath)) {
+            if (!QDir().mkpath(cacheDirPath)) {
+                cacheDisabled = true;
+                qWarning() << "[CachedThumb] cache disabled, failed to create cache dir" << cacheDirPath;
+                return;
+            } else {
+                qInfo() << "[CachedThumb] cache directory created at" << cacheDirPath;
+            }
+        }
+    }
+
+    // Check free space, only once in a while since it can be slow
+    {
+        QMutexLocker locker(&countMutex);
+        if (saveCount % 100 == 0) { // check the first time and every 100 thereafter
+            QStorageInfo storage(cacheDirPath);
+            storage.refresh();
+            int mb = storage.bytesAvailable() / 1024 / 1024;
+            // 1024px thumbs are around 1MB (PNG) so check for room for about 100 of them.
+            // Add extra margin since the filesystem metadata may not be in sync
+            cacheDisabled = mb < 1024;
+            // qDebug() << "[CacheThumb] free space MB" << mb << dt;
+
+            if (cacheDisabled) {
+                qWarning() << "[CachedThumb] cache disabled, low free space on" << cacheDirPath;
+                return;
+            }
+        }
+        saveCount++;
+    }
+
+    QImage thumb = DkImage::createThumb(img, bin.size, ScaleConstraint::longest_side);
+    if (thumb.isNull()) {
+        qWarning() << "[CachedThumb] null image" << mFileInfo.fileName();
+        return;
+    }
+
+    Q_ASSERT(thumb.width() == bin.size || thumb.height() == bin.size);
+
+    thumb.setText(QStringLiteral("Software"), QStringLiteral("nomacs"));
+    thumb.setText(QStringLiteral("Thumb::MTime"), QString::number(modTime.toSecsSinceEpoch()));
+    thumb.setText(QStringLiteral("Thumb::Size"), QString::number(mFileInfo.size()));
+    thumb.setText(QStringLiteral("Thumb::URI"), mUri);
+    thumb.setText(QStringLiteral("Thumb::Image::Width"), QString::number(img.width()));
+    thumb.setText(QStringLiteral("Thumb::Image::Height"), QString::number(img.height()));
+
+    // TODO: most others also set this, can be used by file managers for grouping or badges
+    // thumb.setText(QStringLiteral("Thumb::MimeType"), img.mimeType());
+
+    // For interop we want sRGB thumbnails, createThumb() does the conversion
+    Q_ASSERT(!thumb.colorSpace().isValid() || thumb.colorSpace() == QColorSpace{QColorSpace::SRgb});
+    thumb.setColorSpace({}); // prevent libpng "warning: iCCP: known incorrect sRGB profile"
+
+    // Write to a temporary and atomic swap to prevent thumb corruption (other processes or cleanup function)
+    QSaveFile f(cacheFilePath);
+    if (f.open(QFile::WriteOnly | QFile::Truncate)) {
+        const char *format = "png";
+        int quality = 50;
+        if (!sXdgCompliant && !DkImage::alphaChannelUsed(thumb)) {
+            // On Windows/macOS we don't need XDG compliance and can use JPEG thumbs
+            // Linux users also have this option if they don't care about sharing thumbs
+            format = "jpg";
+            quality = 90;
+        }
+        if (thumb.save(&f, format, quality)) {
+            if (f.commit()) {
+                // qInfo() << "[CachedThumb] SAVED" << mFileInfo.fileName() << img.size() << "to" << thumb.size() << dt;
+            }
+        }
+    }
+
+    if (f.error() != QFile::NoError) {
+        qWarning() << "[CacheThumb] write failed:" << f.error() << f.errorString() << cacheFilePath;
+    }
+}
+
+QString DkCachedThumb::cacheHome()
+{
+    QString path{};
+#if defined(Q_OS_WIN)
+    path = DkUtils::getTemporaryDirPath() + "/thumbnails";
+#elif defined(Q_OS_MACOS)
+    path = QDir::homePath() + "/Library/Caches/nomacs/thumbnails";
+#else
+    path = qEnvironmentVariable("XDG_CACHE_HOME");
+    if (path.isEmpty()) {
+        path = QDir::homePath() + "/.cache";
+    }
+    path += sXdgCompliant ? "/thumbnails" : "/nomacs/thumbnails";
+#endif
+    return path;
+}
+
+bool DkCachedThumb::isLargeEnough(const QSize &sz) const
+{
+    switch (mConstraint) {
+    case ScaleConstraint::longest_side:
+        return qMax(sz.width(), sz.height()) >= mSize;
+    case ScaleConstraint::shortest_side:
+        return qMin(sz.width(), sz.height()) >= mSize;
+    case ScaleConstraint::width:
+        return sz.width() >= mSize;
+    case ScaleConstraint::height:
+        return sz.height() >= mSize;
+    }
+    return false;
+}
+
+QDateTime DkCachedThumb::lastModified() const
+{
+    // Try to use the zip member modtime - repacking the zip won't drop thumbnails.
+    // If we don't have that, fallback to .zip modtime
+    QDateTime lastModified = mFileInfo.lastModified();
+    if (!lastModified.isValid() && mFileInfo.isFromZip()) {
+        lastModified = QFileInfo(mFileInfo.dirPath()).lastModified();
+    }
+    return lastModified;
+}
+}

--- a/ImageLounge/src/DkCore/DkCachedThumb.h
+++ b/ImageLounge/src/DkCore/DkCachedThumb.h
@@ -17,9 +17,16 @@ class DkCachedThumb
 {
 public:
     /**
-     * @brief Async cleanup of the cache
+     * @brief Background cleanup of the cache
+     * @note do nothing if cleanup is already running
      */
-    static void DllCoreExport cleanup();
+    static void DllCoreExport cleanupAsync();
+
+    /**
+     * @brief Foreground cleanup of the cache
+     * @note wait if cleanup is already running, then wait for completion
+     */
+    static void cleanupSync(bool deleteAll);
 
     /**
      * @brief Return true if shared cache enabled on XDG-capable system
@@ -49,12 +56,12 @@ public:
      */
     void save(const QImage &img, int loadedBinSize = 0);
 
-private:
-    // Delete old cache files
-    static void cleanupSync();
-
     // Top-level cache directory ($HOME/.cache/thumbnails)
     static QString cacheHome();
+
+private:
+    static QFuture<void> &cleanupJob();
+    static void cleanup(bool deleteAll);
 
     // Return true if image size(sz) is large enough to meet size/constraint
     bool isLargeEnough(const QSize &sz) const;

--- a/ImageLounge/src/DkCore/DkCachedThumb.h
+++ b/ImageLounge/src/DkCore/DkCachedThumb.h
@@ -22,6 +22,12 @@ public:
     static void DllCoreExport cleanup();
 
     /**
+     * @brief Return true if shared cache enabled on XDG-capable system
+     * @return
+     */
+    static bool isXdgCompliant();
+
+    /**
      * @brief setup for loading or saving thumb from/to cache
      * @param fileInfo original file
      * @param size minimum thumbnail size wrt constraint

--- a/ImageLounge/src/DkCore/DkCachedThumb.h
+++ b/ImageLounge/src/DkCore/DkCachedThumb.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include "DkFileInfo.h"
+#include "DkImageStorage.h"
+
+#include <QImageReader>
+
+namespace nmc
+{
+/**
+ * @brief Thumbnail disk cache following XDG specification
+ *
+ * @note This object is reentrant, we can construct and load/save
+ *       thumbs from any thread.
+ */
+class DkCachedThumb
+{
+public:
+    /**
+     * @brief Async cleanup of the cache
+     */
+    static void DllCoreExport cleanup();
+
+    /**
+     * @brief setup for loading or saving thumb from/to cache
+     * @param fileInfo original file
+     * @param size minimum thumbnail size wrt constraint
+     * @param constraint how the thumbnail will be resized
+     */
+    DkCachedThumb(DkFileInfo &fileInfo, int size, ScaleConstraint constraint);
+
+    /**
+     * @brief read from thumbnail cache
+     * @note the returned image could be larger than needed, but never smaller (to reduce blur)
+     * @return valid thumbnail (all freshness checks passed) or null image
+     */
+    QImage load();
+
+    /**
+     * @brief write to thumbnail cache, if requirements are satisfied
+     * @param img image to be scaled and saved to cache
+     * @param loadedBinSize if >0, the bin this image came from; allows saving smaller thumbs from larger ones
+     */
+    void save(const QImage &img, int loadedBinSize = 0);
+
+private:
+    // Delete old cache files
+    static void cleanupSync();
+
+    // Top-level cache directory ($HOME/.cache/thumbnails)
+    static QString cacheHome();
+
+    // Return true if image size(sz) is large enough to meet size/constraint
+    bool isLargeEnough(const QSize &sz) const;
+
+    // Return modified date of original file, best effort if archived/zipped
+    QDateTime lastModified() const;
+
+    // xdg folder size and filesystem name
+    struct XdgBin {
+        int size{0};
+        const char *name{"invalid"};
+    };
+
+    static constexpr std::array<XdgBin, 4> kXdgBins = {
+        {{128, "normal"}, {256, "large"}, {512, "x-large"}, {1024, "xx-large"}}};
+
+    const DkFileInfo mFileInfo;
+    const int mSize;
+    const ScaleConstraint mConstraint;
+
+    QByteArray mUri; // original file's uri
+    QByteArray mCacheFileName; // hash of uri + file extension
+};
+
+}

--- a/ImageLounge/src/DkCore/DkFileInfo.cpp
+++ b/ImageLounge/src/DkCore/DkFileInfo.cpp
@@ -532,9 +532,14 @@ DkFileInfoList DkFileInfo::readDirectory(const QString &dirPath, const QString &
 
     // seems better to use a hashtable here; ~50 extensions are possible without kimageformats
     const QStringList &fileFilters = DkSettingsManager::param().app().browseFilters;
+    const QStringList &containerFilters = DkSettingsManager::param().app().containerRawFilters.split(u' ');
     QSet<QString> suffixes;
-    for (const QString &filter : fileFilters)
+    for (const QString &filter : fileFilters) {
+        if (containerFilters.contains(filter)) {
+            continue;
+        }
         suffixes.insert(QString(filter).replace("*.", ""));
+    }
 
     DkFileInfoList filtered;
 

--- a/ImageLounge/src/DkCore/DkImageStorage.cpp
+++ b/ImageLounge/src/DkCore/DkImageStorage.cpp
@@ -2247,8 +2247,11 @@ QImage DkImage::createThumb(const QImage &image, int maxSize, ScaleConstraint co
     int imgW = image.width();
     int imgH = image.height();
 
-    if (imgW <= maxSize && imgH <= maxSize)
-        return image;
+    if (imgW <= maxSize && imgH <= maxSize) {
+        QImage thumb = image;
+        thumb.convertToColorSpace(QColorSpace{QColorSpace::SRgb}); // FIXME: DkImage::defaultColorSpace
+        return thumb;
+    }
 
     int heightForMaxWidth = maxSize * imgH / imgW; // height if imgW == maxSize
     int widthForMaxHeight = maxSize * imgW / imgH; // width if imgH == maxSize
@@ -2301,7 +2304,7 @@ QImage DkImage::createThumb(const QImage &image, int maxSize, ScaleConstraint co
         thumb = thumb.scaled(QSize{imgW, imgH}, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
     }
 
-    thumb.convertToColorSpace(QColorSpace{QColorSpace::SRgb});
+    thumb.convertToColorSpace(QColorSpace{QColorSpace::SRgb}); // FIXME: DkImage::defaultColorSpace
 
     return thumb;
 }

--- a/ImageLounge/src/DkCore/DkImageStorage.cpp
+++ b/ImageLounge/src/DkCore/DkImageStorage.cpp
@@ -2297,8 +2297,8 @@ QImage DkImage::createThumb(const QImage &image, int maxSize, ScaleConstraint co
 
     if (thumb.isNull()) {
         // fast downscaling
-        thumb = image.scaled(QSize(imgW * 2, imgH * 2), Qt::KeepAspectRatio, Qt::FastTransformation);
-        thumb = thumb.scaled(QSize(imgW, imgH), Qt::KeepAspectRatio, Qt::SmoothTransformation);
+        thumb = image.scaled(QSize{imgW * 2, imgH * 2}, Qt::IgnoreAspectRatio, Qt::FastTransformation);
+        thumb = thumb.scaled(QSize{imgW, imgH}, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
     }
 
     thumb.convertToColorSpace(QColorSpace{QColorSpace::SRgb});

--- a/ImageLounge/src/DkCore/DkImageStorage.cpp
+++ b/ImageLounge/src/DkCore/DkImageStorage.cpp
@@ -2243,7 +2243,7 @@ QImage DkImage::createThumb(const QImage &image, int maxSize, ScaleConstraint co
     if (image.isNull())
         return image;
 
-    maxSize = maxSize == -1 ? max_thumb_size * DkSettingsManager::param().dpiScaleFactor() : maxSize;
+    maxSize = maxSize == -1 ? DkSettingsManager::param().resources().maxThumbSize : maxSize;
     int imgW = image.width();
     int imgH = image.height();
 

--- a/ImageLounge/src/DkCore/DkImageStorage.cpp
+++ b/ImageLounge/src/DkCore/DkImageStorage.cpp
@@ -2285,12 +2285,12 @@ QImage DkImage::createThumb(const QImage &image, int maxSize, ScaleConstraint co
 #ifdef WITH_OPENCV
     if (DkSettingsManager::param().display().highQualityThumbs) {
         try {
-            cv::Mat rImgCv = DkImage::qImage2Mat(image);
-            cv::Mat tmp;
-            cv::resize(rImgCv, tmp, cv::Size(imgW, imgH), 0, 0, CV_INTER_AREA);
-            thumb = DkImage::mat2QImage(tmp, image);
+            const auto srcImg = DkNativeImage::fromConstImage(image);
+            auto dstImg = srcImg.allocateLike(QSize{imgW, imgH});
+            cv::resize(srcImg.constMat(), dstImg.mat(), cv::Size(imgW, imgH), 0, 0, CV_INTER_AREA);
+            thumb = dstImg.img();
         } catch (...) {
-            qWarning() << "imageStorageScaleToSize: OpenCV exception caught while resizing...";
+            qWarning() << "[createThumb] exception while resizing";
         }
     }
 #endif

--- a/ImageLounge/src/DkCore/DkImageStorage.cpp
+++ b/ImageLounge/src/DkCore/DkImageStorage.cpp
@@ -2280,13 +2280,28 @@ QImage DkImage::createThumb(const QImage &image, int maxSize, ScaleConstraint co
         Q_UNREACHABLE();
     }
 
-    // fast downscaling
-    QImage thumb = image.scaled(QSize(imgW * 2, imgH * 2), Qt::KeepAspectRatio, Qt::FastTransformation);
-    thumb = thumb.scaled(QSize(imgW, imgH), Qt::KeepAspectRatio, Qt::SmoothTransformation);
+    QImage thumb;
+
+#ifdef WITH_OPENCV
+    if (DkSettingsManager::param().display().highQualityThumbs) {
+        try {
+            cv::Mat rImgCv = DkImage::qImage2Mat(image);
+            cv::Mat tmp;
+            cv::resize(rImgCv, tmp, cv::Size(imgW, imgH), 0, 0, CV_INTER_AREA);
+            thumb = DkImage::mat2QImage(tmp, image);
+        } catch (...) {
+            qWarning() << "imageStorageScaleToSize: OpenCV exception caught while resizing...";
+        }
+    }
+#endif
+
+    if (thumb.isNull()) {
+        // fast downscaling
+        thumb = image.scaled(QSize(imgW * 2, imgH * 2), Qt::KeepAspectRatio, Qt::FastTransformation);
+        thumb = thumb.scaled(QSize(imgW, imgH), Qt::KeepAspectRatio, Qt::SmoothTransformation);
+    }
 
     thumb.convertToColorSpace(QColorSpace{QColorSpace::SRgb});
-
-    // qDebug() << "thumb size in createThumb: " << thumb.size() << " format: " << thumb.format();
 
     return thumb;
 }

--- a/ImageLounge/src/DkCore/DkImageStorage.cpp
+++ b/ImageLounge/src/DkCore/DkImageStorage.cpp
@@ -2238,28 +2238,46 @@ std::optional<QImage> DkImage::unsharpMask(QImage &&img, float sigma, float weig
     return std::nullopt;
 }
 
-QImage DkImage::createThumb(const QImage &image, int maxSize)
+QImage DkImage::createThumb(const QImage &image, int maxSize, ScaleConstraint constraint)
 {
-    if (image.isNull()) {
+    if (image.isNull())
         return image;
-    }
-    const double maxThumbSize = maxSize == -1 ? max_thumb_size * DkSettingsManager::param().dpiScaleFactor() : maxSize;
+
+    maxSize = maxSize == -1 ? max_thumb_size * DkSettingsManager::param().dpiScaleFactor() : maxSize;
     int imgW = image.width();
     int imgH = image.height();
 
-    if (imgW <= maxThumbSize && imgH <= maxThumbSize) {
+    if (imgW <= maxSize && imgH <= maxSize)
         return image;
-    }
 
-    if (imgW > imgH) {
-        imgH = qRound(maxThumbSize / imgW * imgH);
-        imgW = maxThumbSize;
-    } else if (imgW < imgH) {
-        imgW = qRound(maxThumbSize / imgH * imgW);
-        imgH = maxThumbSize;
-    } else {
-        imgW = maxThumbSize;
-        imgH = maxThumbSize;
+    int heightForMaxWidth = maxSize * imgH / imgW; // height if imgW == maxSize
+    int widthForMaxHeight = maxSize * imgW / imgH; // width if imgH == maxSize
+
+    bool wide = imgW > imgH;
+    imgW = maxSize;
+    imgH = maxSize;
+
+    switch (constraint) {
+    case ScaleConstraint::longest_side:
+        if (wide)
+            imgH = heightForMaxWidth;
+        else
+            imgW = widthForMaxHeight;
+        break;
+    case ScaleConstraint::shortest_side:
+        if (wide)
+            imgW = widthForMaxHeight;
+        else
+            imgH = heightForMaxWidth;
+        break;
+    case ScaleConstraint::width:
+        imgH = heightForMaxWidth;
+        break;
+    case ScaleConstraint::height:
+        imgW = widthForMaxHeight;
+        break;
+    default:
+        Q_UNREACHABLE();
     }
 
     // fast downscaling

--- a/ImageLounge/src/DkCore/DkImageStorage.h
+++ b/ImageLounge/src/DkCore/DkImageStorage.h
@@ -49,6 +49,14 @@ namespace nmc
 {
 class DkRotatingRect;
 
+// sets if width or height is used for aspect-preserving rescale (createThumb etc)
+enum class ScaleConstraint {
+    longest_side, // use width if > height
+    shortest_side, // use width if < height
+    width,
+    height
+};
+
 /**
  * DkImage holds some basic image processing
  * methods that are generally needed.
@@ -123,7 +131,7 @@ public:
      * @note size passed through QIcon::addFile is ignored; we always render the requested size
      */
     static QIcon loadIcon(const QString &filePath, const QColor &color = {});
-    static QImage createThumb(const QImage &img, int maxSize = -1);
+    static QImage createThumb(const QImage &img, int maxSize = -1, ScaleConstraint constraint = {});
     static QPixmap makeSquare(const QPixmap &pm);
     static QPixmap merge(const QVector<QImage> &imgs);
     static QImage cropToImage(const QImage &src, const DkRotatingRect &rect, const QColor &fillColor = QColor());

--- a/ImageLounge/src/DkCore/DkSettings.cpp
+++ b/ImageLounge/src/DkCore/DkSettings.cpp
@@ -564,6 +564,8 @@ void DkSettings::load(QSettings &settings, bool defaults)
     resources_p.thumbDiskSpace = settings.value("thumbDiskSpace", resources_p.thumbDiskSpace).toInt();
     resources_p.preloadThumbs = settings.value("preloadThumbs", resources_p.preloadThumbs).toBool();
     resources_p.sharedThumbs = settings.value("sharedThumbs", resources_p.sharedThumbs).toBool();
+    resources_p.thumbDiskCache = settings.value("thumbDiskCache", resources_p.thumbDiskCache).toBool();
+    resources_p.cleanupThumbCache = settings.value("cleanupDiskCache", resources_p.cleanupThumbCache).toBool();
 
     if (sync_p.switchModifier) {
         global_p.altMod = Qt::ControlModifier;
@@ -886,6 +888,10 @@ void DkSettings::save(QSettings &settings, bool force)
         settings.setValue("preloadThumbs", resources_p.preloadThumbs);
     if (force || resources_p.sharedThumbs != resources_d.sharedThumbs)
         settings.setValue("sharedThumbs", resources_p.sharedThumbs);
+    if (force || resources_p.thumbDiskCache != resources_d.thumbDiskCache)
+        settings.setValue("thumbDiskCache", resources_p.thumbDiskCache);
+    if (force || resources_p.cleanupThumbCache != resources_d.cleanupThumbCache)
+        settings.setValue("cleanupDiskCache", resources_p.cleanupThumbCache);
 
     settings.endGroup();
 
@@ -1071,6 +1077,8 @@ void DkSettings::setToDefaultSettings()
     resources_p.thumbDiskSpace = 0;
     resources_p.preloadThumbs = false;
     resources_p.sharedThumbs = true;
+    resources_p.thumbDiskCache = false;
+    resources_p.cleanupThumbCache = false;
 
     qDebug() << "ok... default settings are set";
 }

--- a/ImageLounge/src/DkCore/DkSettings.cpp
+++ b/ImageLounge/src/DkCore/DkSettings.cpp
@@ -558,6 +558,13 @@ void DkSettings::load(QSettings &settings, bool defaults)
     resources_p.gammaCorrection = settings.value("gammaCorrection", resources_p.gammaCorrection).toBool();
     resources_p.loadSavedImage = settings.value("loadSavedImage", resources_p.loadSavedImage).toInt();
 
+    resources_p.maxThumbSize = settings.value("maxThumbSize", resources_p.maxThumbSize).toInt();
+    resources_p.thumbThreads = settings.value("thumbThreads", resources_p.thumbThreads).toInt();
+    resources_p.thumbCacheMemory = settings.value("thumbCacheMemory", resources_p.thumbCacheMemory).toInt();
+    resources_p.thumbDiskSpace = settings.value("thumbDiskSpace", resources_p.thumbDiskSpace).toInt();
+    resources_p.preloadThumbs = settings.value("preloadThumbs", resources_p.preloadThumbs).toBool();
+    resources_p.sharedThumbs = settings.value("sharedThumbs", resources_p.sharedThumbs).toBool();
+
     if (sync_p.switchModifier) {
         global_p.altMod = Qt::ControlModifier;
         global_p.ctrlMod = Qt::AltModifier;
@@ -867,6 +874,19 @@ void DkSettings::save(QSettings &settings, bool force)
     if (force || resources_p.loadSavedImage != resources_d.loadSavedImage)
         settings.setValue("loadSavedImage", resources_p.loadSavedImage);
 
+    if (force || resources_p.maxThumbSize != resources_d.maxThumbSize)
+        settings.setValue("maxThumbSize", resources_p.maxThumbSize);
+    if (force || resources_p.thumbThreads != resources_d.thumbThreads)
+        settings.setValue("thumbThreads", resources_p.thumbThreads);
+    if (force || resources_p.thumbCacheMemory != resources_d.thumbCacheMemory)
+        settings.setValue("thumbCacheMemory", resources_p.thumbCacheMemory);
+    if (force || resources_p.thumbDiskSpace != resources_d.thumbDiskSpace)
+        settings.setValue("thumbDiskSpace", resources_p.thumbDiskSpace);
+    if (force || resources_p.preloadThumbs != resources_d.preloadThumbs)
+        settings.setValue("preloadThumbs", resources_p.preloadThumbs);
+    if (force || resources_p.sharedThumbs != resources_d.sharedThumbs)
+        settings.setValue("sharedThumbs", resources_p.sharedThumbs);
+
     settings.endGroup();
 
     // keep loaded settings in mind
@@ -1044,6 +1064,13 @@ void DkSettings::setToDefaultSettings()
     resources_p.gammaCorrection = true;
     resources_p.loadSavedImage = ls_load_to_tab;
     resources_p.waitForLastImg = true;
+
+    resources_p.maxThumbSize = 256;
+    resources_p.thumbThreads = qMax(1, QThread::idealThreadCount() - 2);
+    resources_p.thumbCacheMemory = 128;
+    resources_p.thumbDiskSpace = 0;
+    resources_p.preloadThumbs = false;
+    resources_p.sharedThumbs = true;
 
     qDebug() << "ok... default settings are set";
 }

--- a/ImageLounge/src/DkCore/DkSettings.cpp
+++ b/ImageLounge/src/DkCore/DkSettings.cpp
@@ -1069,9 +1069,9 @@ void DkSettings::setToDefaultSettings()
     resources_p.maxThumbSize = 256;
     resources_p.thumbThreads = qMax(1, QThread::idealThreadCount() - 2);
     resources_p.thumbCacheMemory = 128;
-    resources_p.thumbDiskSpace = 0;
+    resources_p.thumbDiskSpace = 1024;
     resources_p.preloadThumbs = false;
-    resources_p.sharedThumbs = true;
+    resources_p.sharedThumbs = false;
     resources_p.thumbDiskCache = false;
     resources_p.cleanupThumbCache = false;
 

--- a/ImageLounge/src/DkCore/DkSettings.cpp
+++ b/ImageLounge/src/DkCore/DkSettings.cpp
@@ -121,11 +121,6 @@ int DkSettings::effectiveThumbSize(QWidget *widget) const
     return qRound(display_p.thumbSize * dpiScaleFactor(widget));
 }
 
-int DkSettings::effectiveThumbPreviewSize(QWidget *widget) const
-{
-    return qRound(display_p.thumbPreviewSize * dpiScaleFactor(widget));
-}
-
 QStringList DkSettings::translatedCamData() const
 {
     return scamDataDesc;

--- a/ImageLounge/src/DkCore/DkSettings.cpp
+++ b/ImageLounge/src/DkCore/DkSettings.cpp
@@ -476,6 +476,7 @@ void DkSettings::load(QSettings &settings, bool defaults)
     display_p.thumbSize = settings.value("thumbSize", display_p.thumbSize).toInt();
     display_p.iconSize = settings.value("iconSize", display_p.iconSize).toInt();
     display_p.thumbPreviewSize = settings.value("thumbPreviewSize", display_p.thumbPreviewSize).toInt();
+    display_p.highQualityThumbs = settings.value("highQualityThumbs", display_p.highQualityThumbs).toBool();
     // display_p.saveThumb = settings.value("saveThumb", display_p.saveThumb).toBool();
     display_p.antiAliasing = settings.value("antiAliasing", display_p.antiAliasing).toBool();
     display_p.highQualityAntiAliasing = settings.value("highQualityAntiAliasing", display_p.highQualityAntiAliasing)
@@ -739,6 +740,8 @@ void DkSettings::save(QSettings &settings, bool force)
         settings.setValue("iconSize", display_p.iconSize);
     if (force || display_p.thumbPreviewSize != display_d.thumbPreviewSize)
         settings.setValue("thumbPreviewSize", display_p.thumbPreviewSize);
+    if (force || display_p.highQualityThumbs != display_d.highQualityThumbs)
+        settings.setValue("highQualityThumbs", display_p.highQualityThumbs);
     // if (force ||display_p.saveThumb != display_d.saveThumb)
     //	settings.setValue("saveThumb", display_p.saveThumb);
     if (force || display_p.antiAliasing != display_d.antiAliasing)
@@ -982,6 +985,7 @@ void DkSettings::setToDefaultSettings()
     display_p.thumbSize = 64;
     display_p.iconSize = 20;
     display_p.thumbPreviewSize = 64;
+    display_p.highQualityThumbs = false;
     display_p.antiAliasing = true;
     display_p.highQualityAntiAliasing = false;
     display_p.showCrop = false;

--- a/ImageLounge/src/DkCore/DkSettings.h
+++ b/ImageLounge/src/DkCore/DkSettings.h
@@ -237,6 +237,8 @@ public:
         int thumbSize;
         int iconSize;
         int thumbPreviewSize;
+        bool highQualityThumbs;
+
         // bool saveThumb;
         int interpolateZoomLevel;
         bool showCrop;

--- a/ImageLounge/src/DkCore/DkSettings.h
+++ b/ImageLounge/src/DkCore/DkSettings.h
@@ -375,7 +375,6 @@ public:
     double dpiScaleFactor(QWidget *w = nullptr) const;
     int effectiveIconSize(QWidget *w = nullptr) const;
     int effectiveThumbSize(QWidget *w = nullptr) const;
-    int effectiveThumbPreviewSize(QWidget *w = nullptr) const;
 
     App &app();
     Global &global();

--- a/ImageLounge/src/DkCore/DkSettings.h
+++ b/ImageLounge/src/DkCore/DkSettings.h
@@ -334,6 +334,13 @@ public:
         QString preferredExtension;
         bool gammaCorrection;
         int loadSavedImage;
+
+        int maxThumbSize; // max thumbnail size to load (scaled above this size is blurring)
+        int thumbThreads; // number of thumbnail loading threads
+        int thumbCacheMemory; // MiB, 0=disable, thumb memory cache (not including QPixmap cache)
+        int thumbDiskSpace; // MiB, 0=disable, max cache on disk after trimming
+        bool preloadThumbs; // preload thumbs before they need to be painted
+        bool sharedThumbs; // if true, thumbs are shared with the system thumbnailer
     };
 
     enum DisplayItems {

--- a/ImageLounge/src/DkCore/DkSettings.h
+++ b/ImageLounge/src/DkCore/DkSettings.h
@@ -338,9 +338,11 @@ public:
         int maxThumbSize; // max thumbnail size to load (scaled above this size is blurring)
         int thumbThreads; // number of thumbnail loading threads
         int thumbCacheMemory; // MiB, 0=disable, thumb memory cache (not including QPixmap cache)
-        int thumbDiskSpace; // MiB, 0=disable, max cache on disk after trimming
+        int thumbDiskSpace; // MiB, max cache on disk after trimming
         bool preloadThumbs; // preload thumbs before they need to be painted
         bool sharedThumbs; // if true, thumbs are shared with the system thumbnailer
+        bool thumbDiskCache; // if true, thumbs are saved to disk cache
+        bool cleanupThumbCache; // if true, cleanup disk cache at startup
     };
 
     enum DisplayItems {

--- a/ImageLounge/src/DkCore/DkSettings.h
+++ b/ImageLounge/src/DkCore/DkSettings.h
@@ -234,10 +234,10 @@ public:
         bool defaultBackgroundColor;
         bool defaultIconColor;
 
-        int thumbSize;
+        int thumbSize; // ribbon thumbnail size
         int iconSize;
         int thumbPreviewSize;
-        bool highQualityThumbs;
+        bool highQualityThumbs; // grid thumbnail size
 
         // bool saveThumb;
         int interpolateZoomLevel;

--- a/ImageLounge/src/DkCore/DkThumbs.cpp
+++ b/ImageLounge/src/DkCore/DkThumbs.cpp
@@ -284,23 +284,27 @@ DkThumbLoader::LoadThumbnailResultLocal DkThumbLoader::scaleFullThumbnail(const 
 
 void DkThumbLoader::requestThumbnail(const LoadThumbnailRequest &request)
 {
-    const auto *cached = mThumbnailCache.object(request.id);
+    const LoadThumbnailResultLocal *cached = mThumbnailCache.object(request.id);
     if (cached) {
         if (!cached->valid) {
             emit thumbnailLoadFailed(cached->request.id, cached->request.filePath);
-            return;
+        } else {
+            emit thumbnailLoaded(cached->request.id, cached->request.filePath, cached->thumb, cached->fromExif);
         }
-
-        emit thumbnailLoaded(cached->request.id, cached->request.filePath, cached->thumb, cached->fromExif);
         return;
     }
 
     if (mIdleWatchers.size() == 0) {
-        const int count = mCounts.value(request.id, 0);
-        if (count == 0) {
+        // We may have multiple widgets requesting the same thumbnail. With cancellation, we
+        // must ensure if only one cancels the others will not; and so we count the requests.
+        auto it = mCounts.find(request.id);
+        if (it == mCounts.end()) {
             mQueue.push(request);
+            mCounts.insert(request.id, 1);
+        } else {
+            it.value() += 1;
+            Q_ASSERT(it.value() > 0);
         }
-        mCounts.insert(request.id, count + 1);
         return;
     }
 
@@ -316,6 +320,10 @@ void DkThumbLoader::cancelThumbnailRequest(const LoadThumbnailRequest &request)
         return;
     }
     it.value() -= 1;
+    Q_ASSERT(it.value() >= 0);
+    if (it.value() == 0) {
+        mCounts.remove(it.key());
+    }
 }
 
 void DkThumbLoader::dispatchFullImage(const LoadThumbnailRequest &request, const QImage &img)
@@ -340,6 +348,12 @@ void DkThumbLoader::onThumbnailLoadFinished()
     auto *res = new LoadThumbnailResultLocal{w->result()};
     const size_t resSize = sizeof(*res) + res->sizeInBytes();
 
+    auto it = mCounts.find(res->request.id);
+    if (it != mCounts.end()) {
+        // We have finished the request, the count might be gone due to cancellations
+        mCounts.remove(it.key());
+    }
+
     handleFinishedWatcher(w);
 
     if (!res->valid) { // NOLINT(clang-analyzer-core.uninitialized.Branch) -- false positive
@@ -363,11 +377,13 @@ void DkThumbLoader::handleFinishedWatcher(QFutureWatcher<LoadThumbnailResultLoca
         return;
     }
 
-    while (mQueue.size() > 0) {
-        const auto request = mQueue.front();
+    while (!mQueue.empty()) {
+        // Remove next request from the queue; if it has no refcount, all requests were cancelled
+        const LoadThumbnailRequest request = std::move(mQueue.front());
         mQueue.pop();
-        if (mCounts.value(request.id, 0) > 0) {
-            mCounts.remove(request.id);
+        auto it = mCounts.find(request.id);
+        if (it != mCounts.end()) {
+            // Do not drop refcount here, we need to keep count while the request is processed
             w->setFuture(QtConcurrent::run(loadThumbnailLocal, request));
             return;
         }

--- a/ImageLounge/src/DkCore/DkThumbs.cpp
+++ b/ImageLounge/src/DkCore/DkThumbs.cpp
@@ -276,12 +276,6 @@ DkThumbLoader::LoadThumbnailResultLocal DkThumbLoader::loadThumbnailLocal(const 
     return {request, DkImage::createThumb(res->thumb, request.size, request.constraint), true, res->fromExif};
 }
 
-DkThumbLoader::LoadThumbnailResultLocal DkThumbLoader::scaleFullThumbnail(const LoadThumbnailRequest &request,
-                                                                          const QImage &img)
-{
-    return {request, DkImage::createThumb(img, request.size, request.constraint), true, false};
-}
-
 void DkThumbLoader::requestThumbnail(const LoadThumbnailRequest &request)
 {
     const LoadThumbnailResultLocal *cached = mThumbnailCache.object(request.id);
@@ -326,20 +320,6 @@ void DkThumbLoader::cancelThumbnailRequest(const LoadThumbnailRequest &request)
     }
 }
 
-void DkThumbLoader::dispatchFullImage(const LoadThumbnailRequest &request, const QImage &img)
-{
-    if (mIdleWatchers.size() == 0) {
-        // Full image takes priority, so we can skip the pending requests
-        mCounts.remove(request.id);
-        mFullImageQueue.push({request, img, true, false});
-        return;
-    }
-
-    auto *w = mIdleWatchers.back();
-    mIdleWatchers.pop_back();
-    w->setFuture(QtConcurrent::run(scaleFullThumbnail, request, img));
-}
-
 void DkThumbLoader::onThumbnailLoadFinished()
 {
     const auto w = dynamic_cast<QFutureWatcher<LoadThumbnailResultLocal> *>(sender());
@@ -370,13 +350,6 @@ void DkThumbLoader::onThumbnailLoadFinished()
 
 void DkThumbLoader::handleFinishedWatcher(QFutureWatcher<LoadThumbnailResultLocal> *w)
 {
-    if (mFullImageQueue.size() > 0) {
-        const LoadThumbnailResultLocal &item = mFullImageQueue.front();
-        w->setFuture(QtConcurrent::run(scaleFullThumbnail, item.request, item.thumb));
-        mFullImageQueue.pop();
-        return;
-    }
-
     while (!mQueue.empty()) {
         // Remove next request from the queue; if it has no refcount, all requests were cancelled
         const LoadThumbnailRequest request = std::move(mQueue.front());

--- a/ImageLounge/src/DkCore/DkThumbs.cpp
+++ b/ImageLounge/src/DkCore/DkThumbs.cpp
@@ -103,8 +103,7 @@ std::optional<LoadThumbnailResult> loadThumbnail(const LoadThumbnailRequest &req
     std::unique_ptr<DkCachedThumb> cachedThumb{};
 
     if (request.option != LoadThumbnailOption::force_full //
-        && DkSettingsManager::param().resources().thumbDiskCache
-        && DkSettingsManager::param().resources().thumbDiskSpace > 0) {
+        && DkSettingsManager::param().resources().thumbDiskCache) {
         cachedThumb = std::make_unique<DkCachedThumb>(fileInfo, request.size, request.constraint);
         QImage thumb = cachedThumb->load();
         if (!thumb.isNull()) {

--- a/ImageLounge/src/DkCore/DkThumbs.cpp
+++ b/ImageLounge/src/DkCore/DkThumbs.cpp
@@ -227,7 +227,8 @@ void removeBlackBorder(QImage &img)
 DkThumbsThreadPool::DkThumbsThreadPool()
 {
     const auto &res = DkSettingsManager::param().resources();
-    int numThreads = qBound(1, res.thumbThreads, QThread::idealThreadCount() - 2);
+    int cpuThreads = QThread::idealThreadCount();
+    int numThreads = cpuThreads <= 2 ? 1 : qBound(1, res.thumbThreads, cpuThreads - 2);
     mPool = new QThreadPool();
     mPool->setMaxThreadCount(numThreads);
 }

--- a/ImageLounge/src/DkCore/DkThumbs.cpp
+++ b/ImageLounge/src/DkCore/DkThumbs.cpp
@@ -277,11 +277,11 @@ void DkThumbLoader::requestThumbnail(const LoadThumbnailRequest &request)
     const auto *cached = mThumbnailCache.object(request.id);
     if (cached) {
         if (!cached->valid) {
-            emit thumbnailLoadFailed(cached->request.filePath);
+            emit thumbnailLoadFailed(cached->request.id, cached->request.filePath);
             return;
         }
 
-        emit thumbnailLoaded(cached->request.filePath, cached->thumb, cached->fromExif);
+        emit thumbnailLoaded(cached->request.id, cached->request.filePath, cached->thumb, cached->fromExif);
         return;
     }
 
@@ -333,12 +333,12 @@ void DkThumbLoader::onThumbnailLoadFinished()
     handleFinishedWatcher(w);
 
     if (!res->valid) { // NOLINT(clang-analyzer-core.uninitialized.Branch) -- false positive
-        emit thumbnailLoadFailed(res->request.filePath);
+        emit thumbnailLoadFailed(res->request.id, res->request.filePath);
         mThumbnailCache.insert(res->request.id, res, resSize);
         return;
     }
 
-    emit thumbnailLoaded(res->request.filePath, res->thumb, res->fromExif);
+    emit thumbnailLoaded(res->request.id, res->request.filePath, res->thumb, res->fromExif);
 
     // Add cache after finished using res because the cache takes ownership.
     mThumbnailCache.insert(res->request.id, res, resSize);

--- a/ImageLounge/src/DkCore/DkThumbs.cpp
+++ b/ImageLounge/src/DkCore/DkThumbs.cpp
@@ -119,12 +119,16 @@ std::optional<LoadThumbnailResult> loadThumbnail(const LoadThumbnailRequest &req
     }
 
     std::optional<ThumbnailFromMetadata> exifThumb{};
-    if (opt != LoadThumbnailOption::force_full) {
+    if (request.option != LoadThumbnailOption::force_full) {
         exifThumb = loadThumbnailFromMetadata(*metaData);
     }
 
     std::optional<QImage> fullThumb{};
-    if (opt != LoadThumbnailOption::force_exif && !exifThumb) {
+    bool loadFull = request.option != LoadThumbnailOption::force_exif && !exifThumb;
+    loadFull |= request.option == LoadThumbnailOption::force_size && exifThumb
+        && qMax(exifThumb->thumb.height(), exifThumb->thumb.width()) < request.size;
+    if (loadFull) {
+        exifThumb = {};
         fullThumb = loadThumbnailFromFullImage(thumbPath, ba);
     }
 

--- a/ImageLounge/src/DkCore/DkThumbs.cpp
+++ b/ImageLounge/src/DkCore/DkThumbs.cpp
@@ -102,7 +102,8 @@ std::optional<LoadThumbnailResult> loadThumbnail(const LoadThumbnailRequest &req
     std::optional<QImage> fullThumb{};
     std::unique_ptr<DkCachedThumb> cachedThumb{};
 
-    if (request.option != LoadThumbnailOption::force_full) {
+    if (request.option != LoadThumbnailOption::force_full
+        && DkSettingsManager::param().resources().thumbDiskSpace > 0) {
         cachedThumb = std::make_unique<DkCachedThumb>(fileInfo, request.size, request.constraint);
         QImage thumb = cachedThumb->load();
         if (!thumb.isNull()) {
@@ -224,8 +225,10 @@ void removeBlackBorder(QImage &img)
 // DkThumbsThreadPool --------------------------------------------------------------------
 DkThumbsThreadPool::DkThumbsThreadPool()
 {
+    const auto &res = DkSettingsManager::param().resources();
+    int numThreads = qBound(1, res.thumbThreads, QThread::idealThreadCount() - 2);
     mPool = new QThreadPool();
-    mPool->setMaxThreadCount(qMax(mPool->maxThreadCount() - 2, 1));
+    mPool->setMaxThreadCount(numThreads);
 }
 
 DkThumbsThreadPool &DkThumbsThreadPool::instance()
@@ -245,9 +248,16 @@ void DkThumbsThreadPool::clear()
 }
 
 DkThumbLoader::DkThumbLoader()
-    : mWatchers(qMax(QThread::idealThreadCount() - 2, 1))
 {
-    mIdleWatchers.reserve(mWatchers.size());
+    unsigned numThreads = DkThumbsThreadPool::pool()->maxThreadCount();
+
+    const auto &res = DkSettingsManager::param().resources();
+    auto maxBytes = qsizetype(res.thumbCacheMemory) * 1024 * 1024;
+
+    mThumbnailCache.setMaxCost(maxBytes);
+    mWatchers = decltype(mWatchers){numThreads};
+
+    mIdleWatchers.reserve(numThreads);
     for (auto &ele : mWatchers) {
         mIdleWatchers.push_back(&ele);
         connect(&ele,

--- a/ImageLounge/src/DkCore/DkThumbs.cpp
+++ b/ImageLounge/src/DkCore/DkThumbs.cpp
@@ -348,10 +348,10 @@ void DkThumbLoader::handleFinishedWatcher(QFutureWatcher<LoadThumbnailResultLoca
     mIdleWatchers.push_back(w);
 }
 
-LoadThumbnailRequest::LoadThumbnailRequest(const QString &filePath_, LoadThumbnailOption option_, int maxSize_)
+LoadThumbnailRequest::LoadThumbnailRequest(const QString &filePath_, LoadThumbnailOption option_, int size_)
     : filePath(filePath_)
     , option(option_)
-    , size(maxSize_)
+    , size(size_)
 {
     QString key = filePath;
     key += QString::number(static_cast<int>(option));

--- a/ImageLounge/src/DkCore/DkThumbs.cpp
+++ b/ImageLounge/src/DkCore/DkThumbs.cpp
@@ -28,13 +28,12 @@
 #include "DkThumbs.h"
 
 #include "DkBasicLoader.h"
+#include "DkCachedThumb.h"
 #include "DkFileInfo.h"
 #include "DkMetaData.h"
 #include "DkSettings.h"
 #include "DkTimer.h"
 
-#include <QColorSpace>
-#include <QStringBuilder>
 #include <QtConcurrentRun>
 
 namespace nmc
@@ -97,45 +96,63 @@ std::optional<LoadThumbnailResult> loadThumbnail(const LoadThumbnailRequest &req
         return std::nullopt;
     }
 
-    if (fileInfo.isFromZip()) {
-        std::unique_ptr<QIODevice> io = fileInfo.getIODevice();
-        if (io)
-            ba.reset(new QByteArray(io->readAll()));
-    }
-
     const QString thumbPath = fileInfo.path(); // resolved path (shortcuts/aliases)
 
-    // read the thumbnail from the exif data
-    try {
-        if (!ba || ba->isEmpty()) {
-            metaData->readMetaData(thumbPath);
-        } else {
-            metaData->readMetaData(thumbPath, ba);
-        }
-    } catch (...) {
-        // this should never happen since we handle exceptions in metaData
-        qWarning() << "[Thumbnail] unexpected exception when reading exif thumbnail";
-    }
-
     std::optional<ThumbnailFromMetadata> exifThumb{};
-    if (request.option != LoadThumbnailOption::force_full) {
-        exifThumb = loadThumbnailFromMetadata(*metaData);
-    }
-
     std::optional<QImage> fullThumb{};
-    bool loadFull = request.option != LoadThumbnailOption::force_exif && !exifThumb;
-    loadFull |= request.option == LoadThumbnailOption::force_size && exifThumb
-        && qMax(exifThumb->thumb.height(), exifThumb->thumb.width()) < request.size;
-    if (loadFull) {
-        exifThumb = {};
-        fullThumb = loadThumbnailFromFullImage(thumbPath, ba);
+    std::unique_ptr<DkCachedThumb> cachedThumb{};
+
+    if (request.option != LoadThumbnailOption::force_full) {
+        cachedThumb = std::make_unique<DkCachedThumb>(fileInfo, request.size, request.constraint);
+        QImage thumb = cachedThumb->load();
+        if (!thumb.isNull()) {
+            fullThumb = thumb;
+        }
     }
 
-    if (!fullThumb && !exifThumb) {
-        return std::nullopt;
+    if (!fullThumb) {
+        if (fileInfo.isFromZip()) {
+            std::unique_ptr<QIODevice> io = fileInfo.getIODevice();
+            if (io)
+                ba.reset(new QByteArray(io->readAll()));
+        }
+
+        // read the thumbnail from the exif data
+        try {
+            if (!ba || ba->isEmpty()) {
+                metaData->readMetaData(thumbPath);
+            } else {
+                metaData->readMetaData(thumbPath, ba);
+            }
+        } catch (...) {
+            // this should never happen since we handle exceptions in metaData
+            qWarning() << "[Thumbnail] unexpected exception when reading exif thumbnail";
+        }
+
+        if (request.option != LoadThumbnailOption::force_full) {
+            exifThumb = loadThumbnailFromMetadata(*metaData);
+        }
+
+        bool loadFull = request.option != LoadThumbnailOption::force_exif && !exifThumb;
+        loadFull |= request.option == LoadThumbnailOption::force_size && exifThumb
+            && qMax(exifThumb->thumb.height(), exifThumb->thumb.width()) < request.size;
+        if (loadFull) {
+            exifThumb = {};
+            fullThumb = loadThumbnailFromFullImage(thumbPath, ba);
+        }
+
+        if (!fullThumb && !exifThumb) {
+            return std::nullopt;
+        }
     }
 
     QImage thumb = exifThumb ? exifThumb.value().thumb : fullThumb.value();
+
+    if (!thumb.isNull() && cachedThumb) {
+        if (dt.elapsed() >= 10) { // skip save if it loaded quickly
+            cachedThumb->save(thumb);
+        }
+    }
 
     LoadThumbnailResult res = {
         thumb,
@@ -145,9 +162,10 @@ std::optional<LoadThumbnailResult> loadThumbnail(const LoadThumbnailRequest &req
         exifThumb && exifThumb->transformed,
     };
 
-    QString info = QString("[Thumbnail] %1 exif=%2 size=%3x%4 %8ms")
-                       .arg(thumbPath)
+    QString info = QString("[Thumbnail] %1 exif=%2 req=%3 size=%4x%5 %6ms")
+                       .arg(fileInfo.fileName())
                        .arg(exifThumb ? "yes" : "no")
+                       .arg(request.size)
                        .arg(res.thumb.width())
                        .arg(res.thumb.height())
                        .arg(dt.elapsed());

--- a/ImageLounge/src/DkCore/DkThumbs.cpp
+++ b/ImageLounge/src/DkCore/DkThumbs.cpp
@@ -29,7 +29,6 @@
 
 #include "DkBasicLoader.h"
 #include "DkFileInfo.h"
-#include "DkImageStorage.h"
 #include "DkMetaData.h"
 #include "DkSettings.h"
 #include "DkTimer.h"
@@ -246,13 +245,13 @@ DkThumbLoader::LoadThumbnailResultLocal DkThumbLoader::loadThumbnailLocal(const 
     if (!res) {
         return {request, QImage(), false, false};
     }
-    return {request, DkImage::createThumb(res->thumb, request.size), true, res->fromExif};
+    return {request, DkImage::createThumb(res->thumb, request.size, request.constraint), true, res->fromExif};
 }
 
 DkThumbLoader::LoadThumbnailResultLocal DkThumbLoader::scaleFullThumbnail(const LoadThumbnailRequest &request,
                                                                           const QImage &img)
 {
-    return {request, DkImage::createThumb(img), true, false};
+    return {request, DkImage::createThumb(img, request.size, request.constraint), true, false};
 }
 
 void DkThumbLoader::requestThumbnail(const LoadThumbnailRequest &request)
@@ -348,13 +347,18 @@ void DkThumbLoader::handleFinishedWatcher(QFutureWatcher<LoadThumbnailResultLoca
     mIdleWatchers.push_back(w);
 }
 
-LoadThumbnailRequest::LoadThumbnailRequest(const QString &filePath_, LoadThumbnailOption option_, int size_)
+LoadThumbnailRequest::LoadThumbnailRequest(const QString &filePath_,
+                                           LoadThumbnailOption option_,
+                                           int size_,
+                                           ScaleConstraint constraint_)
     : filePath(filePath_)
     , option(option_)
     , size(size_)
+    , constraint(constraint_)
 {
     QString key = filePath;
     key += QString::number(static_cast<int>(option));
+    key += QString::number(static_cast<int>(constraint_));
     key += QString::number(size);
 
     id = qHash(key);

--- a/ImageLounge/src/DkCore/DkThumbs.cpp
+++ b/ImageLounge/src/DkCore/DkThumbs.cpp
@@ -85,16 +85,16 @@ std::optional<QImage> loadThumbnailFromFullImage(const QString &filePath, QShare
     }
 }
 
-std::optional<LoadThumbnailResult> loadThumbnail(const QString &filePath, LoadThumbnailOption opt)
+std::optional<LoadThumbnailResult> loadThumbnail(const LoadThumbnailRequest &request)
 {
     DkTimer dt{};
 
     auto metaData = std::make_unique<DkMetaDataT>();
     QSharedPointer<QByteArray> ba{};
-    DkFileInfo fileInfo(filePath);
+    DkFileInfo fileInfo(request.filePath);
 
     if (fileInfo.isSymLink() && !fileInfo.resolveSymLink()) {
-        qWarning() << "[Thumbnail] broken link:" << filePath;
+        qWarning() << "[Thumbnail] broken link:" << request.filePath;
         return std::nullopt;
     }
 
@@ -236,68 +236,69 @@ DkThumbLoader::DkThumbLoader()
     }
 }
 
-DkThumbLoader::LoadThumbnailResultLocal DkThumbLoader::loadThumbnailLocal(const QString &filePath)
+DkThumbLoader::LoadThumbnailResultLocal DkThumbLoader::loadThumbnailLocal(const LoadThumbnailRequest &request)
 {
-    const auto res = loadThumbnail(filePath, LoadThumbnailOption::none);
+    const auto res = loadThumbnail(request);
     if (!res) {
-        return {QImage(), filePath, false, false};
+        return {request, QImage(), false, false};
     }
-    return {DkImage::createThumb(res->thumb), filePath, true, res->fromExif};
+    return {request, DkImage::createThumb(res->thumb, request.size), true, res->fromExif};
 }
 
-DkThumbLoader::LoadThumbnailResultLocal DkThumbLoader::scaleFullThumbnail(const QString &filePath, const QImage &img)
+DkThumbLoader::LoadThumbnailResultLocal DkThumbLoader::scaleFullThumbnail(const LoadThumbnailRequest &request,
+                                                                          const QImage &img)
 {
-    return {DkImage::createThumb(img), filePath, true, false};
+    return {request, DkImage::createThumb(img), true, false};
 }
 
-void DkThumbLoader::requestThumbnail(const QString &filePath)
+void DkThumbLoader::requestThumbnail(const LoadThumbnailRequest &request)
 {
-    const auto *cached = mThumbnailCache.object(filePath);
+    const auto *cached = mThumbnailCache.object(request.id);
     if (cached) {
         if (!cached->valid) {
-            emit thumbnailLoadFailed(cached->filePath);
+            emit thumbnailLoadFailed(cached->request.filePath);
             return;
         }
 
-        emit thumbnailLoaded(cached->filePath, cached->thumb, cached->fromExif);
+        emit thumbnailLoaded(cached->request.filePath, cached->thumb, cached->fromExif);
         return;
     }
 
     if (mIdleWatchers.size() == 0) {
-        const int count = mCounts.value(filePath, 0);
+        const int count = mCounts.value(request.id, 0);
         if (count == 0) {
-            mQueue.push(filePath);
+            mQueue.push(request);
         }
-        mCounts.insert(filePath, count + 1);
+        mCounts.insert(request.id, count + 1);
         return;
     }
 
     auto *w = mIdleWatchers.back();
     mIdleWatchers.pop_back();
-    w->setFuture(QtConcurrent::run(loadThumbnailLocal, filePath));
+    w->setFuture(QtConcurrent::run(loadThumbnailLocal, request));
 }
 
-void DkThumbLoader::cancelThumbnailRequest(const QString &filePath)
+void DkThumbLoader::cancelThumbnailRequest(const LoadThumbnailRequest &request)
 {
-    auto it = mCounts.find(filePath);
+    auto it = mCounts.find(request.id);
     if (it == mCounts.end()) {
         return;
     }
     it.value() -= 1;
 }
 
-void DkThumbLoader::dispatchFullImage(const QString &filePath, const QImage &img)
+void DkThumbLoader::dispatchFullImage(const LoadThumbnailRequest &request, const QImage &img)
 {
     if (mIdleWatchers.size() == 0) {
         // Full image takes priority, so we can skip the pending requests
-        mCounts.remove(filePath);
-        mFullImageQueue.push({img, filePath, true, false});
+        mCounts.remove(request.id);
+        mFullImageQueue.push({request, img, true, false});
         return;
     }
 
     auto *w = mIdleWatchers.back();
     mIdleWatchers.pop_back();
-    w->setFuture(QtConcurrent::run(scaleFullThumbnail, filePath, img));
+    w->setFuture(QtConcurrent::run(scaleFullThumbnail, request, img));
 }
 
 void DkThumbLoader::onThumbnailLoadFinished()
@@ -306,40 +307,52 @@ void DkThumbLoader::onThumbnailLoadFinished()
     Q_ASSERT(w != nullptr);
 
     auto *res = new LoadThumbnailResultLocal{w->result()};
+    const size_t resSize = sizeof(*res) + res->sizeInBytes();
 
     handleFinishedWatcher(w);
 
     if (!res->valid) { // NOLINT(clang-analyzer-core.uninitialized.Branch) -- false positive
-        emit thumbnailLoadFailed(res->filePath);
-        mThumbnailCache.insert(res->filePath, res, 1 + res->filePath.size());
+        emit thumbnailLoadFailed(res->request.filePath);
+        mThumbnailCache.insert(res->request.id, res, resSize);
         return;
     }
 
-    emit thumbnailLoaded(res->filePath, res->thumb, res->fromExif);
+    emit thumbnailLoaded(res->request.filePath, res->thumb, res->fromExif);
 
     // Add cache after finished using res because the cache takes ownership.
-    // Add 1 to avoid zero cost.
-    mThumbnailCache.insert(res->filePath, res, 1 + res->filePath.size() + res->thumb.sizeInBytes());
+    mThumbnailCache.insert(res->request.id, res, resSize);
 }
 
 void DkThumbLoader::handleFinishedWatcher(QFutureWatcher<LoadThumbnailResultLocal> *w)
 {
     if (mFullImageQueue.size() > 0) {
         const LoadThumbnailResultLocal &item = mFullImageQueue.front();
-        w->setFuture(QtConcurrent::run(scaleFullThumbnail, item.filePath, item.thumb));
+        w->setFuture(QtConcurrent::run(scaleFullThumbnail, item.request, item.thumb));
         mFullImageQueue.pop();
         return;
     }
 
     while (mQueue.size() > 0) {
-        const QString filePath = mQueue.front();
+        const auto request = mQueue.front();
         mQueue.pop();
-        if (mCounts.value(filePath, 0) > 0) {
-            mCounts.remove(filePath);
-            w->setFuture(QtConcurrent::run(loadThumbnailLocal, filePath));
+        if (mCounts.value(request.id, 0) > 0) {
+            mCounts.remove(request.id);
+            w->setFuture(QtConcurrent::run(loadThumbnailLocal, request));
             return;
         }
     }
     mIdleWatchers.push_back(w);
+}
+
+LoadThumbnailRequest::LoadThumbnailRequest(const QString &filePath_, LoadThumbnailOption option_, int maxSize_)
+    : filePath(filePath_)
+    , option(option_)
+    , size(maxSize_)
+{
+    QString key = filePath;
+    key += QString::number(static_cast<int>(option));
+    key += QString::number(size);
+
+    id = qHash(key);
 }
 }

--- a/ImageLounge/src/DkCore/DkThumbs.cpp
+++ b/ImageLounge/src/DkCore/DkThumbs.cpp
@@ -102,7 +102,8 @@ std::optional<LoadThumbnailResult> loadThumbnail(const LoadThumbnailRequest &req
     std::optional<QImage> fullThumb{};
     std::unique_ptr<DkCachedThumb> cachedThumb{};
 
-    if (request.option != LoadThumbnailOption::force_full
+    if (request.option != LoadThumbnailOption::force_full //
+        && DkSettingsManager::param().resources().thumbDiskCache
         && DkSettingsManager::param().resources().thumbDiskSpace > 0) {
         cachedThumb = std::make_unique<DkCachedThumb>(fileInfo, request.size, request.constraint);
         QImage thumb = cachedThumb->load();

--- a/ImageLounge/src/DkCore/DkThumbs.h
+++ b/ImageLounge/src/DkCore/DkThumbs.h
@@ -65,6 +65,9 @@ enum class LoadThumbnailOption {
     // Only load EXIF thumbnail.
     force_exif,
 
+    // Return requested size if smaller than full image
+    force_size,
+
     // Only load full image.
     force_full,
 };

--- a/ImageLounge/src/DkCore/DkThumbs.h
+++ b/ImageLounge/src/DkCore/DkThumbs.h
@@ -58,14 +58,6 @@ private:
     QThreadPool *mPool;
 };
 
-struct LoadThumbnailResult {
-    QImage thumb{};
-    QString filePath{};
-    std::unique_ptr<DkMetaDataT> metaData{};
-    bool fromExif{};
-    bool transformed{};
-};
-
 enum class LoadThumbnailOption {
     // Try to load EXIF thumbnail first, and fall back to full image if not exist.
     none,
@@ -77,7 +69,35 @@ enum class LoadThumbnailOption {
     force_full,
 };
 
-std::optional<LoadThumbnailResult> loadThumbnail(const QString &filePath, LoadThumbnailOption opt);
+using ThumbnailId = size_t;
+
+struct LoadThumbnailRequest {
+    ThumbnailId id{};
+    QString filePath{};
+    LoadThumbnailOption option{};
+    int size{};
+
+    LoadThumbnailRequest() = default;
+
+    explicit LoadThumbnailRequest(const QString &filePath,
+                                  LoadThumbnailOption option = LoadThumbnailOption::none,
+                                  int maxSize = 400);
+
+    size_t sizeInBytes() const
+    {
+        return filePath.length() * 2;
+    }
+};
+
+struct LoadThumbnailResult {
+    QImage thumb{};
+    QString filePath{};
+    std::unique_ptr<DkMetaDataT> metaData{};
+    bool fromExif{};
+    bool transformed{};
+};
+
+std::optional<LoadThumbnailResult> loadThumbnail(const LoadThumbnailRequest &request);
 
 struct ThumbnailFromMetadata {
     QImage thumb{};
@@ -91,37 +111,42 @@ class DkThumbLoader : public QObject
     Q_OBJECT
 
     struct LoadThumbnailResultLocal {
+        LoadThumbnailRequest request;
         QImage thumb{};
-        QString filePath{};
         bool valid{};
         bool fromExif{};
+
+        size_t sizeInBytes() const
+        {
+            return request.sizeInBytes() + thumb.sizeInBytes();
+        }
     };
 
-    QCache<QString, LoadThumbnailResultLocal> mThumbnailCache{100000000}; // 100 MB
+    QCache<ThumbnailId, LoadThumbnailResultLocal> mThumbnailCache{100000000}; // 100 MB
     std::vector<QFutureWatcher<LoadThumbnailResultLocal>> mWatchers{};
     std::vector<QFutureWatcher<LoadThumbnailResultLocal> *> mIdleWatchers{};
-    std::queue<QString> mQueue{};
+    std::queue<LoadThumbnailRequest> mQueue{};
     std::queue<LoadThumbnailResultLocal> mFullImageQueue{};
-    QHash<QString, int> mCounts{};
+    QHash<ThumbnailId, int> mCounts{};
 
 public:
     DkThumbLoader();
-    void requestThumbnail(const QString &filePath);
-    void cancelThumbnailRequest(const QString &filePath);
+    void requestThumbnail(const LoadThumbnailRequest &request);
+    void cancelThumbnailRequest(const LoadThumbnailRequest &request);
 
     // When we have full image loaded in the viewport,
     // create a side effect to update the thumbnail.
-    void dispatchFullImage(const QString &filePath, const QImage &img);
+    void dispatchFullImage(const LoadThumbnailRequest &request, const QImage &img);
 
 signals:
+    // TODO: signals should return request object or id
     void thumbnailLoaded(const QString &filePath, const QImage &thumb, bool fromExif);
     void thumbnailLoadFailed(const QString &filePath);
-    void thumbnailRequested(const QString &filePath, LoadThumbnailOption opt = LoadThumbnailOption::force_exif);
 
 private:
     void onThumbnailLoadFinished();
-    static LoadThumbnailResultLocal loadThumbnailLocal(const QString &filePath);
-    static LoadThumbnailResultLocal scaleFullThumbnail(const QString &filePath, const QImage &img);
+    static LoadThumbnailResultLocal loadThumbnailLocal(const LoadThumbnailRequest &request);
+    static LoadThumbnailResultLocal scaleFullThumbnail(const LoadThumbnailRequest &request, const QImage &img);
     void handleFinishedWatcher(QFutureWatcher<LoadThumbnailResultLocal> *w);
 };
 }

--- a/ImageLounge/src/DkCore/DkThumbs.h
+++ b/ImageLounge/src/DkCore/DkThumbs.h
@@ -130,7 +130,6 @@ class DkThumbLoader : public QObject
     std::vector<QFutureWatcher<LoadThumbnailResultLocal>> mWatchers{};
     std::vector<QFutureWatcher<LoadThumbnailResultLocal> *> mIdleWatchers{};
     std::queue<LoadThumbnailRequest> mQueue{};
-    std::queue<LoadThumbnailResultLocal> mFullImageQueue{};
     QHash<ThumbnailId, int> mCounts{};
 
 public:
@@ -146,10 +145,6 @@ public:
     // or multiple requests are made to the same thumb, signals will still be sent.
     void cancelThumbnailRequest(const LoadThumbnailRequest &request);
 
-    // When we have full image loaded in the viewport,
-    // create a side effect to update the thumbnail.
-    void dispatchFullImage(const LoadThumbnailRequest &request, const QImage &img);
-
 signals:
     // Always send one of these signals on completion. Cancellation does not guarantee these won't be sent
     void thumbnailLoaded(ThumbnailId id, const QString &filePath, const QImage &thumb, bool fromExif);
@@ -158,7 +153,6 @@ signals:
 private:
     void onThumbnailLoadFinished();
     static LoadThumbnailResultLocal loadThumbnailLocal(const LoadThumbnailRequest &request);
-    static LoadThumbnailResultLocal scaleFullThumbnail(const LoadThumbnailRequest &request, const QImage &img);
     void handleFinishedWatcher(QFutureWatcher<LoadThumbnailResultLocal> *w);
 };
 }

--- a/ImageLounge/src/DkCore/DkThumbs.h
+++ b/ImageLounge/src/DkCore/DkThumbs.h
@@ -145,9 +145,8 @@ public:
     void dispatchFullImage(const LoadThumbnailRequest &request, const QImage &img);
 
 signals:
-    // TODO: signals should return request object or id
-    void thumbnailLoaded(const QString &filePath, const QImage &thumb, bool fromExif);
-    void thumbnailLoadFailed(const QString &filePath);
+    void thumbnailLoaded(ThumbnailId id, const QString &filePath, const QImage &thumb, bool fromExif);
+    void thumbnailLoadFailed(ThumbnailId id, const QString &filePath);
 
 private:
     void onThumbnailLoadFinished();

--- a/ImageLounge/src/DkCore/DkThumbs.h
+++ b/ImageLounge/src/DkCore/DkThumbs.h
@@ -82,9 +82,9 @@ struct LoadThumbnailRequest {
 
     LoadThumbnailRequest() = default;
 
-    explicit LoadThumbnailRequest(const QString &filePath,
-                                  LoadThumbnailOption option = LoadThumbnailOption::none,
-                                  int maxSize = 400);
+    explicit LoadThumbnailRequest(const QString &filePath_,
+                                  LoadThumbnailOption option_ = {},
+                                  int size_ = max_thumb_size);
 
     size_t sizeInBytes() const
     {

--- a/ImageLounge/src/DkCore/DkThumbs.h
+++ b/ImageLounge/src/DkCore/DkThumbs.h
@@ -128,7 +128,7 @@ class DkThumbLoader : public QObject
         }
     };
 
-    QCache<ThumbnailId, LoadThumbnailResultLocal> mThumbnailCache{100000000}; // 100 MB
+    QCache<ThumbnailId, LoadThumbnailResultLocal> mThumbnailCache{};
     std::vector<QFutureWatcher<LoadThumbnailResultLocal>> mWatchers{};
     std::vector<QFutureWatcher<LoadThumbnailResultLocal> *> mIdleWatchers{};
     std::queue<LoadThumbnailRequest> mQueue{};

--- a/ImageLounge/src/DkCore/DkThumbs.h
+++ b/ImageLounge/src/DkCore/DkThumbs.h
@@ -34,6 +34,7 @@
 #include <optional>
 #include <queue>
 
+#include "DkImageStorage.h"
 #include "DkMetaData.h"
 
 class QThreadPool;
@@ -79,12 +80,14 @@ struct LoadThumbnailRequest {
     QString filePath{};
     LoadThumbnailOption option{};
     int size{};
+    ScaleConstraint constraint{};
 
     LoadThumbnailRequest() = default;
 
     explicit LoadThumbnailRequest(const QString &filePath_,
                                   LoadThumbnailOption option_ = {},
-                                  int size_ = max_thumb_size);
+                                  int size_ = max_thumb_size,
+                                  ScaleConstraint constraint_ = {});
 
     size_t sizeInBytes() const
     {

--- a/ImageLounge/src/DkCore/DkThumbs.h
+++ b/ImageLounge/src/DkCore/DkThumbs.h
@@ -42,8 +42,6 @@ class QThreadPool;
 namespace nmc
 {
 
-#define max_thumb_size 400
-
 class DkThumbsThreadPool
 {
 public:
@@ -86,7 +84,7 @@ struct LoadThumbnailRequest {
 
     explicit LoadThumbnailRequest(const QString &filePath_,
                                   LoadThumbnailOption option_ = {},
-                                  int size_ = max_thumb_size,
+                                  int size_ = -1,
                                   ScaleConstraint constraint_ = {});
 
     size_t sizeInBytes() const

--- a/ImageLounge/src/DkCore/DkThumbs.h
+++ b/ImageLounge/src/DkCore/DkThumbs.h
@@ -135,7 +135,15 @@ class DkThumbLoader : public QObject
 
 public:
     DkThumbLoader();
+
+    // Increase refcount on this request, signal sent on completion or failure.
+    // If request is cached, send signal immediately
+    // No signal is sent if request is cancelled while waiting, but once
+    // it hits the thread pool no cancellation is possible.
     void requestThumbnail(const LoadThumbnailRequest &request);
+
+    // Decrease the refcount on this request. If the request is in the thread pool
+    // or multiple requests are made to the same thumb, signals will still be sent.
     void cancelThumbnailRequest(const LoadThumbnailRequest &request);
 
     // When we have full image loaded in the viewport,
@@ -143,6 +151,7 @@ public:
     void dispatchFullImage(const LoadThumbnailRequest &request, const QImage &img);
 
 signals:
+    // Always send one of these signals on completion. Cancellation does not guarantee these won't be sent
     void thumbnailLoaded(ThumbnailId id, const QString &filePath, const QImage &thumb, bool fromExif);
     void thumbnailLoadFailed(ThumbnailId id, const QString &filePath);
 

--- a/ImageLounge/src/DkGui/DkCentralWidget.cpp
+++ b/ImageLounge/src/DkGui/DkCentralWidget.cpp
@@ -800,7 +800,7 @@ void DkCentralWidget::imageLoaded(QSharedPointer<DkImageContainerT> img)
         switchWidget(tabInfo->getMode());
     }
 
-    if (img && !img->isEdited()) {
+    if (img && !img->isEdited() && !DkSettingsManager::param().display().highQualityThumbs) {
         mThumbLoader.dispatchFullImage(LoadThumbnailRequest{img->filePath()}, img->pixmap());
     }
 }

--- a/ImageLounge/src/DkGui/DkCentralWidget.cpp
+++ b/ImageLounge/src/DkGui/DkCentralWidget.cpp
@@ -880,8 +880,11 @@ void DkCentralWidget::showViewPort(bool show /* = true */)
         switchWidget(mWidgets[viewport_widget]);
         if (getCurrentImage())
             getViewPort()->setImage(getCurrentImage()->image());
-    } else if (hasViewPort())
+        getViewPort()->show();
+    } else if (hasViewPort()) {
         getViewPort()->deactivate();
+        getViewPort()->hide();
+    }
 }
 
 void DkCentralWidget::showRecentFiles(bool show)

--- a/ImageLounge/src/DkGui/DkCentralWidget.cpp
+++ b/ImageLounge/src/DkGui/DkCentralWidget.cpp
@@ -833,11 +833,17 @@ void DkCentralWidget::showThumbView(bool show)
         auto tw = getThumbScrollWidget();
         Q_ASSERT(tw);
 
-        tw->updateThumbs(tabInfo->getImageLoader()->getImages());
-        tw->getThumbWidget()->setImageLoader(tabInfo->getImageLoader());
+        auto imageLoader = tabInfo->getImageLoader();
 
-        if (tabInfo->getImage())
-            tw->getThumbWidget()->ensureVisible(tabInfo->getImage()->filePath());
+        tw->getThumbWidget()->setImageLoader(imageLoader);
+
+        if (imageLoader) {
+            tw->updateThumbs(imageLoader->getImages());
+
+            auto image = imageLoader->getCurrentImage();
+            if (image)
+                tw->getThumbWidget()->ensureVisible(image->filePath());
+        }
 
         connect(tw,
                 &DkThumbScrollWidget::updateDirSignal,

--- a/ImageLounge/src/DkGui/DkCentralWidget.cpp
+++ b/ImageLounge/src/DkGui/DkCentralWidget.cpp
@@ -877,6 +877,7 @@ void DkCentralWidget::showViewPort(bool show /* = true */)
             getViewPort()->setImage(getCurrentImage()->image());
         getViewPort()->show();
     } else if (hasViewPort()) {
+        getViewPort()->getController()->getFilePreview()->cancelLoading();
         getViewPort()->deactivate();
         getViewPort()->hide();
     }

--- a/ImageLounge/src/DkGui/DkCentralWidget.cpp
+++ b/ImageLounge/src/DkGui/DkCentralWidget.cpp
@@ -37,7 +37,6 @@
 #include "DkMessageBox.h"
 #include "DkPreferenceWidgets.h"
 #include "DkSettings.h"
-#include "DkThumbs.h"
 #include "DkThumbsWidgets.h"
 #include "DkUtils.h"
 #include "DkViewPort.h"
@@ -799,10 +798,6 @@ void DkCentralWidget::imageLoaded(QSharedPointer<DkImageContainerT> img)
 
         updateTab(tabInfo);
         switchWidget(tabInfo->getMode());
-    }
-
-    if (img && !img->isEdited() && !DkSettingsManager::param().display().highQualityThumbs) {
-        mThumbLoader.dispatchFullImage(LoadThumbnailRequest{img->filePath()}, img->pixmap());
     }
 }
 

--- a/ImageLounge/src/DkGui/DkCentralWidget.cpp
+++ b/ImageLounge/src/DkGui/DkCentralWidget.cpp
@@ -801,7 +801,7 @@ void DkCentralWidget::imageLoaded(QSharedPointer<DkImageContainerT> img)
     }
 
     if (img && !img->isEdited()) {
-        mThumbLoader.dispatchFullImage(img->filePath(), img->pixmap());
+        mThumbLoader.dispatchFullImage(LoadThumbnailRequest{img->filePath()}, img->pixmap());
     }
 }
 

--- a/ImageLounge/src/DkGui/DkCentralWidget.cpp
+++ b/ImageLounge/src/DkGui/DkCentralWidget.cpp
@@ -829,26 +829,26 @@ void DkCentralWidget::showThumbView(bool show)
         switchWidget(thumbs_widget);
         tabInfo->activate();
 
-        // should be definitely true
-        if (auto tw = getThumbScrollWidget()) {
-            tw->updateThumbs(tabInfo->getImageLoader()->getImages());
-            tw->getThumbWidget()->setImageLoader(tabInfo->getImageLoader());
+        auto tw = getThumbScrollWidget();
+        Q_ASSERT(tw);
 
-            if (tabInfo->getImage())
-                tw->getThumbWidget()->ensureVisible(tabInfo->getImage()->filePath());
+        tw->updateThumbs(tabInfo->getImageLoader()->getImages());
+        tw->getThumbWidget()->setImageLoader(tabInfo->getImageLoader());
 
-            connect(tw,
-                    &DkThumbScrollWidget::updateDirSignal,
-                    tabInfo->getImageLoader().data(),
-                    &DkImageLoader::loadDirRecursive,
-                    Qt::UniqueConnection);
-            connect(tw,
-                    &DkThumbScrollWidget::filterChangedSignal,
-                    tabInfo->getImageLoader().data(),
-                    &DkImageLoader::setFolderFilter,
-                    Qt::UniqueConnection);
-            emit thumbViewLoadedSignal(tabInfo->getImageLoader().data()->getDirPath());
-        }
+        if (tabInfo->getImage())
+            tw->getThumbWidget()->ensureVisible(tabInfo->getImage()->filePath());
+
+        connect(tw,
+                &DkThumbScrollWidget::updateDirSignal,
+                tabInfo->getImageLoader().data(),
+                &DkImageLoader::loadDirRecursive,
+                Qt::UniqueConnection);
+        connect(tw,
+                &DkThumbScrollWidget::filterChangedSignal,
+                tabInfo->getImageLoader().data(),
+                &DkImageLoader::setFolderFilter,
+                Qt::UniqueConnection);
+        emit thumbViewLoadedSignal(tabInfo->getImageLoader().data()->getDirPath());
 
     } else {
         if (auto tw = getThumbScrollWidget()) {

--- a/ImageLounge/src/DkGui/DkCentralWidget.cpp
+++ b/ImageLounge/src/DkGui/DkCentralWidget.cpp
@@ -167,7 +167,8 @@ void DkTabInfo::deactivate()
 
 void DkTabInfo::activate(bool isActive)
 {
-    if (mImageLoader)
+    // on thumb preview causes duplicate updates which are very slow for large directories
+    if (mImageLoader && mTabMode != tab_thumb_preview)
         mImageLoader->activate(isActive);
 }
 

--- a/ImageLounge/src/DkGui/DkControlWidget.cpp
+++ b/ImageLounge/src/DkGui/DkControlWidget.cpp
@@ -78,15 +78,6 @@ DkControlWidget::DkControlWidget(DkThumbLoader *thumbLoader, DkViewPort *parent,
     mBottomLabel = new DkLabelBg("", this);
     mBottomLeftLabel = new DkLabelBg("", this);
 
-    // wheel label
-    QPixmap wp = QPixmap(":/nomacs/img/thumbs-move.svg");
-
-    mWheelButton = new QLabel(this);
-    mWheelButton->setAttribute(Qt::WA_TransparentForMouseEvents);
-    mWheelButton->setPixmap(wp);
-    mWheelButton->adjustSize();
-    mWheelButton->hide();
-
     // image histogram
     mHistogram = new DkHistogramWidget(this);
 
@@ -846,17 +837,6 @@ DkFolderScrollBar *DkControlWidget::getScroller() const
 // DkControlWidget - Events --------------------------------------------------------------------
 void DkControlWidget::mousePressEvent(QMouseEvent *event)
 {
-    mEnterPos = event->pos();
-
-    if (mFilePreview && mFilePreview->isVisible() && event->buttons() == Qt::MiddleButton) {
-        QTimer *mImgTimer = mFilePreview->getMoveImageTimer();
-        mImgTimer->start(1);
-
-        // show icon
-        mWheelButton->move(event->pos().x() - 16, event->pos().y() - 16);
-        mWheelButton->show();
-    }
-
     if (mPluginViewport)
         QCoreApplication::sendEvent(mPluginViewport, event);
     else
@@ -865,13 +845,6 @@ void DkControlWidget::mousePressEvent(QMouseEvent *event)
 
 void DkControlWidget::mouseReleaseEvent(QMouseEvent *event)
 {
-    if (mFilePreview && mFilePreview->isVisible()) {
-        mFilePreview->setCurrentDx(0);
-        QTimer *mImgTimer = mFilePreview->getMoveImageTimer();
-        mImgTimer->stop();
-        mWheelButton->hide();
-    }
-
     if (mPluginViewport)
         QCoreApplication::sendEvent(mPluginViewport, event);
     else
@@ -880,16 +853,6 @@ void DkControlWidget::mouseReleaseEvent(QMouseEvent *event)
 
 void DkControlWidget::mouseMoveEvent(QMouseEvent *event)
 {
-    // scroll thumbs preview
-    if (mFilePreview && mFilePreview->isVisible() && event->buttons() == Qt::MiddleButton) {
-        float dx = (float)std::fabs(mEnterPos.x() - event->pos().x()) * 0.015f;
-        dx = std::exp(dx);
-        if (mEnterPos.x() - event->pos().x() < 0)
-            dx = -dx;
-
-        mFilePreview->setCurrentDx(dx); // update dx
-    }
-
     if (mPluginViewport)
         QCoreApplication::sendEvent(mPluginViewport, event);
     else

--- a/ImageLounge/src/DkGui/DkControlWidget.h
+++ b/ImageLounge/src/DkGui/DkControlWidget.h
@@ -199,9 +199,5 @@ protected:
     DkPluginViewPort *mPluginViewport = nullptr;
 
     QSharedPointer<DkImageContainerT> mImgC;
-
-    QLabel *mWheelButton;
-
-    QPointF mEnterPos;
 };
 }

--- a/ImageLounge/src/DkGui/DkDialog.cpp
+++ b/ImageLounge/src/DkGui/DkDialog.cpp
@@ -3263,7 +3263,7 @@ int DkMosaicDialog::computeMosaic(const QString &filter, const QString &suffix, 
         }
 
         try {
-            std::optional<LoadThumbnailResult> thumb = loadThumbnail(imgPath, LoadThumbnailOption::none);
+            std::optional<LoadThumbnailResult> thumb = loadThumbnail(LoadThumbnailRequest{imgPath});
             if (thumb) {
                 thumb->thumb = DkImage::createThumb(thumb->thumb);
             }

--- a/ImageLounge/src/DkGui/DkMetaDataWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkMetaDataWidgets.cpp
@@ -481,6 +481,7 @@ void DkMetaDataDock::setImage(QSharedPointer<DkImageContainerT> imgC)
     }
 
     QImage thumbImg = res->thumb;
+    thumbImg.setDevicePixelRatio(devicePixelRatio());
 
     const QSize tSize = thumbImg.size();
     const qint64 tSizeBytes = thumbImg.sizeInBytes();

--- a/ImageLounge/src/DkGui/DkNoMacs.cpp
+++ b/ImageLounge/src/DkGui/DkNoMacs.cpp
@@ -728,6 +728,8 @@ void DkNoMacs::restartFrameless(bool)
     QString exe = QApplication::applicationFilePath();
     QStringList args;
 
+    args << "--skip-startup";
+
     if (objectName() != "DkNoMacsFrameless")
         args << "-m" << "frameless";
     else
@@ -1544,6 +1546,8 @@ void DkNoMacs::newInstance(const QString &filePath)
 
     auto *a = static_cast<QAction *>(sender());
 
+    args << "--skip-startup";
+
     if (a && a == DkActionManager::instance().action(DkActionManager::menu_file_private_instance))
         args.append("-p");
 
@@ -1574,6 +1578,8 @@ void DkNoMacs::restartWithPseudoColor(bool contrast)
 
     QString exe = QApplication::applicationFilePath();
     QStringList args;
+
+    args << "--skip-startup";
 
     if (contrast)
         args << "-m" << "pseudocolor";

--- a/ImageLounge/src/DkGui/DkPreferenceWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkPreferenceWidgets.cpp
@@ -1219,9 +1219,10 @@ void DkFilePreference::createLayout()
     auto *sharedBox = new QCheckBox(tr("Share thumbnails with other programs"), this);
     sharedBox->setToolTip(tr("Thumbnails created by other software will be used by nomacs, and vice versa."));
     sharedBox->setChecked(res.sharedThumbs);
-#ifndef Q_OS_UNIX
+#if defined(Q_OS_MACOS) || defined(Q_OS_WIN)
     sharedBox->setEnabled(false);
 #endif
+
     connect(sharedBox, &QCheckBox::toggled, this, [this, &res](bool checked) {
         // if sharing is disabled, offer to cleanup the non-shared area
         const QString cachePath = DkCachedThumb::cacheHome();

--- a/ImageLounge/src/DkGui/DkPreferenceWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkPreferenceWidgets.cpp
@@ -1256,7 +1256,7 @@ void DkFilePreference::createLayout()
     thumbCacheGroup->setToolTip(tr("Save generated thumbnails to disk for future use."));
     thumbCacheGroup->setCheckable(true);
     thumbCacheGroup->setChecked(res.thumbDiskCache);
-    connect(thumbCacheGroup, &QGroupBox::clicked, [&](bool checked) {
+    connect(thumbCacheGroup, &QGroupBox::clicked, [this, &res](bool checked) {
         res.thumbDiskCache = checked;
         showRestartLabel();
     });

--- a/ImageLounge/src/DkGui/DkPreferenceWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkPreferenceWidgets.cpp
@@ -29,6 +29,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "DkPreferenceWidgets.h"
 
 #include "DkBasicWidgets.h"
+#include "DkCachedThumb.h"
 #include "DkDialog.h"
 #include "DkImageStorage.h"
 #include "DkSettings.h"
@@ -42,6 +43,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <QColorSpace>
 #include <QComboBox>
 #include <QFileDialog>
+#include <QGroupBox>
 #include <QHeaderView>
 #include <QMessageBox>
 #include <QPainter>
@@ -810,16 +812,6 @@ void DkDisplayPreference::createLayout()
     keepZoomGroup->addWidget(keepZoomButtons[DkSettings::zoom_never_keep]);
     keepZoomGroup->addWidget(keepZoomButtons[DkSettings::zoom_always_fit]);
 
-    auto *enableHqThumbs = new QCheckBox(tr("Enable High Quality Thumbnails"));
-    enableHqThumbs->setChecked(DkSettingsManager::param().display().highQualityThumbs);
-    enableHqThumbs->setToolTip(tr("If checked, use the full-resolution image if EXIF thumbnail is too small."));
-    connect(enableHqThumbs, &QCheckBox::toggled, this, [](bool checked) {
-        DkSettingsManager::param().display().highQualityThumbs = checked;
-    });
-
-    auto *thumbsGroup = new DkGroupWidget(tr("Thumbnails"), this);
-    thumbsGroup->addWidget(enableHqThumbs);
-
     mColorProfiles = new QComboBox(this);
     mColorProfiles->setToolTip(tr("Choose the color profile of the monitor"));
     connect(mColorProfiles, &QComboBox::activated, this, &DkDisplayPreference::onColorProfileActivated);
@@ -948,7 +940,6 @@ void DkDisplayPreference::createLayout()
     l->setAlignment(Qt::AlignTop);
     l->addWidget(zoomGroup);
     l->addWidget(keepZoomGroup);
-    l->addWidget(thumbsGroup);
     l->addWidget(colorGroup);
     l->addWidget(iconGroup);
     l->addWidget(navigationGroup);
@@ -1162,6 +1153,129 @@ void DkFilePreference::createLayout()
     historyGroup->addWidget(historyBox);
     historyGroup->addWidget(hLabel);
 
+    // thumbnails
+    auto &res = DkSettingsManager::param().resources();
+
+    auto *enableHqThumbs = new QCheckBox(tr("Use high-quality thumbnails"));
+    enableHqThumbs->setToolTip(tr("Use antialiasing and avoid upsampling."));
+    enableHqThumbs->setChecked(DkSettingsManager::param().display().highQualityThumbs);
+    connect(enableHqThumbs, &QCheckBox::toggled, this, [](bool checked) {
+        DkSettingsManager::param().display().highQualityThumbs = checked;
+    });
+
+    auto *preloadBox = new QCheckBox(tr("Preload thumbnails"), this);
+    preloadBox->setToolTip(
+        tr("Compute a limited number of thumbnails before they are needed. Reduces delays but uses more memory."));
+    preloadBox->setChecked(res.preloadThumbs);
+    connect(preloadBox, &QCheckBox::toggled, this, [](bool checked) {
+        DkSettingsManager::param().resources().preloadThumbs = checked;
+    });
+
+    auto *sizesBox = new QComboBox(this);
+    sizesBox->setToolTip(
+        tr("Limit the size of thumbnails to conserve resources. Zooming above this size will be disabled or will lose "
+           "sharpness."));
+    sizesBox->setMaximumWidth(200);
+    for (int px = 128; px <= 1024; px *= 2) {
+        sizesBox->addItem(QString("%1 px").arg(px), px);
+    }
+    sizesBox->setCurrentIndex(sizesBox->findData(res.maxThumbSize));
+    connect(sizesBox, &QComboBox::currentIndexChanged, this, [sizesBox](int) {
+        DkSettingsManager::param().resources().maxThumbSize = sizesBox->currentData().toInt();
+    });
+
+    auto *thumbThreads = new DkSlider(tr("Thumbnail threads"), this);
+    thumbThreads->setToolTip(tr("Limit temporary memory and CPU used to generate thumbnails."));
+    thumbThreads->setMaximumWidth(500);
+    thumbThreads->setRange(1, QThread::idealThreadCount() - 2);
+    thumbThreads->setValue(res.thumbThreads);
+    connect(thumbThreads, &DkSlider::valueChanged, this, [this](int value) {
+        DkSettingsManager::param().resources().thumbThreads = value;
+        showRestartLabel();
+    });
+
+    auto *thumbMemory = new DkSlider(tr("Thumbnail memory cache limit"), this);
+    thumbMemory->setToolTip(tr("Keeps recent thumbnails in memory. Use 0 to disable."));
+    thumbMemory->setValueSuffix(QStringLiteral(" MB"));
+    thumbMemory->setMaximumWidth(500);
+    thumbMemory->setRange(0, 1024);
+    thumbMemory->setValue(res.thumbCacheMemory);
+    connect(thumbMemory, &DkSlider::valueChanged, this, [this](int value) {
+        DkSettingsManager::param().resources().thumbCacheMemory = value;
+        showRestartLabel();
+    });
+
+    auto *diskSlider = new DkSlider(tr("Disk cache limit"), this);
+    diskSlider->setToolTip(tr("When deletion is enabled, trim disk cache to this size."));
+    diskSlider->setValueSuffix(tr(" MB"));
+    diskSlider->setMaximumWidth(500);
+    diskSlider->setRange(0, 1024 * 10);
+    diskSlider->setValue(res.thumbDiskSpace);
+    connect(diskSlider, &DkSlider::valueChanged, this, [this](int value) {
+        DkSettingsManager::param().resources().thumbDiskSpace = value;
+        showRestartLabel();
+    });
+
+    auto *sharedBox = new QCheckBox(tr("Share thumbnails with other programs"), this);
+    sharedBox->setToolTip(tr("Thumbnails created by other software will be used by nomacs, and vice versa."));
+    sharedBox->setChecked(res.sharedThumbs);
+#ifndef Q_OS_UNIX
+    sharedBox->setEnabled(false);
+#endif
+    connect(sharedBox, &QCheckBox::toggled, this, [this, &res](bool checked) {
+        // if sharing is disabled, offer to cleanup the non-shared area
+        const QString cachePath = DkCachedThumb::cacheHome();
+        if (checked && !res.sharedThumbs && QFile::exists(cachePath)) {
+            int result = QMessageBox::question(this,
+                                               tr("Cleanup thumbnails?"),
+                                               tr("There are thumbnails saved in:\n\n\"%1\"\n\n"
+                                                  "When sharing thumbnails, these will no longer be used.\n\n"
+                                                  "Delete them now?")
+                                                   .arg(cachePath),
+                                               QMessageBox::No | QMessageBox::Yes);
+            if (result == QMessageBox::Yes) {
+                DkCachedThumb::cleanupSync(true);
+            }
+        }
+        res.sharedThumbs = checked;
+        showRestartLabel();
+    });
+
+    auto *cleanupBox = new QCheckBox(tr("Delete old thumbnails on startup"), this);
+    cleanupBox->setToolTip(
+        tr("When cache limit is exceeded, delete least-recently-used thumbnails in the background."));
+    cleanupBox->setChecked(res.cleanupThumbCache);
+    diskSlider->setEnabled(res.cleanupThumbCache);
+    connect(cleanupBox, &QCheckBox::toggled, this, [this, &res, diskSlider](bool checked) {
+        res.cleanupThumbCache = checked;
+        diskSlider->setEnabled(checked);
+        showRestartLabel();
+    });
+
+    auto *thumbCacheGroup = new QGroupBox(tr("Enable disk cache"), this);
+    thumbCacheGroup->setToolTip(tr("Save generated thumbnails to disk for future use."));
+    thumbCacheGroup->setCheckable(true);
+    thumbCacheGroup->setChecked(res.thumbDiskCache);
+    connect(thumbCacheGroup, &QGroupBox::clicked, [&](bool checked) {
+        res.thumbDiskCache = checked;
+        showRestartLabel();
+    });
+
+    auto *thumbCacheLayout = new QVBoxLayout;
+    thumbCacheGroup->setLayout(thumbCacheLayout);
+    thumbCacheLayout->addWidget(sharedBox);
+    thumbCacheLayout->addWidget(cleanupBox);
+    thumbCacheLayout->addWidget(diskSlider);
+
+    auto *thumbGroup = new DkGroupWidget(tr("Thumbnails"), this);
+    thumbGroup->addWidget(enableHqThumbs);
+    thumbGroup->addWidget(preloadBox);
+    thumbGroup->addWidget(new QLabel(tr("Maximum thumbnail size"), this));
+    thumbGroup->addWidget(sizesBox);
+    thumbGroup->addWidget(thumbThreads);
+    thumbGroup->addWidget(thumbMemory);
+    thumbGroup->addWidget(thumbCacheGroup);
+
     // loading policy
     QVector<QRadioButton *> loadButtons;
     loadButtons.append(new QRadioButton(tr("Skip Images"), this));
@@ -1221,6 +1335,7 @@ void DkFilePreference::createLayout()
     l->addWidget(tempFolderGroup);
     l->addWidget(cacheGroup);
     l->addWidget(historyGroup);
+    l->addWidget(thumbGroup);
     l->addWidget(loadGroup);
     l->addWidget(saveGroup);
     l->addWidget(skipGroup);
@@ -1246,6 +1361,11 @@ void DkFilePreference::onSaveGroupButtonClicked(int buttonId) const
 {
     if (DkSettingsManager::param().resources().loadSavedImage != buttonId)
         DkSettingsManager::param().resources().loadSavedImage = buttonId;
+}
+
+void DkFilePreference::showRestartLabel() const
+{
+    emit infoSignal(tr("Please Restart nomacs to apply changes"));
 }
 
 void DkFilePreference::onSkipBoxValueChanged(int value) const

--- a/ImageLounge/src/DkGui/DkPreferenceWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkPreferenceWidgets.cpp
@@ -1187,7 +1187,7 @@ void DkFilePreference::createLayout()
     auto *thumbThreads = new DkSlider(tr("Thumbnail threads"), this);
     thumbThreads->setToolTip(tr("Limit temporary memory and CPU used to generate thumbnails."));
     thumbThreads->setMaximumWidth(500);
-    thumbThreads->setRange(1, QThread::idealThreadCount() - 2);
+    thumbThreads->setRange(1, qMax(1, QThread::idealThreadCount() - 2));
     thumbThreads->setValue(res.thumbThreads);
     connect(thumbThreads, &DkSlider::valueChanged, this, [this](int value) {
         DkSettingsManager::param().resources().thumbThreads = value;

--- a/ImageLounge/src/DkGui/DkPreferenceWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkPreferenceWidgets.cpp
@@ -810,6 +810,16 @@ void DkDisplayPreference::createLayout()
     keepZoomGroup->addWidget(keepZoomButtons[DkSettings::zoom_never_keep]);
     keepZoomGroup->addWidget(keepZoomButtons[DkSettings::zoom_always_fit]);
 
+    auto *enableHqThumbs = new QCheckBox(tr("Enable High Quality Thumbnails"));
+    enableHqThumbs->setChecked(DkSettingsManager::param().display().highQualityThumbs);
+    enableHqThumbs->setToolTip(tr("If checked, use the full-resolution image if EXIF thumbnail is too small."));
+    connect(enableHqThumbs, &QCheckBox::toggled, this, [](bool checked) {
+        DkSettingsManager::param().display().highQualityThumbs = checked;
+    });
+
+    auto *thumbsGroup = new DkGroupWidget(tr("Thumbnails"), this);
+    thumbsGroup->addWidget(enableHqThumbs);
+
     mColorProfiles = new QComboBox(this);
     mColorProfiles->setToolTip(tr("Choose the color profile of the monitor"));
     connect(mColorProfiles, &QComboBox::activated, this, &DkDisplayPreference::onColorProfileActivated);
@@ -938,6 +948,7 @@ void DkDisplayPreference::createLayout()
     l->setAlignment(Qt::AlignTop);
     l->addWidget(zoomGroup);
     l->addWidget(keepZoomGroup);
+    l->addWidget(thumbsGroup);
     l->addWidget(colorGroup);
     l->addWidget(iconGroup);
     l->addWidget(navigationGroup);

--- a/ImageLounge/src/DkGui/DkPreferenceWidgets.h
+++ b/ImageLounge/src/DkGui/DkPreferenceWidgets.h
@@ -214,6 +214,7 @@ signals:
     void infoSignal(const QString &msg) const;
 
 protected:
+    void showRestartLabel() const;
     void createLayout();
     void paintEvent(QPaintEvent *ev) override;
 };

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -282,7 +282,6 @@ void DkFilePreview::paintEvent(QPaintEvent *)
     painter.setWorldTransform(worldMatrix);
     painter.setWorldMatrixEnabled(true);
 
-    painter.setRenderHint(QPainter::SmoothPixmapTransform);
     drawThumbs(&painter);
 
     if (currentFileIdx != oldFileIdx && currentFileIdx >= 0) {
@@ -379,6 +378,8 @@ void DkFilePreview::drawThumbs(QPainter *painter)
         // only fetch thumbs if we are not moving too fast...
         if (!existsInTable) {
             int size = max_thumb_size;
+            ScaleConstraint constraint = orientation == Qt::Horizontal ? ScaleConstraint::height
+                                                                       : ScaleConstraint::width;
             LoadThumbnailOption option = LoadThumbnailOption::none;
             if (DkSettingsManager::param().display().highQualityThumbs) {
                 size = r.height() * this->devicePixelRatio();
@@ -387,7 +388,7 @@ void DkFilePreview::drawThumbs(QPainter *painter)
 
             Thumb newThumb;
             newThumb.loading = true;
-            newThumb.request = LoadThumbnailRequest{filePath, option, size, ScaleConstraint::height};
+            newThumb.request = LoadThumbnailRequest{filePath, option, size, constraint};
 
             mThumbs.insert(filePath, newThumb);
             mThumbLoader->requestThumbnail(newThumb.request);

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -90,21 +90,26 @@ DkFilePreview::DkFilePreview(DkThumbLoader *loader, QWidget *parent, Qt::WindowF
             &DkThumbLoader::thumbnailLoaded,
             this,
             [this](const QString &filePath, const QImage &thumb, const bool fromExif) {
-                if (!mThumbs.contains(filePath)) {
+                auto it = mThumbs.find(filePath);
+                if (it == mThumbs.end()) {
                     return;
                 }
-                mThumbs[filePath].image = thumb;
-                mThumbs[filePath].fromExif = fromExif;
-                mThumbs[filePath].loading = false;
+                Thumb &th = *it;
+                th.request = {};
+                th.image = thumb;
+                th.fromExif = fromExif;
+                th.loading = false;
                 update();
             });
 
     connect(mThumbLoader, &DkThumbLoader::thumbnailLoadFailed, this, [this](const QString &filePath) {
-        if (!mThumbs.contains(filePath)) {
+        auto it = mThumbs.find(filePath);
+        if (it == mThumbs.end()) {
             return;
         }
-        mThumbs[filePath].notExist = true;
-        mThumbs[filePath].loading = false;
+        Thumb &th = *it;
+        th.notExist = true;
+        th.loading = false;
         update();
     });
 }
@@ -365,7 +370,7 @@ void DkFilePreview::drawThumbs(QPainter *painter)
 
         if (oobStart || oobEnd) {
             if (existsInTable && thumb->loading) {
-                mThumbLoader->cancelThumbnailRequest(mThumbs[filePath].request);
+                mThumbLoader->cancelThumbnailRequest(thumb->request);
                 mThumbs.remove(filePath);
             }
 

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -534,6 +534,16 @@ void DkFilePreview::resizeEvent(QResizeEvent *event)
         moveImageTimer->start();
     }
 
+    if (DkSettingsManager::param().display().highQualityThumbs
+        && ((orientation == Qt::Horizontal && event->size().height() != event->oldSize().height())
+            || (orientation == Qt::Vertical && event->size().width() != event->oldSize().width()))) {
+        for (auto &thumb : mThumbs) {
+            if (thumb.loading)
+                mThumbLoader->cancelThumbnailRequest(thumb.request);
+        }
+        mThumbs.clear();
+    }
+
     // now update...
     borderTrigger = (orientation == Qt::Horizontal) ? (float)width() * winPercent : (float)height() * winPercent;
     int borderTriggerI = qRound(borderTrigger);

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -1328,11 +1328,11 @@ void DkThumbScene::updateThumbLabels()
 
 void DkThumbScene::setImageLoader(QSharedPointer<DkImageLoader> loader)
 {
-    connectLoader(mLoader, false); // disconnect
-    mLoader = loader;
-    connectLoader(loader);
-    showFile(""); // if we don't do this, then if the FIRST directory opened after startup is empty, no directory will
-                  // be displayed in the status bar
+    if (mLoader != loader) {
+        connectLoader(mLoader, false); // disconnect
+        mLoader = loader;
+        connectLoader(loader);
+    }
 }
 
 void DkThumbScene::connectLoader(QSharedPointer<DkImageLoader> loader, bool connectSignals)

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -1352,19 +1352,24 @@ void DkThumbScene::updateLayout()
 
 void DkThumbScene::updateThumbs(QVector<QSharedPointer<DkImageContainerT>> thumbs)
 {
-    int selectedIdx = mLastSelectedIdx;
-    mLastSelectedIdx = -1;
+    const DkThumbLabel *anchor = mThumbLabels.value(mSelectionAnchor);
+    const DkThumbLabel *cursor = mThumbLabels.value(mSelectionCursor);
+    const QString anchorPath = anchor ? anchor->filePath() : QString{};
+    const QString cursorPath = cursor ? cursor->filePath() : QString{};
+    mSelectionAnchor = -1;
+    mSelectionCursor = -1;
 
-    Q_ASSERT(mThumbLabels.size() >= mThumbs.size());
-
-    if (selectedIdx < 0) {
-        for (int idx = 0; idx < mThumbs.size(); idx++) {
-            if (mThumbLabels.at(idx)->isSelected()) {
-                selectedIdx = idx;
-                break;
-            }
-        }
+    // use a map as we could have 10,000 thumbs or more
+    const QStringList selectedFiles = getSelectedFiles();
+    QSet<QString> selected;
+    selected.reserve(selectedFiles.count());
+    for (auto &path : selectedFiles) {
+        selected.insert(path);
     }
+
+    QSignalBlocker blocker(this);
+    clearSelection();
+    blocker.unblock();
 
     mThumbs.clear();
     mThumbs.reserve(thumbs.size());
@@ -1373,10 +1378,31 @@ void DkThumbScene::updateThumbs(QVector<QSharedPointer<DkImageContainerT>> thumb
     }
     updateThumbLabels();
 
-    if (selectedIdx >= 0 && !mThumbs.empty()) {
-        selectedIdx = qBound(0, selectedIdx, mThumbs.size() - 1);
-        selectThumbs(true, selectedIdx, selectedIdx + 1, false);
-        // ensureVisible(selectedIdx); // TODO:
+    blocker.reblock();
+
+    for (auto &thumb : mThumbLabels) {
+        const QString path = thumb->filePath();
+        bool select = selected.contains(path);
+        thumb->setSelected(select);
+        if (select) {
+            if (path == anchorPath) {
+                mSelectionAnchor = thumb->index();
+            }
+            if (path == cursorPath) {
+                mSelectionCursor = thumb->index();
+            }
+        }
+    }
+
+    blocker.unblock();
+
+    emit selectionChanged();
+
+    showFile();
+
+    if (mSelectionCursor >= 0) {
+        DkThumbLabel *thumb = mThumbLabels.value(mSelectionCursor);
+        thumb->ensureVisible();
     }
 
     update();
@@ -1410,7 +1436,6 @@ void DkThumbScene::updateThumbLabels()
         thumb->setVisible(false);
     }
 
-    showFile();
     updateLayout();
 }
 
@@ -1655,7 +1680,7 @@ void DkThumbScene::resizeThumbs(float dx)
     DkSettingsManager::param().display().thumbPreviewSize = newSize;
 
     // keep the selection or center thumb visible when zooming
-    DkThumbLabel *centerThumb = getSelectedThumbs().value(0);
+    DkThumbLabel *centerThumb = mThumbLabels.value(mSelectionCursor);
     if (!centerThumb) {
         centerThumb = getCenterThumb();
     }

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -90,8 +90,8 @@ DkFilePreview::DkFilePreview(DkThumbLoader *loader, QWidget *parent, Qt::WindowF
             &DkThumbLoader::thumbnailLoaded,
             this,
             [this](ThumbnailId id, const QString &filePath, const QImage &img, const bool fromExif) {
-                auto req = mThumbRequests.find(id);
-                if (req == mThumbRequests.end()) { // request from another widget
+                auto req = mThumbRequests.constFind(id);
+                if (req == mThumbRequests.constEnd()) { // request from another widget
                     return;
                 }
                 Q_ASSERT(req.value() == filePath);
@@ -110,8 +110,8 @@ DkFilePreview::DkFilePreview(DkThumbLoader *loader, QWidget *parent, Qt::WindowF
             });
 
     connect(mThumbLoader, &DkThumbLoader::thumbnailLoadFailed, this, [this](ThumbnailId id, const QString &filePath) {
-        auto req = mThumbRequests.find(id);
-        if (req == mThumbRequests.end()) {
+        auto req = mThumbRequests.constFind(id);
+        if (req == mThumbRequests.constEnd()) {
             return;
         }
         Q_ASSERT(req.value() == filePath);
@@ -326,41 +326,40 @@ void DkFilePreview::paintEvent(QPaintEvent *)
 
 void DkFilePreview::drawThumbs(QPainter *painter)
 {
-    // qDebug() << "drawing thumbs: " << worldMatrix.dx();
-
+    // Recalculate geometry and hit boxes for mouse events.
+    // TODO: extract this to updateLayout() or redesign as it is invariant to repaint events
     bufferDim = (orientation == Qt::Horizontal) ? QRectF(QPointF(0, yOffset / 2), QSize(xOffset, 0))
                                                 : QRectF(QPointF(yOffset / 2, 0), QSize(0, xOffset));
     thumbRects.clear();
 
-    DkTimer dt;
+    const QPoint mousePos = worldMatrix.inverted().map(mapFromGlobal(QCursor::pos())); // for hover effect
+    const int thumbSize = DkSettingsManager::param().effectiveThumbSize(this); // size when we don't have img yet
 
-    // mouse over effect
-    QPoint p = worldMatrix.inverted().map(mapFromGlobal(QCursor::pos()));
+    const auto &files = mFiles;
+    const int numFiles = files.size();
+    for (int idx = 0; idx < numFiles; idx++) {
+        const QString &filePath = files[idx].path();
 
-    for (int idx = 0; static_cast<unsigned int>(idx) < mFiles.size(); idx++) {
-        const QString &filePath = mFiles[idx].path();
+        const auto thumbsIter = mThumbs.constFind(filePath);
+        std::optional<Thumb> thumb = std::nullopt;
+        if (thumbsIter != mThumbs.constEnd()) {
+            thumb = *thumbsIter;
+        }
 
-        const auto thumb = mThumbs.constFind(filePath);
-        bool existsInTable = thumb != mThumbs.constEnd();
-
-        if (existsInTable && thumb->notExist) {
+        // If the thumbnail failed to load, don't draw anything
+        if (thumb && thumb->notExist) {
             thumbRects.push_back(QRectF());
             continue;
         }
 
         QImage img;
-        if (existsInTable && !thumb->image.isNull()) {
+        if (thumb) {
             img = thumb->image;
         }
 
-        // if (img.width() > max_thumb_size * DkSettingsManager::param().dpiScaleFactor())
-        //	qDebug() << thumb->getFilePath() << "size:" << img.size();
-
-        QPointF anchor = orientation == Qt::Horizontal ? bufferDim.topRight() : bufferDim.bottomLeft();
+        const QPointF anchor = orientation == Qt::Horizontal ? bufferDim.topRight() : bufferDim.bottomLeft();
         QRectF r = !img.isNull() ? QRectF(anchor, img.size() / devicePixelRatio())
-                                 : QRectF(anchor,
-                                          QSize(DkSettingsManager::param().effectiveThumbSize(this),
-                                                DkSettingsManager::param().effectiveThumbSize(this)));
+                                 : QRectF(anchor, QSize{thumbSize, thumbSize});
         if (orientation == Qt::Horizontal && height() - yOffset < r.height() * 2)
             r.setSize(QSizeF(qFloor(r.width() * (float)(height() - yOffset) / r.height()), height() - yOffset));
         else if (orientation == Qt::Vertical && width() - yOffset < r.width() * 2)
@@ -376,12 +375,13 @@ void DkFilePreview::drawThumbs(QPainter *painter)
         else
             r.moveCenter(QPoint(width() / 2, qFloor(r.center().y())));
 
+        thumbRects.push_back(r);
+
         // update the buffer dim
         if (orientation == Qt::Horizontal)
             bufferDim.setRight(qFloor(bufferDim.right() + r.width()) + qCeil(xOffset / 2.0f));
         else
             bufferDim.setBottom(qFloor(bufferDim.bottom() + r.height()) + qCeil(xOffset / 2.0f));
-        thumbRects.push_back(r);
 
         QRectF imgWorldRect = worldMatrix.mapRect(r);
 
@@ -395,22 +395,24 @@ void DkFilePreview::drawThumbs(QPainter *painter)
         const bool oobEnd = (orientation == Qt::Horizontal && imgWorldRect.left() > width())
             || (orientation == Qt::Vertical && imgWorldRect.top() > height());
 
+        // cancel and skip hidden thumbs
         if (oobStart || oobEnd) {
-            if (existsInTable && thumb->loading) {
+            if (thumb && thumb->loading) {
                 auto req = thumb->request;
                 mThumbs.remove(req.filePath);
                 mThumbRequests.remove(req.id);
                 mThumbLoader->cancelThumbnailRequest(req);
             }
 
+            // abort processing further items?
             if (oobEnd && !scrollToCurrentImage) {
                 break;
             }
             continue;
         }
 
-        // only fetch thumbs if we are not moving too fast...
-        if (!existsInTable) {
+        // we have a visible thumb, fetch it
+        if (!thumb) {
             int size = DkSettingsManager::param().resources().maxThumbSize;
             ScaleConstraint constraint = orientation == Qt::Horizontal ? ScaleConstraint::height
                                                                        : ScaleConstraint::width;
@@ -459,10 +461,8 @@ void DkFilePreview::drawThumbs(QPainter *painter)
 
         if (idx == currentFileIdx)
             drawCurrentImgEffect(painter, r);
-        else if (idx == selected && r.contains(p))
+        else if (idx == selected && r.contains(mousePos))
             drawSelectedEffect(painter, r);
-
-        // painter->fillRect(QRect(0,0,200, 110), leftGradient);
     }
 }
 
@@ -572,6 +572,7 @@ void DkFilePreview::resizeEvent(QResizeEvent *event)
         moveImageTimer->start();
     }
 
+    // refetch thumbs if sizes changed
     if (DkSettingsManager::param().display().highQualityThumbs
         && ((orientation == Qt::Horizontal && event->size().height() != event->oldSize().height())
             || (orientation == Qt::Vertical && event->size().width() != event->oldSize().width()))) {

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -1291,6 +1291,7 @@ void DkThumbScene::updateLayout()
 
             DkThumbLabel *cLabel = mThumbLabels.at(tIdx);
             cLabel->setPos(cXOffset, cYOffset);
+            cLabel->setRow(rIdx);
             cXOffset += psz + mXOffset;
         }
 

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -2093,6 +2093,19 @@ void DkThumbsView::mousePressEvent(QMouseEvent *event)
     }
 }
 
+void DkThumbsView::mouseDoubleClickEvent(QMouseEvent *event)
+{
+    DkThumbScene *sc = thumbsScene();
+    DkThumbLabel *itemClicked = static_cast<DkThumbLabel *>(sc->itemAt(mapToScene(event->pos()), QTransform()));
+
+    // Prevent fullscreen switch when mouse is in the space between thumbnails
+    if (!itemClicked) {
+        return;
+    }
+
+    QGraphicsView::mouseDoubleClickEvent(event);
+}
+
 void DkThumbsView::mouseMoveEvent(QMouseEvent *event)
 {
     if (event->buttons() == Qt::LeftButton) {

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -1899,19 +1899,6 @@ void DkThumbScene::renameSelected() const
     }
 }
 
-QStringList DkThumbScene::getSelectedFiles() const
-{
-    QStringList fileList;
-
-    for (int idx = 0; idx < mThumbs.size(); idx++) {
-        if (mThumbLabels.at(idx) && mThumbLabels.at(idx)->isSelected()) {
-            fileList.append(mThumbLabels.at(idx)->filePath());
-        }
-    }
-
-    return fileList;
-}
-
 void DkThumbScene::thumbClicked(DkThumbLabel *thumb, QMouseEvent *event)
 {
     if (event->buttons() != Qt::LeftButton) {
@@ -1959,14 +1946,32 @@ void DkThumbScene::thumbClicked(DkThumbLabel *thumb, QMouseEvent *event)
 
 QVector<DkThumbLabel *> DkThumbScene::getSelectedThumbs() const
 {
+    const QVector<QGraphicsItem *> items = selectedItems();
     QVector<DkThumbLabel *> selected;
+    selected.reserve(items.count());
 
-    for (DkThumbLabel *label : mThumbLabels) {
-        if (label->isSelected())
-            selected << label;
+    for (auto *item : items) {
+        selected += static_cast<DkThumbLabel *>(item);
     }
 
+    std::sort(selected.begin(), selected.end(), [](const DkThumbLabel *a, const DkThumbLabel *b) {
+        return a->index() < b->index();
+    });
+
     return selected;
+}
+
+QStringList DkThumbScene::getSelectedFiles() const
+{
+    const auto selected = getSelectedThumbs();
+    QStringList fileList;
+    fileList.reserve(selected.count());
+
+    for (DkThumbLabel *thumb : selected) {
+        fileList += thumb->filePath();
+    }
+
+    return fileList;
 }
 
 DkThumbLabel *DkThumbScene::getCenterThumb() const
@@ -1988,11 +1993,7 @@ DkThumbLabel *DkThumbScene::getCenterThumb() const
 
 bool DkThumbScene::allThumbsSelected() const
 {
-    for (DkThumbLabel *label : mThumbLabels)
-        if (label->isVisible() && label->flags() & QGraphicsItem::ItemIsSelectable && !label->isSelected())
-            return false;
-
-    return true;
+    return getSelectedThumbs().count() == mThumbs.count();
 }
 
 void DkThumbScene::viewportChanged(const QRectF &portRect)

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -2195,7 +2195,6 @@ void DkThumbScrollWidget::setVisible(bool visible)
     connectToActions(visible);
 
     if (visible) {
-        mThumbsScene->updateThumbLabels();
         mFilterEdit->setText("");
     } else
         mThumbsScene->cancelLoading();

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -366,7 +366,7 @@ void DkFilePreview::drawThumbs(QPainter *painter)
 
         if (oobStart || oobEnd) {
             if (existsInTable && thumb->loading) {
-                mThumbLoader->cancelThumbnailRequest(filePath);
+                mThumbLoader->cancelThumbnailRequest(mThumbs[filePath].request);
                 mThumbs.remove(filePath);
             }
 
@@ -380,8 +380,9 @@ void DkFilePreview::drawThumbs(QPainter *painter)
         if (!existsInTable) {
             Thumb newThumb;
             newThumb.loading = true;
+            newThumb.request = LoadThumbnailRequest{filePath};
             mThumbs.insert(filePath, newThumb);
-            mThumbLoader->requestThumbnail(filePath);
+            mThumbLoader->requestThumbnail(newThumb.request);
         }
 
         bool isLeftGradient = (orientation == Qt::Horizontal && worldMatrix.dx() < 0
@@ -917,6 +918,8 @@ void DkThumbLabel::onThumbnailLoaded(const QString &filePath, const QImage &thum
     }
 
     mFetchingThumb = false;
+    mThumbRequest = {};
+
     // update label
     mText.setPos(0, DkSettingsManager::param().effectiveThumbPreviewSize());
 
@@ -934,6 +937,7 @@ void DkThumbLabel::onThumbnailLoadFailed(const QString &filePath)
     }
     mThumbNotExist = true;
     mFetchingThumb = false;
+    mThumbRequest = {};
     update();
 }
 
@@ -956,8 +960,9 @@ void DkThumbLabel::cancelLoading()
     if (!mFetchingThumb) {
         return;
     }
-    mThumbLoader->cancelThumbnailRequest(mFilePath);
+    mThumbLoader->cancelThumbnailRequest(mThumbRequest);
     mFetchingThumb = false;
+    mThumbRequest = {};
 }
 
 QRectF DkThumbLabel::boundingRect() const
@@ -992,11 +997,13 @@ void DkThumbLabel::generatePixmap(const QImage &thumb)
         targetRect.moveCenter(br.center());
     }
 
-    const int w = DkSettingsManager::param().effectiveThumbPreviewSize();
-    QPixmap pm(w, w);
+    const QSize pixmapSize = (br.size() * mDevicePixelRatio).toSize();
+    QPixmap pm(pixmapSize);
+    pm.setDevicePixelRatio(mDevicePixelRatio);
     pm.fill(Qt::transparent);
+
     QPainter painter(&pm);
-    painter.setRenderHints(QPainter::SmoothPixmapTransform | QPainter::Antialiasing);
+    painter.setRenderHints(QPainter::SmoothPixmapTransform);
     painter.drawImage(targetRect, thumb, srcRect);
 
     if (mPixmapKey) {
@@ -1043,11 +1050,17 @@ void DkThumbLabel::paint(QPainter *painter, const QStyleOptionGraphicsItem *opti
 {
     std::optional<QPixmap> pm = pixmap();
 
-    if (!mFetchingThumb && (!pm || pm->size() != boundingRect().size()) && !mThumbNotExist) {
+    mThumbOption = LoadThumbnailOption::none; // TODO: select current options from settings
+    mDevicePixelRatio = painter->device()->devicePixelRatio();
+    const QSize pixmapSize = (boundingRect().size() * mDevicePixelRatio).toSize();
+
+    if (!mFetchingThumb && (!pm || pm->size() != pixmapSize) && !mThumbNotExist) {
         // setting fetching flag first, because requestThumbnail might return thumbnail immediately
         // This avoids stucking infinitely in fetching thumb state
         mFetchingThumb = true;
-        mThumbLoader->requestThumbnail(mFilePath);
+        int maxSize = mThumbOption == LoadThumbnailOption::force_size ? pixmapSize.height() : max_thumb_size;
+        mThumbRequest = LoadThumbnailRequest{mFilePath, mThumbOption, maxSize};
+        mThumbLoader->requestThumbnail(mThumbRequest);
 
         // It is possible we have pixmap now (from cache), check again.
         pm = pixmap();
@@ -1419,6 +1432,7 @@ void DkThumbScene::resizeThumbs(float dx)
     if (newSize > 6 && newSize <= max_thumb_size) {
         DkSettingsManager::param().display().thumbPreviewSize = newSize;
         updateLayout();
+        // TODO: cancel anything no longer visible
     }
 }
 
@@ -2274,7 +2288,7 @@ DkThumbPreviewLabel::DkThumbPreviewLabel(const QString &filePath,
     QFileInfo fInfo(filePath);
     setToolTip(fInfo.fileName());
 
-    mLoader->requestThumbnail(filePath);
+    mLoader->requestThumbnail(LoadThumbnailRequest{filePath});
 }
 
 void DkThumbPreviewLabel::thumbLoaded(const QString &filePath, const QImage &img)

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -1111,13 +1111,12 @@ std::optional<QPixmap> DkThumbLabel::pixmap() const
     return pm;
 }
 
-void DkThumbLabel::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget)
+void DkThumbLabel::fetchThumb(float devicePixelRatio)
 {
     std::optional<QPixmap> pm = pixmap();
-
+    mDevicePixelRatio = devicePixelRatio;
     mThumbOption = DkSettingsManager::param().display().highQualityThumbs ? LoadThumbnailOption::force_size
                                                                           : LoadThumbnailOption::none;
-    mDevicePixelRatio = painter->device()->devicePixelRatio();
     const QSize pixmapSize = (boundingRect().size() * mDevicePixelRatio).toSize();
 
     if (!mFetchingThumb && (!pm || pm->size() != pixmapSize) && !mThumbNotExist) {
@@ -1129,10 +1128,13 @@ void DkThumbLabel::paint(QPainter *painter, const QStyleOptionGraphicsItem *opti
                                                                                     : ScaleConstraint::longest_side;
         mThumbRequest = LoadThumbnailRequest{mFilePath, mThumbOption, maxSize, constraint};
         mThumbLoader->requestThumbnail(mThumbRequest);
-
-        // It is possible we have pixmap now (from cache), check again.
-        pm = pixmap();
     }
+}
+
+void DkThumbLabel::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget)
+{
+    fetchThumb(painter->device()->devicePixelRatio());
+    std::optional<QPixmap> pm = pixmap();
 
     if (mThumbNotExist) {
         painter->setPen(sNoImagePen);

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -1207,7 +1207,6 @@ void DkThumbScene::updateLayout()
     int tso = psz + mXOffset;
     setSceneRect(0, 0, mNumCols * tso + mXOffset, mNumRows * tso + mXOffset);
 
-    DkTimer dt;
     int cYOffset = mXOffset;
 
     for (int rIdx = 0; rIdx < mNumRows; rIdx++) {
@@ -1228,10 +1227,14 @@ void DkThumbScene::updateLayout()
         cYOffset += psz + mXOffset; // 20 for label
     }
 
-    for (int idx = 0; idx < mThumbLabels.size(); idx++) {
-        if (mThumbLabels.at(idx)->isSelected())
-            mThumbLabels.at(idx)->ensureVisible();
+    DkThumbLabel *lastSelected = nullptr;
+    for (DkThumbLabel *thumb : std::as_const(mThumbLabels)) {
+        thumb->cancelLoading(); // visibility and/or size may have changed
+        if (thumb->isSelected())
+            lastSelected = thumb;
     }
+    if (lastSelected)
+        lastSelected->ensureVisible();
     update();
 }
 

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -129,6 +129,18 @@ DkFilePreview::DkFilePreview(DkThumbLoader *loader, QWidget *parent, Qt::WindowF
     });
 }
 
+void DkFilePreview::resetThumbs()
+{
+    // drop our thumbnail cache
+    for (auto &thumb : std::as_const(mThumbs)) {
+        if (thumb.loading) {
+            mThumbLoader->cancelThumbnailRequest(thumb.request);
+        }
+    }
+    mThumbs.clear();
+    mThumbRequests.clear();
+}
+
 void DkFilePreview::init()
 {
     setObjectName("DkFilePreview");
@@ -412,12 +424,12 @@ void DkFilePreview::drawThumbs(QPainter *painter)
             newThumb.request = LoadThumbnailRequest{filePath, option, size, constraint};
             newThumb.loading = true;
 
-            if (!mThumbRequests.contains(newThumb.request.id)) {
-                Q_ASSERT(!mThumbs.contains(filePath));
-                mThumbs.insert(filePath, newThumb);
-                mThumbRequests.insert(newThumb.request.id, filePath);
-                mThumbLoader->requestThumbnail(newThumb.request);
-            }
+            Q_ASSERT(!mThumbs.contains(filePath));
+            mThumbs.insert(filePath, newThumb);
+
+            Q_ASSERT(!mThumbRequests.contains(newThumb.request.id));
+            mThumbRequests.insert(newThumb.request.id, filePath);
+            mThumbLoader->requestThumbnail(newThumb.request);
         }
 
         bool isLeftGradient = (orientation == Qt::Horizontal && worldMatrix.dx() < 0
@@ -563,11 +575,7 @@ void DkFilePreview::resizeEvent(QResizeEvent *event)
     if (DkSettingsManager::param().display().highQualityThumbs
         && ((orientation == Qt::Horizontal && event->size().height() != event->oldSize().height())
             || (orientation == Qt::Vertical && event->size().width() != event->oldSize().width()))) {
-        for (auto &thumb : mThumbs) {
-            if (thumb.loading)
-                mThumbLoader->cancelThumbnailRequest(thumb.request);
-        }
-        mThumbs.clear();
+        resetThumbs();
     }
 
     // now update...
@@ -901,7 +909,8 @@ void DkFilePreview::setFileInfo(QSharedPointer<DkImageContainerT> cImage)
 
 void DkFilePreview::updateThumbs(QVector<QSharedPointer<DkImageContainerT>> images)
 {
-    mThumbs.clear();
+    resetThumbs();
+
     mFiles.resize(images.size());
     for (int idx = 0; idx < images.size(); idx++) {
         const auto &imgC = images[idx];

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -1936,6 +1936,7 @@ void DkThumbScene::viewportChanged(const QRectF &portRect)
     }
 
     // Cancel offscreen thumbnails, prefetch if they are likely to be needed soon
+    const bool preloadThumbs = DkSettingsManager::param().resources().preloadThumbs;
     QList<DkThumbLabel *> prefetch;
     int numRows = lastRow - firstRow + 1;
     for (DkThumbLabel *thumb : std::as_const(offscreen)) {
@@ -1943,7 +1944,7 @@ void DkThumbScene::viewportChanged(const QRectF &portRect)
         bool prevPage = scrollUp && row >= firstRow - numRows && row < firstRow;
         bool nextPage = scrollDown && row <= lastRow + numRows && row > lastRow;
 
-        if (view && (prevPage || nextPage)) {
+        if (view && preloadThumbs && (prevPage || nextPage)) {
             prefetch.append(thumb);
         } else {
             thumb->cancelLoading();

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -1685,7 +1685,7 @@ void DkThumbScene::resizeThumbs(float dx)
     QString centerPath{};
     if (centerThumb) {
         centerPath = centerThumb->filePath();
-        centerThumb = nullptr; // potentially invalidated by updateLayout()
+        centerThumb = nullptr;
     }
 
     updateLayout();

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -2553,7 +2553,16 @@ DkThumbPreviewLabel::DkThumbPreviewLabel(const QString &filePath,
     QFileInfo fInfo(filePath);
     setToolTip(fInfo.fileName());
 
-    LoadThumbnailRequest request{filePath};
+    LoadThumbnailRequest request{};
+    if (DkSettingsManager::param().display().highQualityThumbs) {
+        int imgSize = mThumbSize * devicePixelRatio();
+        request = LoadThumbnailRequest{filePath,
+                                       LoadThumbnailOption::force_size,
+                                       imgSize,
+                                       ScaleConstraint::shortest_side};
+    } else {
+        request = LoadThumbnailRequest{filePath};
+    }
     mThumbId = request.id;
     mLoader->requestThumbnail(request);
 }
@@ -2566,12 +2575,12 @@ void DkThumbPreviewLabel::thumbLoaded(ThumbnailId id, const QString &filePath, c
     mThumbId = {};
     Q_ASSERT(filePath == mFilePath);
 
-    QPixmap pm = QPixmap::fromImage(img);
-    pm = DkImage::makeSquare(pm);
-
-    if (pm.width() > width())
-        pm = pm.scaled(size(), Qt::KeepAspectRatio, Qt::SmoothTransformation);
-
+    QPixmap pm = DkImage::makeSquare(QPixmap::fromImage(img));
+    if (DkSettingsManager::param().display().highQualityThumbs) {
+        pm.setDevicePixelRatio(devicePixelRatio());
+    } else {
+        pm = pm.scaledToWidth(width(), Qt::SmoothTransformation);
+    }
     setPixmap(pm);
 }
 

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -61,6 +61,7 @@
 #include <QToolBar>
 #include <QToolButton>
 #include <QUrl>
+#include <QWindow>
 
 namespace nmc
 {
@@ -2293,6 +2294,19 @@ DkThumbScrollWidget::DkThumbScrollWidget(DkThumbLoader *thumbLoader,
     setContentsMargins(0, 0, 0, 0);
 
     mThumbsScene = new DkThumbScene(thumbLoader, this);
+
+    // resizeEvent() typically fires with screen change but doesn't see new dpr (xcb)
+    mPrevDevicePixelRatio = devicePixelRatio();
+    QWindow *window = topLevelWidget()->windowHandle();
+    connect(window, &QWindow::screenChanged, this, [this](QScreen *) {
+        const qreal dpr = devicePixelRatio();
+        if (dpr != mPrevDevicePixelRatio) {
+            mPrevDevicePixelRatio = dpr;
+            if (isVisible()) {
+                mThumbsScene->updateLayout();
+            }
+        }
+    });
 
     mView = new DkThumbsView(mThumbsScene, this);
     mView->setFocusPolicy(Qt::StrongFocus);

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -1889,6 +1889,10 @@ QStringList DkThumbScene::getSelectedFiles() const
 
 void DkThumbScene::thumbClicked(DkThumbLabel *thumb, QMouseEvent *event)
 {
+    if (event->buttons() != Qt::LeftButton) {
+        return;
+    }
+
     // Sparse selections using anchor+range model:
     // - normal click or ctrl-click sets the anchor
     // - shift click selects range from anchor
@@ -2143,8 +2147,9 @@ void DkThumbsView::mousePressEvent(QMouseEvent *event)
 
     // We have to forward mouse event for double-click event to fire.
     // But this also does single-selection and clears the selection, so
-    // we cannot allow it when doing extended selections (shift+click etc)
-    if (event->modifiers() == Qt::NoModifier) {
+    // we cannot allow it when doing extended selections (shift+click etc),
+    // or when right-clicking for context menu
+    if (event->buttons() != Qt::RightButton && event->modifiers() == Qt::NoModifier) {
         QGraphicsView::mousePressEvent(event);
     }
 }

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -1832,6 +1832,46 @@ QStringList DkThumbScene::getSelectedFiles() const
     return fileList;
 }
 
+void DkThumbScene::thumbClicked(DkThumbLabel *thumb, QMouseEvent *event)
+{
+    // Sparse selections using anchor+range model:
+    // - normal click or ctrl-click sets the anchor
+    // - shift click selects range from anchor
+    // - ctrl+shift click deselects from anchor
+    int to = thumb->index(), from = to;
+    bool select = true, extend = false;
+
+    if (event->modifiers() & Qt::ShiftModifier) {
+        // range selection, selection extends from anchor
+        DkThumbLabel *anchor = mThumbLabels.value(mSelectionAnchor);
+        if (anchor) {
+            from = anchor->index();
+            extend = true;
+            select = !(event->modifiers() & Qt::ControlModifier);
+            if (!select) {
+                // do not include anchor in the deselect
+                from = from > to ? from - 1 : from + 1;
+            }
+            if (from > to) {
+                int tmp = from;
+                from = to;
+                to = tmp;
+            }
+        }
+    } else if (event->modifiers() & Qt::ControlModifier) {
+        // toggle single item
+        mSelectionAnchor = thumb->index();
+        to = thumb->index();
+        from = to;
+        extend = true;
+        select = !thumb->isSelected();
+    } else {
+        mSelectionAnchor = thumb->index();
+    }
+
+    selectThumbs(select, from, to + 1, extend);
+}
+
 QVector<DkThumbLabel *> DkThumbScene::getSelectedThumbs() const
 {
     QVector<DkThumbLabel *> selected;
@@ -2035,18 +2075,21 @@ void DkThumbsView::mousePressEvent(QMouseEvent *event)
     }
 
     DkThumbScene *sc = thumbsScene();
-
     DkThumbLabel *itemClicked = static_cast<DkThumbLabel *>(sc->itemAt(mapToScene(event->pos()), QTransform()));
 
-    // this is a bit of a hack
-    // what we want to achieve: if the user is selecting with e.g. shift or ctrl
-    // and he clicks (unintentionally) into the background - the selection would be lost
-    // otherwise so we just don't propagate this event
-    if (itemClicked || event->modifiers() == Qt::NoModifier)
-        QGraphicsView::mousePressEvent(event);
-
+    // If no item do nothing; this will prevent misclick clearing the selection
     if (!itemClicked) {
-        sc->showFile("");
+        return;
+    }
+
+    // We do this before forwarding so it won't emit selectionChanged() twice
+    sc->thumbClicked(itemClicked, event);
+
+    // We have to forward mouse event for double-click event to fire.
+    // But this also does single-selection and clears the selection, so
+    // we cannot allow it when doing extended selections (shift+click etc)
+    if (event->modifiers() == Qt::NoModifier) {
+        QGraphicsView::mousePressEvent(event);
     }
 }
 
@@ -2088,21 +2131,6 @@ void DkThumbsView::mouseMoveEvent(QMouseEvent *event)
     }
 
     QGraphicsView::mouseMoveEvent(event);
-}
-
-void DkThumbsView::mouseReleaseEvent(QMouseEvent *event)
-{
-    QGraphicsView::mouseReleaseEvent(event);
-
-    DkThumbScene *sc = thumbsScene();
-    DkThumbLabel *itemClicked = static_cast<DkThumbLabel *>(sc->itemAt(mapToScene(event->pos()), QTransform()));
-
-    if (mLastShiftIdx != -1 && event->modifiers() & Qt::ShiftModifier && itemClicked != nullptr) {
-        sc->selectThumbs(true, mLastShiftIdx, sc->findThumb(itemClicked));
-    } else if (itemClicked != nullptr) {
-        mLastShiftIdx = sc->findThumb(itemClicked);
-    } else
-        mLastShiftIdx = -1;
 }
 
 void DkThumbsView::dragEnterEvent(QDragEnterEvent *event)

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -1282,6 +1282,27 @@ void DkThumbScene::updateLayout()
         ensureVisible(lastSelected->filePath());
 
     update();
+
+    // The pixmap cache must be large enough for all thumbnails that need to be painted
+    // If the cache is too small, the paint event will loop back to itself:
+    // paintEvent()->(cache miss)->fetchThumbnail()->update()->paintEvent()
+    const auto gfxViews = views();
+    if (!gfxViews.empty()) {
+        int cacheKb = 9 * 1024; // +1 below puts us at 10MB, the Qt default
+        const QGraphicsView *view = gfxViews.first();
+        const QList<QGraphicsItem *> visibleItems = view->items(view->rect());
+        if (visibleItems.count() > 0) {
+            QSize sz = (visibleItems.first()->boundingRect().size() * view->devicePixelRatio()).toSize();
+            const int bytesPerPixel = 4;
+            const int extraRows = 2;
+            cacheKb += sz.width() * sz.height() * bytesPerPixel * //
+                (visibleItems.count() + extraRows * mNumCols) / 1024;
+        }
+
+        cacheKb = (cacheKb / 1024 + 1) * 1024; // to nearest MB
+
+        QPixmapCache::setCacheLimit(cacheKb);
+    }
 }
 
 void DkThumbScene::updateThumbs(QVector<QSharedPointer<DkImageContainerT>> thumbs)

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -909,19 +909,10 @@ DkThumbLabel::DkThumbLabel(DkThumbLoader *thumbLoader,
                            QGraphicsItem *parent)
     : QGraphicsObject(parent)
     , mText(this)
-    , mFilePath{fileInfo.path()}
     , mThumbLoader{thumbLoader}
     , mFillSquare{fillSquare}
 
 {
-    // clang-format off
-    mTooltip =
-        QObject::tr("Name: ") % fileInfo.fileName() % "\n" %
-        QObject::tr("Size: ") % DkUtils::readableByte((float)fileInfo.size()) % "\n" %
-        QObject::tr("Created: ") % fileInfo.birthTime().toString();
-    // clang-format on
-    setToolTip(mTooltip);
-
     QColor col = DkSettingsManager::param().display().highlightColor;
     col.setAlpha(90);
     mSelectBrush = col;
@@ -931,7 +922,6 @@ DkThumbLabel::DkThumbLabel(DkThumbLoader *thumbLoader,
     font.setBold(false);
     font.setPointSize(9); // two sizes smaller than default font see:stylesheet.css
     mText.setFont(font);
-    mText.setPlainText(fileInfo.fileName());
     mText.setDefaultTextColor(QColor(255, 255, 255));
     mText.hide();
 
@@ -941,6 +931,8 @@ DkThumbLabel::DkThumbLabel(DkThumbLoader *thumbLoader,
     setAcceptHoverEvents(true);
     connect(mThumbLoader, &DkThumbLoader::thumbnailLoaded, this, &DkThumbLabel::onThumbnailLoaded);
     connect(mThumbLoader, &DkThumbLoader::thumbnailLoadFailed, this, &DkThumbLabel::onThumbnailLoadFailed);
+
+    setFileInfo(fileInfo);
 }
 
 void DkThumbLabel::onThumbnailLoaded(const QString &filePath, const QImage &thumb, bool fromExif)
@@ -1200,6 +1192,26 @@ void DkThumbLabel::setFillSquare(bool value)
     update();
 }
 
+void DkThumbLabel::setFileInfo(const DkFileInfo &fileInfo)
+{
+    mFilePath = fileInfo.path();
+    mText.setPlainText(fileInfo.fileName());
+    mThumbNotExist = false;
+
+    // TODO: we can keep pixmap if file did not change
+    if (mPixmapKey)
+        QPixmapCache::remove(mPixmapKey.value());
+    mPixmapKey = std::nullopt;
+
+    // clang-format off
+    mTooltip =
+        QObject::tr("Name: ") % fileInfo.fileName() % "\n" %
+        QObject::tr("Size: ") % DkUtils::readableByte((float)fileInfo.size()) % "\n" %
+        QObject::tr("Created: ") % fileInfo.birthTime().toString();
+    // clang-format on
+    setToolTip(mTooltip);
+}
+
 // DkThumbWidget --------------------------------------------------------------------
 DkThumbScene::DkThumbScene(DkThumbLoader *thumbLoader, QWidget *parent /* = 0 */)
     : QGraphicsScene(parent)
@@ -1222,7 +1234,7 @@ DkThumbScene::DkThumbScene(DkThumbLoader *thumbLoader, QWidget *parent /* = 0 */
 
 void DkThumbScene::updateLayout()
 {
-    if (mThumbLabels.empty())
+    if (mThumbs.empty())
         return;
 
     QSize pSize;
@@ -1233,8 +1245,8 @@ void DkThumbScene::updateLayout()
     int psz = DkSettingsManager::param().effectiveThumbPreviewSize();
     mXOffset = 2; // qCeil(psz*0.1f);
     mNumCols = qMax(qFloor(((float)pSize.width() - mXOffset) / (psz + mXOffset)), 1);
-    mNumCols = qMin(mThumbLabels.size(), mNumCols);
-    mNumRows = qCeil((float)mThumbLabels.size() / mNumCols);
+    mNumCols = qMin(mThumbs.size(), mNumCols);
+    mNumRows = qCeil((float)mThumbs.size() / mNumCols);
 
     int tso = psz + mXOffset;
     setSceneRect(0, 0, mNumCols * tso + mXOffset, mNumRows * tso + mXOffset);
@@ -1301,15 +1313,19 @@ void DkThumbScene::updateThumbs(QVector<QSharedPointer<DkImageContainerT>> thumb
 
 void DkThumbScene::updateThumbLabels()
 {
-    blockSignals(true); // do not emit selection changed while clearing!
-    clear(); // deletes the thumbLabels
-    blockSignals(false);
+    // it is quite expensive to add/remove things from scene, we can
+    // update them instead and use a little more memory to keep them around
+    int i = 0;
+    int end = std::min(mThumbLabels.size(), mThumbs.size());
+    for (; i < end; ++i) {
+        DkThumbLabel *thumb = mThumbLabels.at(i);
+        thumb->setFileInfo(mThumbs.at(i));
+        thumb->setVisible(true);
+    }
 
-    mThumbLabels.clear();
-
-    for (const auto &fileInfo : std::as_const(mThumbs)) {
+    for (; i < mThumbs.size(); ++i) {
         auto *thumb = new DkThumbLabel(mThumbLoader,
-                                       fileInfo,
+                                       mThumbs.at(i),
                                        DkSettingsManager::param().display().displaySquaredThumbs);
         connect(thumb, &DkThumbLabel::loadFileSignal, this, &DkThumbScene::loadFileSignal);
         connect(thumb, &DkThumbLabel::showFileSignal, this, &DkThumbScene::showFile);
@@ -1318,12 +1334,13 @@ void DkThumbScene::updateThumbLabels()
         mThumbLabels.append(thumb);
     }
 
+    for (; i < mThumbLabels.size(); ++i) {
+        DkThumbLabel *thumb = mThumbLabels.at(i);
+        thumb->setVisible(false);
+    }
+
     showFile();
-
-    if (!mThumbs.empty())
-        updateLayout();
-
-    emit selectionChanged();
+    updateLayout();
 }
 
 void DkThumbScene::setImageLoader(QSharedPointer<DkImageLoader> loader)

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -89,25 +89,40 @@ DkFilePreview::DkFilePreview(DkThumbLoader *loader, QWidget *parent, Qt::WindowF
     connect(mThumbLoader,
             &DkThumbLoader::thumbnailLoaded,
             this,
-            [this](const QString &filePath, const QImage &thumb, const bool fromExif) {
-                auto it = mThumbs.find(filePath);
-                if (it == mThumbs.end()) {
+            [this](ThumbnailId id, const QString &filePath, const QImage &img, const bool fromExif) {
+                auto req = mThumbRequests.find(id);
+                if (req == mThumbRequests.end()) { // request from another widget
                     return;
                 }
-                Thumb &th = *it;
-                th.request = {};
-                th.image = thumb;
+                Q_ASSERT(req.value() == filePath);
+                mThumbRequests.remove(id);
+
+                auto thumb = mThumbs.find(filePath);
+                if (thumb == mThumbs.end()) { // may have been removed
+                    return;
+                }
+
+                Thumb &th = *thumb;
+                th.image = img;
                 th.fromExif = fromExif;
                 th.loading = false;
                 update();
             });
 
-    connect(mThumbLoader, &DkThumbLoader::thumbnailLoadFailed, this, [this](const QString &filePath) {
-        auto it = mThumbs.find(filePath);
-        if (it == mThumbs.end()) {
+    connect(mThumbLoader, &DkThumbLoader::thumbnailLoadFailed, this, [this](ThumbnailId id, const QString &filePath) {
+        auto req = mThumbRequests.find(id);
+        if (req == mThumbRequests.end()) {
             return;
         }
-        Thumb &th = *it;
+        Q_ASSERT(req.value() == filePath);
+        mThumbRequests.remove(id);
+
+        auto thumb = mThumbs.find(filePath);
+        if (thumb == mThumbs.end()) {
+            return;
+        }
+
+        Thumb &th = *thumb;
         th.notExist = true;
         th.loading = false;
         update();
@@ -370,8 +385,10 @@ void DkFilePreview::drawThumbs(QPainter *painter)
 
         if (oobStart || oobEnd) {
             if (existsInTable && thumb->loading) {
-                mThumbLoader->cancelThumbnailRequest(thumb->request);
-                mThumbs.remove(filePath);
+                auto req = thumb->request;
+                mThumbs.remove(req.filePath);
+                mThumbRequests.remove(req.id);
+                mThumbLoader->cancelThumbnailRequest(req);
             }
 
             if (oobEnd && !scrollToCurrentImage) {
@@ -392,10 +409,14 @@ void DkFilePreview::drawThumbs(QPainter *painter)
             }
 
             Thumb newThumb;
-            newThumb.loading = true;
             newThumb.request = LoadThumbnailRequest{filePath, option, size, constraint};
+            newThumb.loading = true;
+
+            Q_ASSERT(!mThumbRequests.contains(newThumb.request.id));
+            Q_ASSERT(!mThumbs.contains(filePath));
 
             mThumbs.insert(filePath, newThumb);
+            mThumbRequests.insert(newThumb.request.id, filePath);
             mThumbLoader->requestThumbnail(newThumb.request);
         }
 
@@ -935,11 +956,12 @@ DkThumbLabel::DkThumbLabel(DkThumbLoader *thumbLoader,
     setFileInfo(fileInfo);
 }
 
-void DkThumbLabel::onThumbnailLoaded(const QString &filePath, const QImage &thumb, bool fromExif)
+void DkThumbLabel::onThumbnailLoaded(ThumbnailId id, const QString &filePath, const QImage &thumb, bool fromExif)
 {
-    if (filePath != mFilePath) {
+    if (id != mThumbRequest.id) {
         return;
     }
+    Q_ASSERT(mFilePath == filePath);
 
     mFetchingThumb = false;
     mThumbRequest = {};
@@ -954,11 +976,13 @@ void DkThumbLabel::onThumbnailLoaded(const QString &filePath, const QImage &thum
     update();
 }
 
-void DkThumbLabel::onThumbnailLoadFailed(const QString &filePath)
+void DkThumbLabel::onThumbnailLoadFailed(ThumbnailId id, const QString &filePath)
 {
-    if (filePath != mFilePath) {
+    if (id != mThumbRequest.id) {
         return;
     }
+    Q_ASSERT(mFilePath == filePath);
+
     mThumbNotExist = true;
     mFetchingThumb = false;
     mThumbRequest = {};
@@ -2416,10 +2440,13 @@ DkThumbPreviewLabel::DkThumbPreviewLabel(const QString &filePath,
 
 {
     connect(mLoader, &DkThumbLoader::thumbnailLoaded, this, &DkThumbPreviewLabel::thumbLoaded);
-    connect(mLoader, &DkThumbLoader::thumbnailLoadFailed, this, [this](const QString &path) {
-        if (path != mFilePath) {
+    connect(mLoader, &DkThumbLoader::thumbnailLoadFailed, this, [this](ThumbnailId id, const QString &path) {
+        if (id != mThumbId) {
             return;
         }
+        Q_ASSERT(path == mFilePath);
+        mThumbId = {};
+
         setProperty("empty", true); // apply empty style
         style()->unpolish(this);
         style()->polish(this);
@@ -2433,14 +2460,18 @@ DkThumbPreviewLabel::DkThumbPreviewLabel(const QString &filePath,
     QFileInfo fInfo(filePath);
     setToolTip(fInfo.fileName());
 
-    mLoader->requestThumbnail(LoadThumbnailRequest{filePath});
+    LoadThumbnailRequest request{filePath};
+    mThumbId = request.id;
+    mLoader->requestThumbnail(request);
 }
 
-void DkThumbPreviewLabel::thumbLoaded(const QString &filePath, const QImage &img)
+void DkThumbPreviewLabel::thumbLoaded(ThumbnailId id, const QString &filePath, const QImage &img)
 {
-    if (filePath != mFilePath) {
+    if (mThumbId != id) {
         return;
     }
+    mThumbId = {};
+    Q_ASSERT(filePath == mFilePath);
 
     QPixmap pm = QPixmap::fromImage(img);
     pm = DkImage::makeSquare(pm);

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -1270,6 +1270,14 @@ DkThumbScene::DkThumbScene(DkThumbLoader *thumbLoader, QWidget *parent /* = 0 */
                                            Qt::SHIFT | Qt::Key_Down,
                                            Qt::SHIFT | Qt::Key_Left,
                                            Qt::SHIFT | Qt::Key_Right,
+                                           Qt::CTRL | Qt::Key_Up,
+                                           Qt::CTRL | Qt::Key_Down,
+                                           Qt::CTRL | Qt::Key_Left,
+                                           Qt::CTRL | Qt::Key_Right,
+                                           Qt::CTRL | Qt::SHIFT | Qt::Key_Up,
+                                           Qt::CTRL | Qt::SHIFT | Qt::Key_Down,
+                                           Qt::CTRL | Qt::SHIFT | Qt::Key_Left,
+                                           Qt::CTRL | Qt::SHIFT | Qt::Key_Right,
                                        });
 }
 
@@ -1435,34 +1443,96 @@ void DkThumbScene::connectLoader(QSharedPointer<DkImageLoader> loader, bool conn
 
 void DkThumbScene::keyPressEvent(QKeyEvent *event)
 {
-    int idx = selectedThumbIndex((event->key() != Qt::Key_Right && event->key() != Qt::Key_Down));
+    unsigned mods = event->modifiers();
+    mods &= ~Qt::KeypadModifier; // arrow from numpad
 
-    if (idx == -1)
+    // range mode: extend selection from anchor to current
+    bool range = mods == Qt::ShiftModifier;
+
+    // follow mode: extend selection from last to current; current becomes anchor
+    bool follow = mods == (Qt::ShiftModifier | Qt::ControlModifier);
+
+    // teleport mode: move to another location, deselect previous, current becomes anchor
+    bool teleport = mods == Qt::ControlModifier;
+
+    auto thumb = mThumbLabels.value(mSelectionCursor);
+    if (!thumb) {
         return;
+    }
 
-    if (event->modifiers() != Qt::ShiftModifier
-        && (event->key() == Qt::Key_Left || event->key() == Qt::Key_Right || event->key() == Qt::Key_Up
-            || event->key() == Qt::Key_Down))
-        selectThumbs(false);
+    int from = thumb->index();
+    int to;
 
     switch (event->key()) {
     case Qt::Key_Left: {
-        selectThumb(qMax(idx - 1, 0));
+        to = from - 1;
         break;
     }
     case Qt::Key_Right: {
-        selectThumb(qMin(idx + 1, mThumbs.size() - 1));
+        to = from + 1;
         break;
     }
     case Qt::Key_Up: {
-        selectThumb(qMax(idx - mNumCols, 0));
+        to = from - mNumCols;
         break;
     }
     case Qt::Key_Down: {
-        selectThumb(qMin(idx + mNumCols, mThumbs.size() - 1));
+        to = from + mNumCols;
         break;
     }
+    default:
+        return;
     }
+
+    to = qBound(0, to, mThumbs.size() - 1);
+    bool extend = false;
+
+    if (range) {
+        // select block from anchor to current
+        from = mSelectionAnchor;
+        extend = true;
+
+        // deselect block from last cursor to current cursor
+        QSignalBlocker blocker(this); // prevent selectionChanged()
+        int begin = mSelectionCursor;
+        int end = to;
+        if (end < begin) {
+            int tmp = begin;
+            begin = end;
+            end = tmp;
+        }
+
+        selectThumbs(false, begin, end + 1, extend);
+
+    } else if (follow) {
+        from = to;
+        extend = true;
+        mSelectionAnchor = to;
+    } else if (teleport) {
+        from = to;
+        extend = true;
+        mSelectionAnchor = to;
+
+        // deselect previous cursor
+        QSignalBlocker blocker(this);
+        selectThumbs(false, mSelectionCursor, mSelectionCursor + 1, extend);
+    } else {
+        from = to;
+        mSelectionAnchor = to;
+    }
+
+    mSelectionCursor = to;
+
+    if (from > to) {
+        int tmp = from;
+        from = to;
+        to = tmp;
+    }
+
+    selectThumbs(true, from, to + 1, extend);
+
+    thumb = mThumbLabels.value(mSelectionCursor);
+    thumb->ensureVisible(QRectF{}, 5, 5);
 }
 
 void displayFileInfoInStatusbar(const QString &filePath)
@@ -1541,19 +1611,6 @@ QString DkThumbScene::currentDir() const
     }
 
     return mThumbs[0].dirPath();
-}
-
-int DkThumbScene::selectedThumbIndex(bool first)
-{
-    int selIdx = -1;
-    for (int idx = 0; idx < mThumbs.size(); idx++) {
-        if (first && mThumbLabels[idx]->isSelected())
-            return idx;
-        else if (mThumbLabels[idx]->isSelected())
-            selIdx = idx;
-    }
-
-    return selIdx;
 }
 
 QGraphicsView *DkThumbScene::getView() const
@@ -1840,6 +1897,7 @@ void DkThumbScene::thumbClicked(DkThumbLabel *thumb, QMouseEvent *event)
     // - ctrl+shift click deselects from anchor
     int to = thumb->index(), from = to;
     bool select = true, extend = false;
+    mSelectionCursor = to;
 
     if (event->modifiers() & Qt::ShiftModifier) {
         // range selection, selection extends from anchor

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -1499,8 +1499,20 @@ void DkThumbScene::resizeThumbs(float dx)
 
     if (newSize > 6 && newSize <= max_thumb_size) {
         DkSettingsManager::param().display().thumbPreviewSize = newSize;
+
+        QString centerPath{};
+        DkThumbLabel *centerThumb = getCenterThumb();
+        if (centerThumb) {
+            centerPath = centerThumb->filePath();
+            centerThumb = nullptr; // potentially invalidated by updateLayout()
+        }
+
         updateLayout();
         // TODO: cancel anything no longer visible
+
+        if (selectedItems().empty() && !centerPath.isEmpty()) {
+            ensureVisible(centerPath);
+        }
     }
 }
 
@@ -1744,6 +1756,24 @@ QVector<DkThumbLabel *> DkThumbScene::getSelectedThumbs() const
     }
 
     return selected;
+}
+
+DkThumbLabel *DkThumbScene::getCenterThumb() const
+{
+    DkThumbLabel *centerThumb = nullptr;
+
+    auto viewList = views();
+    if (!viewList.empty()) {
+        QGraphicsView *view = viewList.at(0);
+        // we can't test a point since we might hit the space between items
+        QRect centerRect = QRect{view->rect().center(), QSize{1, 1}}.adjusted(-8, -8, 8, 8);
+        QList<QGraphicsItem *> centerItems = view->items(centerRect, Qt::IntersectsItemBoundingRect);
+        if (!centerItems.isEmpty()) {
+            centerThumb = static_cast<DkThumbLabel *>(centerItems.at(0));
+        }
+    }
+
+    return centerThumb;
 }
 
 int DkThumbScene::findThumb(DkThumbLabel *thumb) const

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -997,13 +997,30 @@ void DkThumbLabel::generatePixmap(const QImage &thumb)
         targetRect.moveCenter(br.center());
     }
 
+    bool unscaled = std::abs(targetRect.height() * mDevicePixelRatio - srcRect.height()) < 1.0;
+    if (unscaled) {
+        // we have a device-scaled thumbnail, but rounding will result in interpolation
+        // adjust to get closer to ideal scale factor and reduce this
+        qreal scaleFactor = srcRect.height() / targetRect.height();
+        qreal scaleDiff = mDevicePixelRatio - scaleFactor;
+        qreal dx = srcRect.width() * scaleDiff / 2.0;
+        qreal dy = srcRect.height() * scaleDiff / 2.0;
+        srcRect = srcRect.adjusted(-dx, -dy, dx, dy);
+
+        // qreal adjFactorH = mDevicePixelRatio - (srcRect.height() / targetRect.height());
+        // qreal adjFactorW = mDevicePixelRatio - (srcRect.width() / targetRect.width());
+        // qDebug() << "SF" << scaleDiff << adjFactorH << adjFactorW;
+    }
+
     const QSize pixmapSize = (br.size() * mDevicePixelRatio).toSize();
     QPixmap pm(pixmapSize);
     pm.setDevicePixelRatio(mDevicePixelRatio);
     pm.fill(Qt::transparent);
 
     QPainter painter(&pm);
-    painter.setRenderHints(QPainter::SmoothPixmapTransform);
+    if (!unscaled) {
+        painter.setRenderHints(QPainter::SmoothPixmapTransform);
+    }
     painter.drawImage(targetRect, thumb, srcRect);
 
     if (mPixmapKey) {
@@ -1050,7 +1067,8 @@ void DkThumbLabel::paint(QPainter *painter, const QStyleOptionGraphicsItem *opti
 {
     std::optional<QPixmap> pm = pixmap();
 
-    mThumbOption = LoadThumbnailOption::none; // TODO: select current options from settings
+    mThumbOption = DkSettingsManager::param().display().highQualityThumbs ? LoadThumbnailOption::force_size
+                                                                          : LoadThumbnailOption::none;
     mDevicePixelRatio = painter->device()->devicePixelRatio();
     const QSize pixmapSize = (boundingRect().size() * mDevicePixelRatio).toSize();
 
@@ -1059,7 +1077,9 @@ void DkThumbLabel::paint(QPainter *painter, const QStyleOptionGraphicsItem *opti
         // This avoids stucking infinitely in fetching thumb state
         mFetchingThumb = true;
         int maxSize = mThumbOption == LoadThumbnailOption::force_size ? pixmapSize.height() : max_thumb_size;
-        mThumbRequest = LoadThumbnailRequest{mFilePath, mThumbOption, maxSize};
+        auto constraint = DkSettingsManager::param().display().displaySquaredThumbs ? ScaleConstraint::shortest_side
+                                                                                    : ScaleConstraint::longest_side;
+        mThumbRequest = LoadThumbnailRequest{mFilePath, mThumbOption, maxSize, constraint};
         mThumbLoader->requestThumbnail(mThumbRequest);
 
         // It is possible we have pixmap now (from cache), check again.

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -1329,6 +1329,8 @@ void DkThumbScene::updateThumbs(QVector<QSharedPointer<DkImageContainerT>> thumb
         selectedIdx = qMax(0, qMin(selectedIdx, mThumbs.size() - 1));
         selectThumb(selectedIdx);
     }
+
+    update();
 }
 
 void DkThumbScene::updateThumbLabels()

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -1307,7 +1307,7 @@ void DkThumbScene::updateLayout()
 
             DkThumbLabel *cLabel = mThumbLabels.at(tIdx);
             cLabel->setPos(cXOffset, cYOffset);
-            cLabel->setRow(rIdx);
+            cLabel->setGridPos(tIdx, rIdx, cIdx);
             cXOffset += psz + mXOffset;
         }
 

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -192,7 +192,7 @@ void DkFilePreview::initOrientations()
         orientation = Qt::Vertical;
 
     if (windowPosition == pos_dock_ver || windowPosition == pos_dock_hor)
-        minHeight = max_thumb_size;
+        minHeight = DkSettingsManager::param().resources().maxThumbSize / devicePixelRatio();
     else
         minHeight = DkSettingsManager::param().effectiveThumbSize(this);
 
@@ -399,7 +399,7 @@ void DkFilePreview::drawThumbs(QPainter *painter)
 
         // only fetch thumbs if we are not moving too fast...
         if (!existsInTable) {
-            int size = max_thumb_size;
+            int size = DkSettingsManager::param().resources().maxThumbSize;
             ScaleConstraint constraint = orientation == Qt::Horizontal ? ScaleConstraint::height
                                                                        : ScaleConstraint::width;
             LoadThumbnailOption option = LoadThumbnailOption::none;
@@ -733,14 +733,14 @@ void DkFilePreview::wheelEvent(QWheelEvent *event)
         int newSize = DkSettingsManager::param().display().thumbSize;
         newSize += qRound(delta * 0.05f);
 
+        // divide by dpr since larger would blur the thumbnail
+        const int maxSize = DkSettingsManager::param().resources().maxThumbSize / devicePixelRatio();
+
+        newSize = qBound(8, newSize, maxSize);
+
         // make sure it is even
         if (qRound(newSize * 0.5f) != newSize * 0.5f)
             newSize++;
-
-        if (newSize < 8)
-            newSize = 8;
-        else if (newSize > max_thumb_size)
-            newSize = max_thumb_size;
 
         if (newSize != DkSettingsManager::param().display().thumbSize) {
             DkSettingsManager::param().display().thumbSize = newSize;
@@ -1134,8 +1134,9 @@ void DkThumbLabel::fetchThumb(float devicePixelRatio)
     if (!mFetchingThumb && (!pm || pm->size() != pixmapSize) && !mThumbNotExist) {
         // setting fetching flag first, because requestThumbnail might return thumbnail immediately
         // This avoids stucking infinitely in fetching thumb state
+        const int maxThumbSize = DkSettingsManager::param().resources().maxThumbSize;
         mFetchingThumb = true;
-        int maxSize = mThumbOption == LoadThumbnailOption::force_size ? pixmapSize.height() : max_thumb_size;
+        int maxSize = mThumbOption == LoadThumbnailOption::force_size ? pixmapSize.height() : maxThumbSize;
         auto constraint = DkSettingsManager::param().display().displaySquaredThumbs ? ScaleConstraint::shortest_side
                                                                                     : ScaleConstraint::longest_side;
         mThumbRequest = LoadThumbnailRequest{mFilePath, mThumbOption, maxSize, constraint};
@@ -1589,23 +1590,23 @@ void DkThumbScene::resizeThumbs(float dx)
         dx += 2.0f;
 
     int newSize = qRound(DkSettingsManager::param().display().thumbPreviewSize * dx);
+    int maxSize = DkSettingsManager::param().resources().maxThumbSize / getView()->devicePixelRatio();
 
-    if (newSize > 6 && newSize <= max_thumb_size) {
-        DkSettingsManager::param().display().thumbPreviewSize = newSize;
+    newSize = qBound(6, newSize, maxSize);
+    DkSettingsManager::param().display().thumbPreviewSize = newSize;
 
-        QString centerPath{};
-        DkThumbLabel *centerThumb = getCenterThumb();
-        if (centerThumb) {
-            centerPath = centerThumb->filePath();
-            centerThumb = nullptr; // potentially invalidated by updateLayout()
-        }
+    QString centerPath{};
+    DkThumbLabel *centerThumb = getCenterThumb();
+    if (centerThumb) {
+        centerPath = centerThumb->filePath();
+        centerThumb = nullptr; // potentially invalidated by updateLayout()
+    }
 
-        updateLayout();
-        // TODO: cancel anything no longer visible
+    updateLayout();
+    // TODO: cancel anything no longer visible
 
-        if (selectedItems().empty() && !centerPath.isEmpty()) {
-            ensureVisible(centerPath);
-        }
+    if (selectedItems().empty() && !centerPath.isEmpty()) {
+        ensureVisible(centerPath);
     }
 }
 

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -1265,8 +1265,10 @@ void DkThumbScene::updateLayout()
         if (thumb->isSelected())
             lastSelected = thumb;
     }
+
     if (lastSelected)
-        lastSelected->ensureVisible();
+        ensureVisible(lastSelected->filePath());
+
     update();
 }
 
@@ -1416,9 +1418,20 @@ void DkThumbScene::showFile(const QString &filePath)
 
 void DkThumbScene::ensureVisible(const QString &path) const
 {
-    for (DkThumbLabel *label : mThumbLabels) {
+    for (DkThumbLabel *label : std::as_const(mThumbLabels)) {
         if (label->filePath() == path) {
-            label->ensureVisible();
+            int xMargin = 50, yMargin = 50;
+
+            const QList<QGraphicsView *> viewList = this->views();
+            if (!viewList.isEmpty()) {
+                QGraphicsView *view = viewList.at(0);
+                QRectF br = label->boundingRect();
+                xMargin = (view->width() - br.width()) / 2;
+                yMargin = (view->height() - br.height()) / 2;
+            }
+
+            // FIXME: there are rare cases where this does not work, seemingly random
+            label->ensureVisible(QRect(), xMargin, yMargin);
             break;
         }
     }

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -1289,7 +1289,7 @@ void DkThumbScene::updateLayout()
         return;
     }
 
-    QSize pSize = QSize(view->viewport()->size());
+    QSize pSize = view->viewport()->size();
 
     int psz = DkSettingsManager::param().effectiveThumbPreviewSize();
     mXOffset = 2; // qCeil(psz*0.1f);
@@ -1572,17 +1572,18 @@ void displayFileInfoInStatusbar(const QString &filePath)
 
 void DkThumbScene::showFile(const QString &filePath)
 {
-    int sf = getSelectedFiles().size();
+    const QStringList selectedFiles = getSelectedFiles();
+    int numSelected = selectedFiles.size();
     DkStatusBar *bar = DkStatusBarManager::instance().statusbar();
     if (filePath == QDir::currentPath() || filePath.isEmpty()) { // i.e. user is NO LONGER hovering over a file
-        if (sf == 0) {
+        if (numSelected == 0) {
             QString info = QString::number(mThumbs.size()) + tr(" images");
             bar->setMessage(tr("%1 | %2").arg(info, currentDir()));
             bar->setMessage("", DkStatusBar::status_filesize_info);
-        } else if (sf == 1) {
-            displayFileInfoInStatusbar(getSelectedFiles()[0]);
+        } else if (numSelected == 1) {
+            displayFileInfoInStatusbar(selectedFiles.at(0));
         } else {
-            QString info = QString::number(sf) + tr(" selected");
+            QString info = QString::number(numSelected) + tr(" selected");
             bar->setMessage(tr("%1 | %2").arg(info, currentDir()));
             bar->setMessage("", DkStatusBar::status_filesize_info);
         }
@@ -1652,7 +1653,7 @@ void DkThumbScene::toggleSquaredThumbs(bool squares)
 {
     DkSettingsManager::param().display().displaySquaredThumbs = squares;
 
-    for (const auto t : mThumbLabels) {
+    for (auto *t : std::as_const(mThumbLabels)) {
         t->setFillSquare(squares);
     }
     update();
@@ -1705,7 +1706,7 @@ void DkThumbScene::cancelLoading()
 {
     DkThumbsThreadPool::clear();
 
-    for (auto t : mThumbLabels)
+    for (auto *t : std::as_const(mThumbLabels))
         t->cancelLoading();
 }
 
@@ -1741,13 +1742,15 @@ void DkThumbScene::selectThumbs(bool selected, int from, int to, bool extend)
 
 void DkThumbScene::copySelected() const
 {
-    QStringList fileList = getSelectedFiles();
-    if (fileList.empty())
+    const QStringList fileList = getSelectedFiles();
+    if (fileList.empty()) {
         return;
+    }
 
     QList<QUrl> urls;
-    for (QString cStr : fileList)
-        urls.append(QUrl::fromLocalFile(cStr));
+    for (const auto &filePath : fileList) {
+        urls.append(QUrl::fromLocalFile(filePath));
+    }
 
     auto *mimeData = new QMimeData();
     mimeData->setUrls(urls);
@@ -1782,14 +1785,15 @@ void DkThumbScene::copyImages(const QMimeData *mimeData, const Qt::DropAction &d
 
     QDir dir = dirInfo.path();
 
-    for (QUrl url : mimeData->urls()) {
+    for (const QUrl &url : mimeData->urls()) {
         QFileInfo fileInfo = DkUtils::urlToLocalFile(url);
         QFile file(fileInfo.absoluteFilePath());
         QString newFilePath = QFileInfo(dir, fileInfo.fileName()).absoluteFilePath();
 
         // ignore existing silently
-        if (QFileInfo(newFilePath).exists())
+        if (QFile::exists(newFilePath)) {
             continue;
+        }
 
         auto askUser = [&](const QString &aMsg) {
             int answer = QMessageBox::critical(DkUtils::getMainWindow(),
@@ -1860,8 +1864,7 @@ void DkThumbScene::deleteSelected()
 
 void DkThumbScene::renameSelected() const
 {
-    QStringList fileList = getSelectedFiles();
-
+    const QStringList fileList = getSelectedFiles();
     if (fileList.empty())
         return;
 
@@ -1967,7 +1970,7 @@ QStringList DkThumbScene::getSelectedFiles() const
     QStringList fileList;
     fileList.reserve(selected.count());
 
-    for (DkThumbLabel *thumb : selected) {
+    for (auto *thumb : selected) {
         fileList += thumb->filePath();
     }
 
@@ -2186,12 +2189,13 @@ void DkThumbsView::mouseMoveEvent(QMouseEvent *event)
         int dist = qRound(QPointF(event->pos() - mMouseDownPos).manhattanLength());
 
         if (dist > QApplication::startDragDistance()) {
-            QStringList fileList = sc->getSelectedFiles();
+            const QStringList fileList = sc->getSelectedFiles();
 
             if (!fileList.empty()) {
                 QList<QUrl> urls;
-                for (QString fStr : fileList)
-                    urls.append(QUrl::fromLocalFile(fStr));
+                for (const auto &filePath : fileList) {
+                    urls.append(QUrl::fromLocalFile(filePath));
+                }
 
                 auto *mimeData = new QMimeData;
                 mimeData->setUrls(urls);
@@ -2395,13 +2399,11 @@ void DkThumbScrollWidget::batchProcessFiles() const
 
 void DkThumbScrollWidget::batchPrint() const
 {
-    QStringList fileList = mThumbsScene->getSelectedFiles();
-
     QVector<QImage> imgs;
     DkBasicLoader bl;
 
-    for (const QString &f : fileList) {
-        bl.loadGeneral(f);
+    for (const auto &filePath : mThumbsScene->getSelectedFiles()) {
+        bl.loadGeneral(filePath);
 
         if (!bl.image().isNull())
             imgs << bl.image();
@@ -2409,8 +2411,9 @@ void DkThumbScrollWidget::batchPrint() const
 
     auto *printPreviewDialog = new DkPrintPreviewDialog(DkUtils::getMainWindow());
 
-    for (const QImage &img : imgs)
+    for (const auto &img : std::as_const(imgs)) {
         printPreviewDialog->addImage(img);
+    }
 
     printPreviewDialog->exec();
     printPreviewDialog->deleteLater();
@@ -2796,16 +2799,18 @@ void DkRecentDirWidget::mousePressEvent(QMouseEvent *event)
 
 void DkRecentDirWidget::enterEvent(DkEnterEvent *event)
 {
-    for (auto b : mButtons)
+    for (auto b : std::as_const(mButtons)) {
         b->show();
+    }
 
     DkWidget::enterEvent(event);
 }
 
 void DkRecentDirWidget::leaveEvent(QEvent *event)
 {
-    for (auto b : mButtons)
+    for (auto b : std::as_const(mButtons)) {
         b->hide();
+    }
 
     DkWidget::leaveEvent(event);
 }
@@ -2853,7 +2858,7 @@ void DkRecentFilesWidget::updateList()
     auto *dummy = new QWidget(this);
     auto *l = new QVBoxLayout(dummy);
 
-    for (auto rd : fm.recentDirs()) {
+    for (const auto &rd : fm.recentDirs()) {
         auto *rf = new DkRecentDirWidget(rd, mThumbLoader, dummy);
         rf->setMaximumWidth(500);
         connect(rf, &DkRecentDirWidget::loadFileSignal, this, &DkRecentFilesWidget::loadFileSignal);
@@ -2960,7 +2965,7 @@ DkRecentDirManager::DkRecentDirManager()
     QList<DkRecentDir> recentDirs = genFileLists(DkSettingsManager::param().global().recentFiles);
 
     // merge pinned dirs with recent dirs
-    for (const DkRecentDir &recentDir : recentDirs) {
+    for (const auto &recentDir : std::as_const(recentDirs)) {
         int idx = mDirs.indexOf(recentDir);
         if (idx < 0)
             mDirs.append(recentDir);

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -412,12 +412,12 @@ void DkFilePreview::drawThumbs(QPainter *painter)
             newThumb.request = LoadThumbnailRequest{filePath, option, size, constraint};
             newThumb.loading = true;
 
-            Q_ASSERT(!mThumbRequests.contains(newThumb.request.id));
-            Q_ASSERT(!mThumbs.contains(filePath));
-
-            mThumbs.insert(filePath, newThumb);
-            mThumbRequests.insert(newThumb.request.id, filePath);
-            mThumbLoader->requestThumbnail(newThumb.request);
+            if (!mThumbRequests.contains(newThumb.request.id)) {
+                Q_ASSERT(!mThumbs.contains(filePath));
+                mThumbs.insert(filePath, newThumb);
+                mThumbRequests.insert(newThumb.request.id, filePath);
+                mThumbLoader->requestThumbnail(newThumb.request);
+            }
         }
 
         bool isLeftGradient = (orientation == Qt::Horizontal && worldMatrix.dx() < 0

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -337,7 +337,7 @@ void DkFilePreview::drawThumbs(QPainter *painter)
     const int thumbSize = DkSettingsManager::param().effectiveThumbSize(this); // size when we don't have img yet
 
     const auto &files = mFiles;
-    const int numFiles = files.size();
+    const int numFiles = static_cast<int>(files.size());
     for (int idx = 0; idx < numFiles; idx++) {
         const QString &filePath = files[idx].path();
 
@@ -1462,7 +1462,7 @@ void DkThumbScene::connectLoader(QSharedPointer<DkImageLoader> loader, bool conn
 
 void DkThumbScene::keyPressEvent(QKeyEvent *event)
 {
-    unsigned mods = event->modifiers();
+    Qt::KeyboardModifiers mods = event->modifiers();
     mods &= ~Qt::KeypadModifier; // arrow from numpad
 
     // range mode: extend selection from anchor to current

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -1367,9 +1367,10 @@ void DkThumbScene::updateThumbs(QVector<QSharedPointer<DkImageContainerT>> thumb
     }
     updateThumbLabels();
 
-    if (selectedIdx >= 0) {
-        selectedIdx = qMax(0, qMin(selectedIdx, mThumbs.size() - 1));
-        selectThumb(selectedIdx);
+    if (selectedIdx >= 0 && !mThumbs.empty()) {
+        selectedIdx = qBound(0, selectedIdx, mThumbs.size() - 1);
+        selectThumbs(true, selectedIdx, selectedIdx + 1, false);
+        // ensureVisible(selectedIdx); // TODO:
     }
 
     update();
@@ -1630,51 +1631,32 @@ void DkThumbScene::cancelLoading()
 
 void DkThumbScene::selectAllThumbs(bool selected)
 {
-    selectThumbs(selected);
+    selectThumbs(selected, 0, mThumbs.size(), false);
 }
 
-void DkThumbScene::selectThumbs(bool selected /* = true */, int from /* = 0 */, int to /* = -1 */)
+void DkThumbScene::selectThumbs(bool selected, int from, int to, bool extend)
 {
-    if (mThumbs.empty())
-        return;
-
-    if (to == -1)
-        to = mThumbs.size() - 1;
-
-    if (from > to) {
-        int tmp = to;
-        to = from;
-        from = tmp;
-    }
-
-    blockSignals(true);
-    for (int idx = from; idx <= to && idx < mThumbs.size(); idx++) {
-        mThumbLabels.at(idx)->setSelected(selected);
-    }
-    blockSignals(false);
-    emit selectionChanged();
-    showFile(); // update selection label
-}
-
-void DkThumbScene::selectThumb(int idx, bool select)
-{
-    if (mThumbs.empty())
-        return;
-
-    if (idx < 0 || idx >= mThumbs.size()) {
-        qWarning() << "[ThumbScene] index out of bounds in selectThumbs()" << idx;
+    if (mThumbs.empty()) {
         return;
     }
 
-    blockSignals(true);
-    mThumbLabels[idx]->setSelected(select);
-    blockSignals(false);
+    Q_ASSERT(from >= 0 && from < mThumbs.size());
+    Q_ASSERT(to >= from && to <= mThumbs.size());
+
+    {
+        QSignalBlocker blocker(this); // prevent selectionChanged()
+
+        if (!extend) {
+            clearSelection();
+        }
+
+        for (int idx = from; idx < to; idx++) {
+            mThumbLabels.at(idx)->setSelected(selected);
+        }
+    }
 
     emit selectionChanged();
-    showFile(); // update selection label
-
-    Q_ASSERT(mThumbs.size() > idx && mThumbLabels[idx]);
-    mThumbLabels[idx]->ensureVisible();
+    showFile(); // update status bar
 }
 
 void DkThumbScene::copySelected() const

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -966,6 +966,18 @@ void DkThumbLabel::onThumbnailLoaded(ThumbnailId id, const QString &filePath, co
     mFetchingThumb = false;
     mThumbRequest = {};
 
+    // If we are not visible to the view (prefetching or straggler), do not generate
+    // a pixmap as it may kick a visible item out of the cache, forcing a refetch
+    QGraphicsView *view = scene()->views().value(0);
+    if (!view) {
+        return;
+    }
+
+    QRectF viewRect = view->mapToScene(view->viewport()->rect()).boundingRect();
+    if (!sceneBoundingRect().intersects(viewRect)) {
+        return;
+    }
+
     // update label
     mText.setPos(0, DkSettingsManager::param().effectiveThumbPreviewSize());
 
@@ -1325,6 +1337,7 @@ void DkThumbScene::updateLayout()
     cacheKb = (cacheKb / 1024 + 1) * 1024; // to nearest MB
     QPixmapCache::setCacheLimit(cacheKb);
 
+    mLastViewPortRect = {};
 }
 
 void DkThumbScene::updateThumbs(QVector<QSharedPointer<DkImageContainerT>> thumbs)
@@ -1880,17 +1893,70 @@ bool DkThumbScene::allThumbsSelected() const
 
 void DkThumbScene::viewportChanged(const QRectF &portRect)
 {
-    // Cancel anything that is no longer visible
-    for (const auto item : items()) {
-        auto it = dynamic_cast<DkThumbLabel *>(item);
-        if (it == nullptr) {
-            continue;
-        }
+    // Detect the scroll direction for prefetching
+    // NOTE: It will take >1 scroll to be sure user is scrolling and it wasn't a layout change
+    bool scrollUp = false, scrollDown = false;
 
-        const bool intersects = portRect.intersects(it->sceneBoundingRect());
-        if (!intersects) {
-            it->cancelLoading();
+    if (mLastViewPortRect.isNull()) {
+        mLastViewPortRect = portRect;
+    } else {
+        float dx = portRect.x() - mLastViewPortRect.x();
+        float dy = portRect.y() - mLastViewPortRect.y();
+        mLastViewPortRect = portRect;
+        if (dx == 0) {
+            if (dy < 0) {
+                scrollUp = true;
+            } else if (dy > 0) {
+                scrollDown = true;
+            }
         }
+    }
+
+    auto *view = getView();
+    Q_ASSERT(view);
+
+    // First/last visible row and prioritize visible thumbs
+    QList<DkThumbLabel *> offscreen;
+    offscreen.reserve(mThumbLabels.size());
+
+    int firstRow = -1, lastRow = -1;
+    for (DkThumbLabel *thumb : std::as_const(mThumbLabels)) {
+        const int row = thumb->row();
+        const bool intersects = portRect.intersects(thumb->sceneBoundingRect());
+
+        if (intersects) {
+            thumb->fetchThumb(view->devicePixelRatio());
+            lastRow = row;
+            if (firstRow < 0) {
+                firstRow = row;
+            }
+        } else {
+            offscreen.append(thumb);
+        }
+    }
+
+    // Cancel offscreen thumbnails, prefetch if they are likely to be needed soon
+    QList<DkThumbLabel *> prefetch;
+    int numRows = lastRow - firstRow + 1;
+    for (DkThumbLabel *thumb : std::as_const(offscreen)) {
+        const int row = thumb->row();
+        bool prevPage = scrollUp && row >= firstRow - numRows && row < firstRow;
+        bool nextPage = scrollDown && row <= lastRow + numRows && row > lastRow;
+
+        if (view && (prevPage || nextPage)) {
+            prefetch.append(thumb);
+        } else {
+            thumb->cancelLoading();
+        }
+    }
+
+    // Prioritize the first thumbs that will scroll into view
+    if (scrollUp) {
+        std::reverse(prefetch.begin(), prefetch.end());
+    }
+
+    for (auto *thumb : std::as_const(prefetch)) {
+        thumb->fetchThumb(view->devicePixelRatio());
     }
 }
 
@@ -1904,8 +1970,11 @@ DkThumbsView::DkThumbsView(DkThumbScene *scene, QWidget *parent /* = 0 */)
     setAcceptDrops(true);
 
     connect(verticalScrollBar(), &QScrollBar::valueChanged, this, [&] {
-        const QRectF portRect = mapToScene(viewport()->rect()).boundingRect();
-        mThumbScene->viewportChanged(portRect);
+        DkThumbScene *sc = thumbsScene();
+        if (sc) { // valueChanged() may fire when scene is destructed
+            const QRectF portRect = mapToScene(viewport()->rect()).boundingRect();
+            sc->viewportChanged(portRect);
+        }
     });
 
     auto *scrollOnePageUpAction = new QAction(this);

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -1307,8 +1307,10 @@ void DkThumbScene::updateThumbs(QVector<QSharedPointer<DkImageContainerT>> thumb
     int selectedIdx = mLastSelectedIdx;
     mLastSelectedIdx = -1;
 
+    Q_ASSERT(mThumbLabels.size() >= mThumbs.size());
+
     if (selectedIdx < 0) {
-        for (int idx = 0; idx < mThumbLabels.size(); idx++) {
+        for (int idx = 0; idx < mThumbs.size(); idx++) {
             if (mThumbLabels.at(idx)->isSelected()) {
                 selectedIdx = idx;
                 break;
@@ -1324,7 +1326,7 @@ void DkThumbScene::updateThumbs(QVector<QSharedPointer<DkImageContainerT>> thumb
     updateThumbLabels();
 
     if (selectedIdx >= 0) {
-        selectedIdx = qMax(0, qMin(selectedIdx, mThumbLabels.size() - 1));
+        selectedIdx = qMax(0, qMin(selectedIdx, mThumbs.size() - 1));
         selectThumb(selectedIdx);
     }
 }
@@ -1404,7 +1406,7 @@ void DkThumbScene::keyPressEvent(QKeyEvent *event)
         break;
     }
     case Qt::Key_Right: {
-        selectThumb(qMin(idx + 1, mThumbLabels.size() - 1));
+        selectThumb(qMin(idx + 1, mThumbs.size() - 1));
         break;
     }
     case Qt::Key_Up: {
@@ -1412,7 +1414,7 @@ void DkThumbScene::keyPressEvent(QKeyEvent *event)
         break;
     }
     case Qt::Key_Down: {
-        selectThumb(qMin(idx + mNumCols, mThumbLabels.size() - 1));
+        selectThumb(qMin(idx + mNumCols, mThumbs.size() - 1));
         break;
     }
     }
@@ -1436,7 +1438,7 @@ void DkThumbScene::showFile(const QString &filePath)
     DkStatusBar *bar = DkStatusBarManager::instance().statusbar();
     if (filePath == QDir::currentPath() || filePath.isEmpty()) { // i.e. user is NO LONGER hovering over a file
         if (sf == 0) {
-            QString info = QString::number(mThumbLabels.size()) + tr(" images");
+            QString info = QString::number(mThumbs.size()) + tr(" images");
             bar->setMessage(tr("%1 | %2").arg(info, currentDir()));
             bar->setMessage("", DkStatusBar::status_filesize_info);
         } else if (sf == 1) {
@@ -1498,7 +1500,7 @@ QString DkThumbScene::currentDir() const
 int DkThumbScene::selectedThumbIndex(bool first)
 {
     int selIdx = -1;
-    for (int idx = 0; idx < mThumbLabels.size(); idx++) {
+    for (int idx = 0; idx < mThumbs.size(); idx++) {
         if (first && mThumbLabels[idx]->isSelected())
             return idx;
         else if (mThumbLabels[idx]->isSelected())
@@ -1575,11 +1577,11 @@ void DkThumbScene::selectAllThumbs(bool selected)
 
 void DkThumbScene::selectThumbs(bool selected /* = true */, int from /* = 0 */, int to /* = -1 */)
 {
-    if (mThumbLabels.empty())
+    if (mThumbs.empty())
         return;
 
     if (to == -1)
-        to = mThumbLabels.size() - 1;
+        to = mThumbs.size() - 1;
 
     if (from > to) {
         int tmp = to;
@@ -1588,7 +1590,7 @@ void DkThumbScene::selectThumbs(bool selected /* = true */, int from /* = 0 */, 
     }
 
     blockSignals(true);
-    for (int idx = from; idx <= to && idx < mThumbLabels.size(); idx++) {
+    for (int idx = from; idx <= to && idx < mThumbs.size(); idx++) {
         mThumbLabels.at(idx)->setSelected(selected);
     }
     blockSignals(false);
@@ -1598,10 +1600,10 @@ void DkThumbScene::selectThumbs(bool selected /* = true */, int from /* = 0 */, 
 
 void DkThumbScene::selectThumb(int idx, bool select)
 {
-    if (mThumbLabels.empty())
+    if (mThumbs.empty())
         return;
 
-    if (idx < 0 || idx >= mThumbLabels.size()) {
+    if (idx < 0 || idx >= mThumbs.size()) {
         qWarning() << "index out of bounds in selectThumbs()" << idx;
         return;
     }
@@ -1613,7 +1615,7 @@ void DkThumbScene::selectThumb(int idx, bool select)
     emit selectionChanged();
     showFile(); // update selection label
 
-    Q_ASSERT(mThumbLabels.size() > idx && mThumbLabels[idx]);
+    Q_ASSERT(mThumbs.size() > idx && mThumbLabels[idx]);
     mThumbLabels[idx]->ensureVisible();
 }
 
@@ -1781,7 +1783,7 @@ QStringList DkThumbScene::getSelectedFiles() const
 {
     QStringList fileList;
 
-    for (int idx = 0; idx < mThumbLabels.size(); idx++) {
+    for (int idx = 0; idx < mThumbs.size(); idx++) {
         if (mThumbLabels.at(idx) && mThumbLabels.at(idx)->isSelected()) {
             fileList.append(mThumbLabels.at(idx)->filePath());
         }
@@ -1837,7 +1839,7 @@ int DkThumbScene::findThumb(DkThumbLabel *thumb) const
 bool DkThumbScene::allThumbsSelected() const
 {
     for (DkThumbLabel *label : mThumbLabels)
-        if (label->flags() & QGraphicsItem::ItemIsSelectable && !label->isSelected())
+        if (label->isVisible() && label->flags() & QGraphicsItem::ItemIsSelectable && !label->isSelected())
             return false;
 
     return true;

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -129,16 +129,26 @@ DkFilePreview::DkFilePreview(DkThumbLoader *loader, QWidget *parent, Qt::WindowF
     });
 }
 
+void DkFilePreview::cancelLoading()
+{
+    for (auto thumb = mThumbs.begin(); thumb != mThumbs.end();) {
+        if (!thumb->loading) {
+            ++thumb;
+            continue;
+        }
+
+        auto req = std::move(thumb->request);
+        thumb = mThumbs.erase(thumb);
+        mThumbLoader->cancelThumbnailRequest(req);
+        mThumbRequests.remove(req.id);
+    }
+}
+
 void DkFilePreview::resetThumbs()
 {
     // drop our thumbnail cache
-    for (auto &thumb : std::as_const(mThumbs)) {
-        if (thumb.loading) {
-            mThumbLoader->cancelThumbnailRequest(thumb.request);
-        }
-    }
+    cancelLoading();
     mThumbs.clear();
-    mThumbRequests.clear();
 }
 
 void DkFilePreview::init()
@@ -927,9 +937,13 @@ void DkFilePreview::updateThumbs(QVector<QSharedPointer<DkImageContainerT>> imag
 void DkFilePreview::setVisible(bool visible, bool saveSettings)
 {
     DkFadeWidget::setVisible(visible, saveSettings);
-    if (mSetWidgetVisible)
+    if (mSetWidgetVisible) {
+        if (!visible) {
+            // note: must wait until actual hide or else we only restart jobs
+            cancelLoading();
+        }
         return; // prevent recursion via fade()
-
+    }
     emit showThumbsDockSignal(visible);
 }
 

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -953,8 +953,7 @@ DkThumbLabel::DkThumbLabel(DkThumbLoader *thumbLoader,
     mText.setDefaultTextColor(QColor(255, 255, 255));
     mText.hide();
 
-    // Not loaded -> disable selection
-    setFlag(ItemIsSelectable, false);
+    setFlag(ItemIsSelectable, true);
 
     setAcceptHoverEvents(true);
     connect(mThumbLoader, &DkThumbLoader::thumbnailLoaded, this, &DkThumbLabel::onThumbnailLoaded);
@@ -991,7 +990,6 @@ void DkThumbLabel::onThumbnailLoaded(ThumbnailId id, const QString &filePath, co
     prepareGeometryChange();
     generatePixmap(thumb);
     updateTooltip(thumb, fromExif);
-    setFlag(ItemIsSelectable, true);
     update();
 }
 

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -981,7 +981,7 @@ void DkThumbLabel::onThumbnailLoaded(ThumbnailId id, const QString &filePath, co
     }
 
     // update label
-    mText.setPos(0, DkSettingsManager::param().effectiveThumbPreviewSize());
+    mText.setPos(0.0, DkSettingsManager::param().display().thumbPreviewSize / mDevicePixelRatio);
 
     prepareGeometryChange();
     generatePixmap(thumb);
@@ -1028,8 +1028,8 @@ void DkThumbLabel::cancelLoading()
 
 QRectF DkThumbLabel::boundingRect() const
 {
-    int sz = DkSettingsManager::param().effectiveThumbPreviewSize();
-    return QRectF(QPoint(0, 0), QSize(sz, sz));
+    qreal sz = DkSettingsManager::param().display().thumbPreviewSize / mDevicePixelRatio;
+    return QRectF(QPointF{}, QSizeF{sz, sz});
 }
 
 QPainterPath DkThumbLabel::shape() const
@@ -1287,7 +1287,7 @@ void DkThumbScene::updateLayout()
 
     QSize pSize = view->viewport()->size();
 
-    int psz = DkSettingsManager::param().effectiveThumbPreviewSize();
+    int psz = qRound(DkSettingsManager::param().display().thumbPreviewSize / view->devicePixelRatio());
     mXOffset = 2; // qCeil(psz*0.1f);
     mNumCols = qMax(qFloor(((float)pSize.width() - mXOffset) / (psz + mXOffset)), 1);
     mNumCols = qMin(mThumbs.size(), mNumCols);
@@ -1671,7 +1671,7 @@ void DkThumbScene::resizeThumbs(float dx)
         dx += 2.0f;
 
     int newSize = qRound(DkSettingsManager::param().display().thumbPreviewSize * dx);
-    int maxSize = DkSettingsManager::param().resources().maxThumbSize / getView()->devicePixelRatio();
+    int maxSize = DkSettingsManager::param().resources().maxThumbSize;
 
     newSize = qBound(6, newSize, maxSize);
     DkSettingsManager::param().display().thumbPreviewSize = newSize;

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -1616,6 +1616,8 @@ void DkThumbScene::resizeThumbs(float dx)
     if (!centerPath.isEmpty()) {
         ensureVisible(centerPath);
     }
+
+    update();
 }
 
 void DkThumbScene::cancelLoading()

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -1892,7 +1892,6 @@ void DkThumbScene::viewportChanged(const QRectF &portRect)
 // DkThumbView --------------------------------------------------------------------
 DkThumbsView::DkThumbsView(DkThumbScene *scene, QWidget *parent /* = 0 */)
     : QGraphicsView(scene, parent)
-    , mThumbScene(scene)
 {
     setObjectName("DkThumbsView");
 
@@ -1944,10 +1943,15 @@ DkThumbsView::DkThumbsView(DkThumbScene *scene, QWidget *parent /* = 0 */)
     this->installEventFilter(actionFilter);
 }
 
+DkThumbScene *DkThumbsView::thumbsScene() const
+{
+    return dynamic_cast<DkThumbScene *>(scene());
+}
+
 void DkThumbsView::wheelEvent(QWheelEvent *event)
 {
     if (event->modifiers() == Qt::ControlModifier) {
-        mThumbScene->resizeThumbs(event->angleDelta().y() / 100.0f);
+        thumbsScene()->resizeThumbs(event->angleDelta().y() / 100.0f);
     } else if (event->modifiers() == Qt::NoModifier) {
         if (verticalScrollBar()->isVisible()) {
             verticalScrollBar()->setValue(verticalScrollBar()->value() - event->angleDelta().y());
@@ -1963,10 +1967,9 @@ void DkThumbsView::mousePressEvent(QMouseEvent *event)
         mMouseDownPos = event->pos();
     }
 
-    qDebug() << "mouse pressed";
+    DkThumbScene *sc = thumbsScene();
 
-    DkThumbLabel *itemClicked = static_cast<DkThumbLabel *>(
-        mThumbScene->itemAt(mapToScene(event->pos()), QTransform()));
+    DkThumbLabel *itemClicked = static_cast<DkThumbLabel *>(sc->itemAt(mapToScene(event->pos()), QTransform()));
 
     // this is a bit of a hack
     // what we want to achieve: if the user is selecting with e.g. shift or ctrl
@@ -1976,17 +1979,18 @@ void DkThumbsView::mousePressEvent(QMouseEvent *event)
         QGraphicsView::mousePressEvent(event);
 
     if (!itemClicked) {
-        mThumbScene->showFile("");
+        sc->showFile("");
     }
 }
 
 void DkThumbsView::mouseMoveEvent(QMouseEvent *event)
 {
     if (event->buttons() == Qt::LeftButton) {
+        DkThumbScene *sc = thumbsScene();
         int dist = qRound(QPointF(event->pos() - mMouseDownPos).manhattanLength());
 
         if (dist > QApplication::startDragDistance()) {
-            QStringList fileList = mThumbScene->getSelectedFiles();
+            QStringList fileList = sc->getSelectedFiles();
 
             if (!fileList.empty()) {
                 QList<QUrl> urls;
@@ -1997,7 +2001,7 @@ void DkThumbsView::mouseMoveEvent(QMouseEvent *event)
                 mimeData->setUrls(urls);
 
                 // create thumb image
-                QVector<DkThumbLabel *> tl = mThumbScene->getSelectedThumbs();
+                QVector<DkThumbLabel *> tl = sc->getSelectedThumbs();
                 QVector<QImage> imgs;
 
                 for (int idx = 0; idx < tl.size() && idx < 3; idx++) {
@@ -2023,13 +2027,13 @@ void DkThumbsView::mouseReleaseEvent(QMouseEvent *event)
 {
     QGraphicsView::mouseReleaseEvent(event);
 
-    DkThumbLabel *itemClicked = static_cast<DkThumbLabel *>(
-        mThumbScene->itemAt(mapToScene(event->pos()), QTransform()));
+    DkThumbScene *sc = thumbsScene();
+    DkThumbLabel *itemClicked = static_cast<DkThumbLabel *>(sc->itemAt(mapToScene(event->pos()), QTransform()));
 
     if (mLastShiftIdx != -1 && event->modifiers() & Qt::ShiftModifier && itemClicked != nullptr) {
-        mThumbScene->selectThumbs(true, mLastShiftIdx, mThumbScene->findThumb(itemClicked));
+        sc->selectThumbs(true, mLastShiftIdx, sc->findThumb(itemClicked));
     } else if (itemClicked != nullptr) {
-        mLastShiftIdx = mThumbScene->findThumb(itemClicked);
+        mLastShiftIdx = sc->findThumb(itemClicked);
     } else
         mLastShiftIdx = -1;
 }
@@ -2093,7 +2097,7 @@ void DkThumbsView::dropEvent(QDropEvent *event)
         if (file.isDir()) {
             emit updateDirSignal(file.absoluteFilePath());
         } else {
-            mThumbScene->copyImages(event->mimeData(), event->proposedAction());
+            thumbsScene()->copyImages(event->mimeData(), event->proposedAction());
         }
     }
 

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -28,11 +28,8 @@
 #include "DkThumbsWidgets.h"
 
 #include "DkActionManager.h"
-#include "DkBasicLoader.h"
 #include "DkDialog.h"
-#include "DkImageContainer.h"
 #include "DkImageLoader.h"
-#include "DkImageStorage.h"
 #include "DkMessageBox.h"
 #include "DkNoMacs.h"
 #include "DkSettings.h"
@@ -42,20 +39,19 @@
 #include "DkTimer.h"
 #include "DkUtils.h"
 
-#include <qpixmap.h>
-#include <qpixmapcache.h>
-
 #include <QAction>
 #include <QApplication>
 #include <QClipboard>
 #include <QDrag>
 #include <QGraphicsSceneMouseEvent>
-#include <QHBoxLayout>
 #include <QInputDialog>
+#include <QLayout>
 #include <QLineEdit>
 #include <QMenu>
 #include <QMessageBox>
 #include <QMimeData>
+#include <QPixmap>
+#include <QPixmapCache>
 #include <QPushButton>
 #include <QResizeEvent>
 #include <QScrollBar>

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -1262,10 +1262,12 @@ void DkThumbScene::updateLayout()
     if (mThumbs.empty())
         return;
 
-    QSize pSize;
+    QGraphicsView *view = getView();
+    if (!view) {
+        return;
+    }
 
-    if (!views().empty())
-        pSize = QSize(views().first()->viewport()->size());
+    QSize pSize = QSize(view->viewport()->size());
 
     int psz = DkSettingsManager::param().effectiveThumbPreviewSize();
     mXOffset = 2; // qCeil(psz*0.1f);
@@ -1309,23 +1311,19 @@ void DkThumbScene::updateLayout()
     // The pixmap cache must be large enough for all thumbnails that need to be painted
     // If the cache is too small, the paint event will loop back to itself:
     // paintEvent()->(cache miss)->fetchThumbnail()->update()->paintEvent()
-    const auto gfxViews = views();
-    if (!gfxViews.empty()) {
-        int cacheKb = 9 * 1024; // +1 below puts us at 10MB, the Qt default
-        const QGraphicsView *view = gfxViews.first();
-        const QList<QGraphicsItem *> visibleItems = view->items(view->rect());
-        if (visibleItems.count() > 0) {
-            QSize sz = (visibleItems.first()->boundingRect().size() * view->devicePixelRatio()).toSize();
-            const int bytesPerPixel = 4;
-            const int extraRows = 2;
-            cacheKb += sz.width() * sz.height() * bytesPerPixel * //
-                (visibleItems.count() + extraRows * mNumCols) / 1024;
-        }
-
-        cacheKb = (cacheKb / 1024 + 1) * 1024; // to nearest MB
-
-        QPixmapCache::setCacheLimit(cacheKb);
+    int cacheKb = 9 * 1024; // +1 below puts us at 10MB, the Qt default
+    const QList<QGraphicsItem *> visibleItems = view->items(view->rect());
+    if (visibleItems.count() > 0) {
+        QSize sz = (visibleItems.first()->boundingRect().size() * view->devicePixelRatio()).toSize();
+        const int bytesPerPixel = 4;
+        const int extraRows = 2;
+        cacheKb += sz.width() * sz.height() * bytesPerPixel * //
+            (visibleItems.count() + extraRows * mNumCols) / 1024;
     }
+
+    cacheKb = (cacheKb / 1024 + 1) * 1024; // to nearest MB
+    QPixmapCache::setCacheLimit(cacheKb);
+
 }
 
 void DkThumbScene::updateThumbs(QVector<QSharedPointer<DkImageContainerT>> thumbs)
@@ -1493,17 +1491,18 @@ void DkThumbScene::ensureVisible(const QString &path) const
         return;
     }
 
+    QGraphicsView *view = getView();
+    if (!view) {
+        return;
+    }
+
     for (DkThumbLabel *label : std::as_const(mThumbLabels)) {
         if (label->filePath() == path) {
             int xMargin = 50, yMargin = 50;
 
-            const QList<QGraphicsView *> viewList = this->views();
-            if (!viewList.isEmpty()) {
-                QGraphicsView *view = viewList.at(0);
-                QRectF br = label->boundingRect();
-                xMargin = (view->width() - br.width()) / 2;
-                yMargin = (view->height() - br.height()) / 2;
-            }
+            QRectF br = label->boundingRect();
+            xMargin = (view->width() - br.width()) / 2;
+            yMargin = (view->height() - br.height()) / 2;
 
             // FIXME: there are rare cases where this does not work, seemingly random
             label->ensureVisible(QRect(), xMargin, yMargin);
@@ -1536,6 +1535,12 @@ int DkThumbScene::selectedThumbIndex(bool first)
     }
 
     return selIdx;
+}
+
+QGraphicsView *DkThumbScene::getView() const
+{
+    QList<QGraphicsView *> list = views();
+    return list.value(0);
 }
 
 void DkThumbScene::toggleThumbLabels(bool show)
@@ -1836,9 +1841,8 @@ DkThumbLabel *DkThumbScene::getCenterThumb() const
 {
     DkThumbLabel *centerThumb = nullptr;
 
-    auto viewList = views();
-    if (!viewList.empty()) {
-        QGraphicsView *view = viewList.at(0);
+    QGraphicsView *view = getView();
+    if (view) {
         // we can't test a point since we might hit the space between items
         QRect centerRect = QRect{view->rect().center(), QSize{1, 1}}.adjusted(-8, -8, 8, 8);
         QList<QGraphicsItem *> centerItems = view->items(centerRect, Qt::IntersectsItemBoundingRect);

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -1598,8 +1598,13 @@ void DkThumbScene::resizeThumbs(float dx)
     newSize = qBound(6, newSize, maxSize);
     DkSettingsManager::param().display().thumbPreviewSize = newSize;
 
+    // keep the selection or center thumb visible when zooming
+    DkThumbLabel *centerThumb = getSelectedThumbs().value(0);
+    if (!centerThumb) {
+        centerThumb = getCenterThumb();
+    }
+
     QString centerPath{};
-    DkThumbLabel *centerThumb = getCenterThumb();
     if (centerThumb) {
         centerPath = centerThumb->filePath();
         centerThumb = nullptr; // potentially invalidated by updateLayout()
@@ -1608,7 +1613,7 @@ void DkThumbScene::resizeThumbs(float dx)
     updateLayout();
     // TODO: cancel anything no longer visible
 
-    if (selectedItems().empty() && !centerPath.isEmpty()) {
+    if (!centerPath.isEmpty()) {
         ensureVisible(centerPath);
     }
 }

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -1418,6 +1418,16 @@ void DkThumbScene::showFile(const QString &filePath)
 
 void DkThumbScene::ensureVisible(const QString &path) const
 {
+    // it is not clear why we need this hack, but it fixes #1408
+    static bool firstTime = true;
+    if (firstTime) {
+        firstTime = false;
+        QTimer::singleShot(0, [this, path] {
+            ensureVisible(path);
+        });
+        return;
+    }
+
     for (DkThumbLabel *label : std::as_const(mThumbLabels)) {
         if (label->filePath() == path) {
             int xMargin = 50, yMargin = 50;

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -1986,21 +1986,6 @@ DkThumbLabel *DkThumbScene::getCenterThumb() const
     return centerThumb;
 }
 
-// TODO: use QVector::indexOf() or map
-int DkThumbScene::findThumb(DkThumbLabel *thumb) const
-{
-    int thumbIdx = -1;
-
-    for (int idx = 0; idx < mThumbLabels.size(); idx++) {
-        if (thumb == mThumbLabels.at(idx)) {
-            thumbIdx = idx;
-            break;
-        }
-    }
-
-    return thumbIdx;
-}
-
 bool DkThumbScene::allThumbsSelected() const
 {
     for (DkThumbLabel *label : mThumbLabels)

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -1871,6 +1871,22 @@ bool DkThumbScene::allThumbsSelected() const
     return true;
 }
 
+void DkThumbScene::viewportChanged(const QRectF &portRect)
+{
+    // Cancel anything that is no longer visible
+    for (const auto item : items()) {
+        auto it = dynamic_cast<DkThumbLabel *>(item);
+        if (it == nullptr) {
+            continue;
+        }
+
+        const bool intersects = portRect.intersects(it->sceneBoundingRect());
+        if (!intersects) {
+            it->cancelLoading();
+        }
+    }
+}
+
 // DkThumbView --------------------------------------------------------------------
 DkThumbsView::DkThumbsView(DkThumbScene *scene, QWidget *parent /* = 0 */)
     : QGraphicsView(scene, parent)
@@ -1881,8 +1897,10 @@ DkThumbsView::DkThumbsView(DkThumbScene *scene, QWidget *parent /* = 0 */)
     setResizeAnchor(QGraphicsView::AnchorUnderMouse);
     setAcceptDrops(true);
 
-    connect(horizontalScrollBar(), &QScrollBar::valueChanged, this, &DkThumbsView::onScroll);
-    connect(verticalScrollBar(), &QScrollBar::valueChanged, this, &DkThumbsView::onScroll);
+    connect(verticalScrollBar(), &QScrollBar::valueChanged, this, [&] {
+        const QRectF portRect = mapToScene(viewport()->rect()).boundingRect();
+        mThumbScene->viewportChanged(portRect);
+    });
 
     auto *scrollOnePageUpAction = new QAction(this);
     scrollOnePageUpAction->setShortcuts({QKeySequence::MoveToPreviousPage, QKeySequence(Qt::SHIFT | Qt::Key_Space)});
@@ -1922,23 +1940,6 @@ DkThumbsView::DkThumbsView(DkThumbScene *scene, QWidget *parent /* = 0 */)
     actionFilter->addAction(scrollToTopAction);
     actionFilter->addAction(scrollToEndAction);
     this->installEventFilter(actionFilter);
-}
-
-void DkThumbsView::onScroll()
-{
-    const QRectF portRect = mapToScene(viewport()->rect()).boundingRect();
-
-    for (const auto item : items()) {
-        auto it = dynamic_cast<DkThumbLabel *>(item);
-        if (it == nullptr) {
-            continue;
-        }
-
-        const bool intesects = portRect.intersects(it->sceneBoundingRect());
-        if (!intesects) {
-            it->cancelLoading();
-        }
-    }
 }
 
 void DkThumbsView::wheelEvent(QWheelEvent *event)

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -78,8 +78,6 @@ DkFilePreview::DkFilePreview(DkThumbLoader *loader, QWidget *parent, Qt::WindowF
     windowPosition = pos_north;
 
     init();
-    // setStyleSheet("QToolTip{border: 0px; border-radius: 21px; color: white; background-color: red;}"); //" +
-    // DkUtils::colorToString(mBgCol) + ";}");
 
     loadSettings();
     initOrientations();
@@ -156,8 +154,6 @@ void DkFilePreview::init()
     setObjectName("DkFilePreview");
     setMouseTracking(true); // receive mouse event everytime
 
-    // thumbsLoader = 0;
-
     xOffset = qRound(DkSettingsManager::param().effectiveThumbSize(this) * 0.1f);
     yOffset = qRound(DkSettingsManager::param().effectiveThumbSize(this) * 0.1f);
 
@@ -189,11 +185,10 @@ void DkFilePreview::init()
     rightGradient.setColorAt(0, Qt::white);
 
     minHeight = DkSettingsManager::param().effectiveThumbSize(this) + yOffset;
-    // resize(parent->width(), minHeight);
 
     selected = -1;
 
-    // wheel label
+    // icon for drag-to-scroll mode
     QPixmap wp = QPixmap(":/nomacs/img/thumbs-move.svg");
     wheelButton = new QLabel(this);
     wheelButton->setAttribute(Qt::WA_TransparentForMouseEvents);
@@ -450,6 +445,7 @@ void DkFilePreview::drawThumbs(QPainter *painter)
                 && imgWorldRect.top() < leftGradient.finalStop().y());
         bool isRightGradient = (orientation == Qt::Horizontal && imgWorldRect.right() > rightGradient.start().x())
             || (orientation == Qt::Vertical && imgWorldRect.bottom() > rightGradient.start().y());
+
         // show that there are more images...
         if (isLeftGradient && !img.isNull())
             img = applyFadeOut(leftGradient, imgWorldRect, img);
@@ -670,13 +666,8 @@ void DkFilePreview::mouseMoveEvent(QMouseEvent *event)
             if (worldMatrix.mapRect(thumbRects.at(idx)).contains(event->pos())) {
                 selected = idx;
 
+                // update tooltip
                 if (selected >= 0 && static_cast<unsigned int>(selected) < mFiles.size()) {
-                    // selectedImg = DkImage::colorizePixmap(QPixmap::fromImage(thumb->getImage()),
-                    // DkSettingsManager::param().display().highlightColor, 0.3f);
-
-                    // important: setText shows the label - if you then hide it here again you'll get a stack overflow
-                    // if (fileLabel->height() < height())
-                    //	fileLabel->setText(thumbs.at(selected).getFile().fileName(), -1);
                     const DkFileInfo &fileInfo = mFiles[selected];
                     auto thumb = mThumbs.constFind(fileInfo.path());
 
@@ -698,8 +689,6 @@ void DkFilePreview::mouseMoveEvent(QMouseEvent *event)
 
         if (selected != -1 || selected != oldSelection)
             update();
-        // else if (selected == -1)
-        //	fileLabel->hide();
     } else
         selected = -1;
 
@@ -707,21 +696,18 @@ void DkFilePreview::mouseMoveEvent(QMouseEvent *event)
         setToolTip(tr("CTRL+Zoom resizes the thumbnails"));
 
     lastMousePos = event->pos();
-
-    // QWidget::mouseMoveEvent(event);
 }
 
 void DkFilePreview::mousePressEvent(QMouseEvent *event)
 {
     if (event->buttons() == Qt::LeftButton) {
+        // TODO: change image on mouse down, not mouse up
         mouseTrace = 0;
     } else if (event->buttons() == Qt::MiddleButton) {
+        // start drag-to-scroll mode and show indicator icon
         enterPos = event->pos();
-        qDebug() << "stop scrolling (middle button)";
         scrollToCurrentImage = false;
         moveImageTimer->start();
-
-        // show icon
         wheelButton->move(event->pos().x() - 16, event->pos().y() - 16);
         wheelButton->show();
     }
@@ -790,10 +776,8 @@ void DkFilePreview::leaveEvent(QEvent *)
 
 void DkFilePreview::contextMenuEvent(QContextMenuEvent *event)
 {
-    contextMenu->exec(event->globalPos());
     event->accept();
-
-    DkFadeWidget::contextMenuEvent(event);
+    contextMenu->exec(event->globalPos());
 }
 
 void DkFilePreview::newPosition()
@@ -889,12 +873,11 @@ void DkFilePreview::moveImages()
              && translation + currentDx <= -(bufferPos - limit * 0.5 + xOffset) && currentDx < 0)
         currentDx = -(bufferPos - limit * 0.5f + xOffset + (float)worldMatrix.dx());
 
-    // qDebug() << "currentDx: " << currentDx;
     if (orientation == Qt::Horizontal)
         worldMatrix.translate(currentDx, 0);
     else
         worldMatrix.translate(0, currentDx);
-    // qDebug() << "dx: " << worldMatrix.dx();
+
     update();
 }
 
@@ -1090,10 +1073,6 @@ void DkThumbLabel::generatePixmap(const QImage &thumb)
         qreal dx = srcRect.width() * scaleDiff / 2.0;
         qreal dy = srcRect.height() * scaleDiff / 2.0;
         srcRect = srcRect.adjusted(-dx, -dy, dx, dy);
-
-        // qreal adjFactorH = mDevicePixelRatio - (srcRect.height() / targetRect.height());
-        // qreal adjFactorW = mDevicePixelRatio - (srcRect.width() / targetRect.width());
-        // qDebug() << "SF" << scaleDiff << adjFactorH << adjFactorW;
     }
 
     const QSize pixmapSize = (br.size() * mDevicePixelRatio).toSize();
@@ -1246,8 +1225,8 @@ void DkThumbLabel::setFillSquare(bool value)
 {
     mFillSquare = value;
     // Instead of requesting thumbnail right away,
-    // we reset the pixmap and call update,
-    // so only the visible ones get loaded.
+    // we reset the pixmap and let it be refetched
+    // again when needed.
     if (mPixmapKey) {
         QPixmapCache::remove(mPixmapKey.value());
     }
@@ -1260,7 +1239,7 @@ void DkThumbLabel::setFileInfo(const DkFileInfo &fileInfo)
     mText.setPlainText(fileInfo.fileName());
     mThumbNotExist = false;
 
-    // TODO: we can keep pixmap if file did not change
+    // TODO: we can keep pixmap if file did not change (store fileInfo as member)
     if (mPixmapKey)
         QPixmapCache::remove(mPixmapKey.value());
     mPixmapKey = std::nullopt;
@@ -1338,7 +1317,7 @@ void DkThumbScene::updateLayout()
 
     DkThumbLabel *lastSelected = nullptr;
     for (DkThumbLabel *thumb : std::as_const(mThumbLabels)) {
-        thumb->cancelLoading(); // visibility and/or size may have changed
+        thumb->cancelLoading(); // visibility and/or required thumb size may have changed
         if (thumb->isSelected())
             lastSelected = thumb;
     }
@@ -1347,8 +1326,8 @@ void DkThumbScene::updateLayout()
         ensureVisible(lastSelected->filePath());
 
     // The pixmap cache must be large enough for all thumbnails that need to be painted
-    // If the cache is too small, the paint event will loop back to itself:
-    // paintEvent()->(cache miss)->fetchThumbnail()->update()->paintEvent()
+    // If the cache is too small, some of the paint events always cache miss and creates
+    // an endless cycle: paintEvent()->(cache miss)->fetchThumbnail()->update()->paintEvent()
     int cacheKb = 9 * 1024; // +1 below puts us at 10MB, the Qt default
     const QList<QGraphicsItem *> visibleItems = view->items(view->rect());
     if (visibleItems.count() > 0) {
@@ -1676,7 +1655,7 @@ void DkThumbScene::selectThumb(int idx, bool select)
         return;
 
     if (idx < 0 || idx >= mThumbs.size()) {
-        qWarning() << "index out of bounds in selectThumbs()" << idx;
+        qWarning() << "[ThumbScene] index out of bounds in selectThumbs()" << idx;
         return;
     }
 
@@ -1893,6 +1872,7 @@ DkThumbLabel *DkThumbScene::getCenterThumb() const
     return centerThumb;
 }
 
+// TODO: use QVector::indexOf() or map
 int DkThumbScene::findThumb(DkThumbLabel *thumb) const
 {
     int thumbIdx = -1;
@@ -2057,8 +2037,6 @@ void DkThumbsView::wheelEvent(QWheelEvent *event)
             verticalScrollBar()->setValue(verticalScrollBar()->value() - event->angleDelta().y());
         }
     }
-
-    // QWidget::wheelEvent(event);
 }
 
 void DkThumbsView::mousePressEvent(QMouseEvent *event)
@@ -2142,8 +2120,6 @@ void DkThumbsView::dragEnterEvent(QDragEnterEvent *event)
 {
     QGraphicsView::dragEnterEvent(event);
 
-    qDebug() << event->source() << " I am: " << this;
-
     if (event->source() == this)
         event->accept();
     else if (event->mimeData()->hasUrls()) {
@@ -2210,12 +2186,10 @@ DkThumbScrollWidget::DkThumbScrollWidget(DkThumbLoader *thumbLoader,
                                          Qt::WindowFlags flags /* = 0 */)
     : DkWidget(parent, flags)
 {
-    // TODO: is this name required elsewhere?
     setObjectName("DkThumbScrollWidget");
     setContentsMargins(0, 0, 0, 0);
 
     mThumbsScene = new DkThumbScene(thumbLoader, this);
-    // thumbsView->setContentsMargins(0,0,0,0);
 
     mView = new DkThumbsView(mThumbsScene, this);
     mView->setFocusPolicy(Qt::StrongFocus);
@@ -2300,7 +2274,6 @@ void DkThumbScrollWidget::createActions()
     }
 
     DkActionManager &am = DkActionManager::instance();
-    // addActions(am.allActions().toList());
     addActions(am.previewActions().toList());
 
     // add a shortcut to open the selected image
@@ -2662,7 +2635,7 @@ void DkRecentDirWidget::createLayout(DkThumbLoader *thumbLoader)
             }
         }
     } else {
-        qInfo() << firstFile.path() << "does not exist - according to a fast check";
+        qInfo() << "[RecentDirs]" << firstFile.path() << "does not exist or timed out";
     }
 
     auto *pathLabel = new QLabel(mRecentDir.dirPath(), this);
@@ -2787,7 +2760,8 @@ void DkRecentFilesWidget::updateList()
         l->addWidget(rf);
     }
 
-    qInfo() << "list updated in" << dt; // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks) false positive on layout
+    qInfo() << "[RecentDirs] list updated in"
+            << dt; // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks) false positive on layout
 
     mScrollArea->setWidget(dummy);
 }

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -950,8 +950,8 @@ void DkThumbLabel::onThumbnailLoaded(const QString &filePath, const QImage &thum
     prepareGeometryChange();
     generatePixmap(thumb);
     updateTooltip(thumb, fromExif);
-    update();
     setFlag(ItemIsSelectable, true);
+    update();
 }
 
 void DkThumbLabel::onThumbnailLoadFailed(const QString &filePath)
@@ -1189,7 +1189,6 @@ void DkThumbLabel::setFillSquare(bool value)
         QPixmapCache::remove(mPixmapKey.value());
     }
     mPixmapKey = std::nullopt;
-    update();
 }
 
 void DkThumbLabel::setFileInfo(const DkFileInfo &fileInfo)
@@ -1280,8 +1279,6 @@ void DkThumbScene::updateLayout()
 
     if (lastSelected)
         ensureVisible(lastSelected->filePath());
-
-    update();
 
     // The pixmap cache must be large enough for all thumbnails that need to be painted
     // If the cache is too small, the paint event will loop back to itself:
@@ -1514,9 +1511,7 @@ int DkThumbScene::selectedThumbIndex(bool first)
 void DkThumbScene::toggleThumbLabels(bool show)
 {
     DkSettingsManager::param().display().showThumbLabel = show;
-
-    for (const auto t : mThumbLabels)
-        t->update();
+    update();
 }
 
 void DkThumbScene::toggleSquaredThumbs(bool squares)
@@ -1526,6 +1521,7 @@ void DkThumbScene::toggleSquaredThumbs(bool squares)
     for (const auto t : mThumbLabels) {
         t->setFillSquare(squares);
     }
+    update();
 }
 
 void DkThumbScene::increaseThumbs()

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -1901,7 +1901,7 @@ void DkThumbScene::renameSelected() const
 
 void DkThumbScene::thumbClicked(DkThumbLabel *thumb, QMouseEvent *event)
 {
-    if (event->buttons() != Qt::LeftButton) {
+    if (event->button() != Qt::LeftButton) {
         return;
     }
 
@@ -2145,6 +2145,12 @@ void DkThumbsView::mousePressEvent(QMouseEvent *event)
         mMouseDownPos = event->pos();
     }
 
+    // No forwarding as we must ignore default item selection model
+}
+
+void DkThumbsView::mouseReleaseEvent(QMouseEvent *event)
+{
+    // Selection happens on mouse release so click to select works and drag can work without modifier key
     DkThumbScene *sc = thumbsScene();
     DkThumbLabel *itemClicked = static_cast<DkThumbLabel *>(sc->itemAt(mapToScene(event->pos()), QTransform()));
 
@@ -2153,20 +2159,15 @@ void DkThumbsView::mousePressEvent(QMouseEvent *event)
         return;
     }
 
-    // We do this before forwarding so it won't emit selectionChanged() twice
     sc->thumbClicked(itemClicked, event);
-
-    // We have to forward mouse event for double-click event to fire.
-    // But this also does single-selection and clears the selection, so
-    // we cannot allow it when doing extended selections (shift+click etc),
-    // or when right-clicking for context menu
-    if (event->buttons() != Qt::RightButton && event->modifiers() == Qt::NoModifier) {
-        QGraphicsView::mousePressEvent(event);
-    }
 }
 
 void DkThumbsView::mouseDoubleClickEvent(QMouseEvent *event)
 {
+    if (event->button() != Qt::LeftButton) {
+        return;
+    }
+
     DkThumbScene *sc = thumbsScene();
     DkThumbLabel *itemClicked = static_cast<DkThumbLabel *>(sc->itemAt(mapToScene(event->pos()), QTransform()));
 

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.h
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.h
@@ -164,6 +164,7 @@ private:
     std::vector<DkFileInfo> mFiles{};
 
     struct Thumb {
+        LoadThumbnailRequest request{};
         QImage image{};
         bool notExist{};
         bool fromExif{};
@@ -223,8 +224,11 @@ private:
     QPen mSelectPen;
     QBrush mSelectBrush;
     DkThumbLoader *mThumbLoader = nullptr;
+    LoadThumbnailRequest mThumbRequest{};
     bool mThumbNotExist = false;
     bool mFetchingThumb = false;
+    qreal mDevicePixelRatio = 1.0;
+    LoadThumbnailOption mThumbOption = LoadThumbnailOption::none;
     bool mIsHovered = false;
     bool mFillSquare = false;
 

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.h
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.h
@@ -247,6 +247,9 @@ public:
     QStringList getSelectedFiles() const;
     QVector<DkThumbLabel *> getSelectedThumbs() const;
 
+    /// return thumb in the middle of the (visible) view
+    DkThumbLabel *getCenterThumb() const;
+
     void setImageLoader(QSharedPointer<DkImageLoader> loader);
     void copyImages(const QMimeData *mimeData, const Qt::DropAction &da = Qt::CopyAction) const;
     int findThumb(DkThumbLabel *thumb) const;

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.h
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.h
@@ -201,6 +201,7 @@ public:
     QString filePath() const;
     QImage image() const;
     void setFillSquare(bool value);
+    void setFileInfo(const DkFileInfo &info);
 
 signals:
     void loadFileSignal(const QString &filePath, bool newTab) const;

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.h
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.h
@@ -133,8 +133,8 @@ private:
     Qt::Orientation orientation;
     QTimer *moveImageTimer;
 
-    QRectF bufferDim;
-    QVector<QRectF> thumbRects;
+    QRectF bufferDim; // dimensions of virtual film strip
+    QVector<QRectF> thumbRects; // thumb rects within bufferDim
 
     QLinearGradient leftGradient;
     QLinearGradient rightGradient;

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.h
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.h
@@ -272,7 +272,6 @@ public:
 
     void setImageLoader(QSharedPointer<DkImageLoader> loader);
     void copyImages(const QMimeData *mimeData, const Qt::DropAction &da = Qt::CopyAction) const;
-    int findThumb(DkThumbLabel *thumb) const;
     bool allThumbsSelected() const;
     void ensureVisible(const QString &path) const;
     void viewportChanged(const QRectF &portRect);
@@ -295,7 +294,6 @@ public slots:
 
 signals:
     void loadFileSignal(const QString &filePath, bool newTab) const;
-    void thumbLoadedSignal() const;
 
 private:
     void selectThumbs(bool select, int from, int to, bool extend);

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.h
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.h
@@ -302,13 +302,13 @@ private:
     void connectLoader(QSharedPointer<DkImageLoader> loader, bool connectSignals = true);
     void keyPressEvent(QKeyEvent *event) override;
     QString currentDir() const;
-    int selectedThumbIndex(bool first = true);
     QGraphicsView *getView() const;
 
     int mXOffset = 0;
     int mNumRows = 0;
     int mNumCols = 0;
-    int mSelectionAnchor = -1; // where to extend selection from (shift+click)
+    int mSelectionAnchor = -1; // where to start range selection from (shift+click, shift+keypress)
+    int mSelectionCursor = -1; // last visited item with keyboard or mouse click
     int mLastSelectedIdx = -1; // last selected item to restore on updateThumbs()
 
     QVector<DkThumbLabel *> mThumbLabels;

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.h
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.h
@@ -310,6 +310,7 @@ private:
     QSharedPointer<DkImageLoader> mLoader;
     QVector<DkFileInfo> mThumbs;
     DkThumbLoader *mThumbLoader;
+    QRectF mLastViewPortRect{};
 };
 
 class DkThumbsView : public QGraphicsView

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.h
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.h
@@ -204,6 +204,16 @@ public:
     void setFillSquare(bool value);
     void setFileInfo(const DkFileInfo &info);
 
+    int row() const
+    {
+        return mRow;
+    }
+
+    void setRow(int row)
+    {
+        mRow = row;
+    }
+
     void fetchThumb(float devicePixelRatio);
 
 signals:
@@ -235,6 +245,7 @@ private:
     LoadThumbnailOption mThumbOption = LoadThumbnailOption::none;
     bool mIsHovered = false;
     bool mFillSquare = false;
+    int mRow{};
 
     static constexpr QColor sNoImagePen = QColor(150, 150, 150);
     static constexpr QColor sNoImageBrush = QColor(100, 100, 100, 50);

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.h
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.h
@@ -74,18 +74,7 @@ public:
     ~DkFilePreview() override
     {
         saveSettings();
-    };
-
-    void setCurrentDx(float dx)
-    {
-        scrollToCurrentImage = false; // external move events
-        currentDx = dx;
-    };
-
-    QTimer *getMoveImageTimer()
-    {
-        return moveImageTimer;
-    };
+    }
 
     void setVisible(bool visible, bool saveSettings = true) override;
 
@@ -93,12 +82,12 @@ public:
     {
         windowPosition = position;
         initOrientations();
-    };
+    }
 
     int getWindowPosition()
     {
         return windowPosition;
-    };
+    }
 
     void cancelLoading();
 

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.h
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.h
@@ -100,6 +100,8 @@ public:
         return windowPosition;
     };
 
+    void cancelLoading();
+
 public slots:
     void moveImages();
     void updateThumbs(QVector<QSharedPointer<DkImageContainerT>> images);

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.h
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.h
@@ -196,14 +196,26 @@ public:
     void setFillSquare(bool value);
     void setFileInfo(const DkFileInfo &info);
 
+    int index() const
+    {
+        return mIndex;
+    }
+
     int row() const
     {
         return mRow;
     }
 
-    void setRow(int row)
+    int col() const
     {
+        return mCol;
+    }
+
+    void setGridPos(int index, int row, int col)
+    {
+        mIndex = index;
         mRow = row;
+        mCol = col;
     }
 
     void fetchThumb(float devicePixelRatio);
@@ -237,7 +249,7 @@ private:
     LoadThumbnailOption mThumbOption = LoadThumbnailOption::none;
     bool mIsHovered = false;
     bool mFillSquare = false;
-    int mRow{};
+    int mIndex{}, mRow{}, mCol{};
 
     static constexpr QColor sNoImagePen = QColor(150, 150, 150);
     static constexpr QColor sNoImageBrush = QColor(100, 100, 100, 50);

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.h
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.h
@@ -285,8 +285,6 @@ public slots:
     void toggleThumbLabels(bool show);
     void resizeThumbs(float dx);
     void showFile(const QString &filePath = QString());
-    void selectThumbs(bool select = true, int from = 0, int to = -1);
-    void selectThumb(int idx, bool select = true);
     void selectAllThumbs(bool select = true);
     void updateThumbs(QVector<QSharedPointer<DkImageContainerT>> thumbs);
     void deleteSelected();
@@ -299,6 +297,7 @@ signals:
     void thumbLoadedSignal() const;
 
 private:
+    void selectThumbs(bool select, int from, int to, bool extend);
     void connectLoader(QSharedPointer<DkImageLoader> loader, bool connectSignals = true);
     void keyPressEvent(QKeyEvent *event) override;
     QString currentDir() const;

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.h
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.h
@@ -265,11 +265,7 @@ public:
     void updateLayout();
     QStringList getSelectedFiles() const;
     QVector<DkThumbLabel *> getSelectedThumbs() const;
-
-    /// return thumb in the middle of the (visible) view
     void thumbClicked(DkThumbLabel *thumb, QMouseEvent *event);
-    DkThumbLabel *getCenterThumb() const;
-
     void setImageLoader(QSharedPointer<DkImageLoader> loader);
     void copyImages(const QMimeData *mimeData, const Qt::DropAction &da = Qt::CopyAction) const;
     bool allThumbsSelected() const;
@@ -296,6 +292,9 @@ signals:
     void loadFileSignal(const QString &filePath, bool newTab) const;
 
 private:
+    // return thumb in the middle of the (visible) view
+    DkThumbLabel *getCenterThumb() const;
+
     void selectThumbs(bool select, int from, int to, bool extend);
     void connectLoader(QSharedPointer<DkImageLoader> loader, bool connectSignals = true);
     void keyPressEvent(QKeyEvent *event) override;

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.h
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.h
@@ -173,6 +173,7 @@ private:
 
     QHash<QString, Thumb> mThumbs;
     DkThumbLoader *mThumbLoader;
+    QHash<ThumbnailId, QString> mThumbRequests;
 
     void init();
     void initOrientations();
@@ -214,8 +215,8 @@ private:
     void hoverLeaveEvent(QGraphicsSceneHoverEvent *event) override;
     void updateTooltip(const QImage &thumb, bool fromExif);
     void generatePixmap(const QImage &thumb);
-    void onThumbnailLoaded(const QString &filePath, const QImage &thumb, bool fromExif);
-    void onThumbnailLoadFailed(const QString &filePath);
+    void onThumbnailLoaded(ThumbnailId id, const QString &filePath, const QImage &thumb, bool fromExif);
+    void onThumbnailLoadFailed(ThumbnailId id, const QString &filePath);
     std::optional<QPixmap> pixmap() const;
 
     QGraphicsTextItem mText;
@@ -460,7 +461,7 @@ signals:
     void loadFileSignal(const QString &filePath, bool newTab);
 
 public slots:
-    void thumbLoaded(const QString &filePath, const QImage &img);
+    void thumbLoaded(ThumbnailId id, const QString &filePath, const QImage &img);
 
 protected:
     void mousePressEvent(QMouseEvent *ev) override;
@@ -468,6 +469,7 @@ protected:
     int mThumbSize = 100;
     DkThumbLoader *mLoader{};
     QString mFilePath;
+    ThumbnailId mThumbId{};
 };
 
 class DllCoreExport DkRecentDirWidget : public DkWidget

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.h
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.h
@@ -257,6 +257,7 @@ public:
     int findThumb(DkThumbLabel *thumb) const;
     bool allThumbsSelected() const;
     void ensureVisible(const QString &path) const;
+    void viewportChanged(const QRectF &portRect);
 
 public slots:
     void updateThumbLabels();
@@ -319,9 +320,6 @@ protected:
     DkThumbScene *mThumbScene = nullptr;
     QPointF mMouseDownPos;
     int mLastShiftIdx = -1; // item index clicked while shift key down
-
-private:
-    void onScroll();
 };
 
 class DllCoreExport DkThumbScrollWidget : public DkWidget

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.h
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.h
@@ -123,6 +123,7 @@ protected:
     void contextMenuEvent(QContextMenuEvent *event) override;
     void loadSettings();
     void saveSettings();
+    void resetThumbs();
 
 private:
     QTransform worldMatrix;

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.h
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.h
@@ -288,6 +288,7 @@ private:
     void keyPressEvent(QKeyEvent *event) override;
     QString currentDir() const;
     int selectedThumbIndex(bool first = true);
+    QGraphicsView *getView() const;
 
     int mXOffset = 0;
     int mNumRows = 0;

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.h
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.h
@@ -267,6 +267,7 @@ public:
     QVector<DkThumbLabel *> getSelectedThumbs() const;
 
     /// return thumb in the middle of the (visible) view
+    void thumbClicked(DkThumbLabel *thumb, QMouseEvent *event);
     DkThumbLabel *getCenterThumb() const;
 
     void setImageLoader(QSharedPointer<DkImageLoader> loader);
@@ -307,6 +308,7 @@ private:
     int mXOffset = 0;
     int mNumRows = 0;
     int mNumCols = 0;
+    int mSelectionAnchor = -1; // where to extend selection from (shift+click)
     int mLastSelectedIdx = -1; // last selected item to restore on updateThumbs()
 
     QVector<DkThumbLabel *> mThumbLabels;
@@ -335,10 +337,8 @@ protected:
     void dragMoveEvent(QDragMoveEvent *event) override;
     void mousePressEvent(QMouseEvent *event) override;
     void mouseMoveEvent(QMouseEvent *event) override;
-    void mouseReleaseEvent(QMouseEvent *event) override;
 
     QPointF mMouseDownPos;
-    int mLastShiftIdx = -1; // item index clicked while shift key down
 };
 
 class DllCoreExport DkThumbScrollWidget : public DkWidget

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.h
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.h
@@ -309,7 +309,6 @@ private:
     int mNumCols = 0;
     int mSelectionAnchor = -1; // where to start range selection from (shift+click, shift+keypress)
     int mSelectionCursor = -1; // last visited item with keyboard or mouse click
-    int mLastSelectedIdx = -1; // last selected item to restore on updateThumbs()
 
     QVector<DkThumbLabel *> mThumbLabels;
     QSharedPointer<DkImageLoader> mLoader;

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.h
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.h
@@ -389,6 +389,7 @@ protected:
     QToolBar *mToolbar = nullptr;
     QLineEdit *mFilterEdit = nullptr;
     QAction *mAction = nullptr;
+    qreal mPrevDevicePixelRatio = 1.0;
 };
 
 class DkRecentDir

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.h
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.h
@@ -332,6 +332,7 @@ protected:
     void dropEvent(QDropEvent *event) override;
     void dragMoveEvent(QDragMoveEvent *event) override;
     void mousePressEvent(QMouseEvent *event) override;
+    void mouseReleaseEvent(QMouseEvent *event) override;
     void mouseDoubleClickEvent(QMouseEvent *event) override;
     void mouseMoveEvent(QMouseEvent *event) override;
 

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.h
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.h
@@ -204,6 +204,8 @@ public:
     void setFillSquare(bool value);
     void setFileInfo(const DkFileInfo &info);
 
+    void fetchThumb(float devicePixelRatio);
+
 signals:
     void loadFileSignal(const QString &filePath, bool newTab) const;
     void showFileSignal(const QString &filePath = QString()) const;

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.h
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.h
@@ -311,6 +311,8 @@ signals:
     void updateDirSignal(const QString &dir) const;
 
 protected:
+    DkThumbScene *thumbsScene() const;
+
     void wheelEvent(QWheelEvent *event) override;
     void dragEnterEvent(QDragEnterEvent *event) override;
     void dropEvent(QDropEvent *event) override;
@@ -319,7 +321,6 @@ protected:
     void mouseMoveEvent(QMouseEvent *event) override;
     void mouseReleaseEvent(QMouseEvent *event) override;
 
-    DkThumbScene *mThumbScene = nullptr;
     QPointF mMouseDownPos;
     int mLastShiftIdx = -1; // item index clicked while shift key down
 };

--- a/ImageLounge/src/DkGui/DkThumbsWidgets.h
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.h
@@ -336,6 +336,7 @@ protected:
     void dropEvent(QDropEvent *event) override;
     void dragMoveEvent(QDragMoveEvent *event) override;
     void mousePressEvent(QMouseEvent *event) override;
+    void mouseDoubleClickEvent(QMouseEvent *event) override;
     void mouseMoveEvent(QMouseEvent *event) override;
 
     QPointF mMouseDownPos;

--- a/ImageLounge/src/DkGui/DkWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkWidgets.cpp
@@ -182,7 +182,7 @@ void DkThumbsSaver::processDir(QVector<QSharedPointer<DkImageContainerT>> images
             }
 
             // FIXME: must ignore orientation metadata here
-            std::optional<LoadThumbnailResult> res = loadThumbnail(filePath, opt);
+            std::optional<LoadThumbnailResult> res = loadThumbnail(LoadThumbnailRequest{filePath, opt});
             if (!res || (!forceSave && res->fromExif)) {
                 return;
             }

--- a/ImageLounge/src/main.cpp
+++ b/ImageLounge/src/main.cpp
@@ -45,6 +45,7 @@
 #include <QThread>
 #include <QTranslator>
 
+#include "DkCachedThumb.h"
 #include "DkCentralWidget.h"
 #include "DkNoMacs.h"
 #include "DkPluginManager.h"
@@ -90,6 +91,8 @@ int main(int argc, char *argv[])
     nmc::DkSettingsManager::instance().init();
     nmc::DkMetaDataHelper::initialize(); // this line makes the XmpParser thread-save - so don't delete it even if you
                                          // seem to know what you do
+
+    nmc::DkCachedThumb::cleanup();
 
     // uncomment this for the single instance feature...
     //// check for single instance

--- a/ImageLounge/src/main.cpp
+++ b/ImageLounge/src/main.cpp
@@ -92,11 +92,6 @@ int main(int argc, char *argv[])
     nmc::DkMetaDataHelper::initialize(); // this line makes the XmpParser thread-save - so don't delete it even if you
                                          // seem to know what you do
 
-    if (nmc::DkSettingsManager::param().resources().thumbDiskCache
-        && nmc::DkSettingsManager::param().resources().cleanupThumbCache) {
-        nmc::DkCachedThumb::cleanupAsync();
-    }
-
     // uncomment this for the single instance feature...
     //// check for single instance
     // nmc::DkRunGuard guard;
@@ -158,6 +153,10 @@ int main(int argc, char *argv[])
 
     QCommandLineOption aboutOpt(QStringList("about"), QObject::tr("Print build information"));
     parser.addOption(aboutOpt);
+
+    QCommandLineOption skipStartupOpt(QStringList("skip-startup"));
+    skipStartupOpt.setFlags(QCommandLineOption::HiddenFromHelp);
+    parser.addOption(skipStartupOpt);
 
     parser.process(app);
 
@@ -277,6 +276,12 @@ int main(int argc, char *argv[])
 
     // bring up theme before any widgets
     nmc::DkThemeManager::instance().applyTheme();
+
+    if (!parser.isSet(skipStartupOpt) //
+        && nmc::DkSettingsManager::param().resources().thumbDiskCache
+        && nmc::DkSettingsManager::param().resources().cleanupThumbCache) {
+        nmc::DkCachedThumb::cleanupAsync();
+    }
 
     // initialize nomacs
     const int modeType = nmc::DkSettings::normalMode(mode);

--- a/ImageLounge/src/main.cpp
+++ b/ImageLounge/src/main.cpp
@@ -93,7 +93,7 @@ int main(int argc, char *argv[])
                                          // seem to know what you do
 
     if (nmc::DkSettingsManager::param().resources().cleanupThumbCache) {
-        nmc::DkCachedThumb::cleanup();
+        nmc::DkCachedThumb::cleanupAsync();
     }
 
     // uncomment this for the single instance feature...

--- a/ImageLounge/src/main.cpp
+++ b/ImageLounge/src/main.cpp
@@ -92,7 +92,8 @@ int main(int argc, char *argv[])
     nmc::DkMetaDataHelper::initialize(); // this line makes the XmpParser thread-save - so don't delete it even if you
                                          // seem to know what you do
 
-    if (nmc::DkSettingsManager::param().resources().cleanupThumbCache) {
+    if (nmc::DkSettingsManager::param().resources().thumbDiskCache
+        && nmc::DkSettingsManager::param().resources().cleanupThumbCache) {
         nmc::DkCachedThumb::cleanupAsync();
     }
 

--- a/ImageLounge/src/main.cpp
+++ b/ImageLounge/src/main.cpp
@@ -92,7 +92,9 @@ int main(int argc, char *argv[])
     nmc::DkMetaDataHelper::initialize(); // this line makes the XmpParser thread-save - so don't delete it even if you
                                          // seem to know what you do
 
-    nmc::DkCachedThumb::cleanup();
+    if (nmc::DkSettingsManager::param().resources().cleanupThumbCache) {
+        nmc::DkCachedThumb::cleanup();
+    }
 
     // uncomment this for the single instance feature...
     //// check for single instance


### PR DESCRIPTION
Updating main comment as a lot has changed.

This PR adds a user option for "high quality" thumbnails. By "high quality" what I am going for is:
- No "fuzzy" thumbnails, at least for big images
- If the EXIF thumbnail is too small, use the full image (or RAW preview)
- Use anti-aliasing (CV_AREA filter) and correct sizing for HiDPI screens.

Because we will be loading the full-size image when we didn't before (e.g. we only loaded EXIF usually) I have added some features to hide or speed that up:
- Thumbnail preloading; when scrolling get the the next visible page of thumbs queued up
- XDG-compatible thumbnail cache -  share thumbs with Linux file managers
- non-XDG mode for Windows/macOS, much smaller/faster cache by using JPEG.
- More settings to tweak behavior

There is also some notable new behavior:
- With hq thumbs mode a lot less memory may be used. We previously held the 400px image in the memory cache, now the "right-sized" image is held which is usually smaller.
- The memory cache isn't as crucial when disk cache is enabled, as cached items are fast to retrieve from SSD (on the order of 5-20ms).

Proposed settings with the default values.

<img width="596" height="556" alt="image" src="https://github.com/user-attachments/assets/22a1624e-ca08-44ca-8de7-5d1106dfa0ca" />

Effect of the anti-aliasing. It is subtle but I think worth it.

<img width="1084" height="593" alt="backyard-normal" src="https://github.com/user-attachments/assets/2791067f-719d-4113-a18a-02fa500e4985" />

<img width="1084" height="593" alt="backyard-hq" src="https://github.com/user-attachments/assets/faf9629c-1331-4d15-b71b-af758712b022" />
