### PR TITLE
fix(manipulators): applying manipulator drops history

### DIFF
--- a/ImageLounge/src/DkGui/DkViewPort.cpp
+++ b/ImageLounge/src/DkGui/DkViewPort.cpp
@@ -943,10 +943,8 @@ void DkViewPort::manipulatorApplied()
     if (!img.isNull()) {
         const QSharedPointer<DkImageContainerT> currImg = mLoader->getCurrentImage();
         if (currImg) {
-            auto imgC = QSharedPointer<DkImageContainerT>(new DkImageContainerT());
-            imgC->fromImageContainer(currImg);
-            imgC->setImage(img, mActiveManipulator->name());
-            setEditedImage(imgC);
+            currImg->setImage(img, mActiveManipulator->name());
+            setEditedImage(currImg);
         }
     } else {
         mController->setInfo(mActiveManipulator->errorMessage());


### PR DESCRIPTION
DkImageContainer::fromImageContainer() drops edit history. I could not find a reason to make a new image container here so just change it directly.

Fixes: #1414
