### PR TITLE
fix(zoom): always-zoom-to-fit conflicts with keep zoom

### DIFF
--- a/ImageLounge/src/DkCore/DkSettings.cpp
+++ b/ImageLounge/src/DkCore/DkSettings.cpp
@@ -443,7 +443,6 @@ void DkSettings::load(QSettings &settings, bool defaults)
 
     display_p.keepZoom = settings.value("keepZoom", display_p.keepZoom).toInt();
     display_p.invertZoom = settings.value("invertZoom", display_p.invertZoom).toBool();
-    display_p.zoomToFit = settings.value("zoomToFit", display_p.zoomToFit).toBool();
     display_p.highlightColor = QColor::fromRgba(
         settings.value("highlightColorRGBA", display_p.highlightColor.rgba()).toInt());
     display_p.hudBgColor = QColor::fromRgba(settings.value("bgColorWidgetRGBA", display_p.hudBgColor.rgba()).toInt());
@@ -696,8 +695,6 @@ void DkSettings::save(QSettings &settings, bool force)
         settings.setValue("keepZoom", display_p.keepZoom);
     if (force || display_p.invertZoom != display_d.invertZoom)
         settings.setValue("invertZoom", display_p.invertZoom);
-    if (force || display_p.zoomToFit != display_d.zoomToFit)
-        settings.setValue("zoomToFit", display_p.zoomToFit);
     if (force || display_p.highlightColor != display_d.highlightColor)
         settings.setValue("highlightColorRGBA", display_p.highlightColor.rgba());
     if (force || display_p.hudBgColor != display_d.hudBgColor)
@@ -927,7 +924,6 @@ void DkSettings::setToDefaultSettings()
 
     display_p.keepZoom = zoom_keep_same_size;
     display_p.invertZoom = false;
-    display_p.zoomToFit = false;
     display_p.highlightColor = QColor(0, 204, 255);
     display_p.hudBgColor = QColor(0, 0, 0, 100);
     display_p.hudFgdColor = QColor(255, 255, 255);

--- a/ImageLounge/src/DkCore/DkSettings.h
+++ b/ImageLounge/src/DkCore/DkSettings.h
@@ -142,10 +142,10 @@ public:
     };
 
     enum keepZoom {
-        zoom_always_keep,
-        zoom_keep_same_size,
-        zoom_never_keep,
-
+        zoom_always_keep, // keep prev image zoom
+        zoom_keep_same_size, // keep if prev image size is the same
+        zoom_never_keep, // zoom to fit, disallow scale > 100%
+        zoom_always_fit, // zoom to fit, allow scale > 100%
         zoom_end,
     };
 
@@ -209,7 +209,6 @@ public:
 
     struct Display {
         int keepZoom;
-        bool zoomToFit;
         bool invertZoom;
         bool tpPattern;
         bool showNavigation;

--- a/ImageLounge/src/DkGui/DkPreferenceWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkPreferenceWidgets.cpp
@@ -791,10 +791,7 @@ void DkDisplayPreference::createLayout()
     keepZoomButtons[DkSettings::zoom_keep_same_size]->setToolTip(
         tr("If checked, the zoom level is only kept, if the image loaded has the same level as the previous."));
     keepZoomButtons[DkSettings::zoom_never_keep] = new QRadioButton(tr("Never keep zoom"), this);
-
-    auto *cbZoomToFit = new QCheckBox(tr("Always zoom to fit"), this);
-    cbZoomToFit->setChecked(DkSettingsManager::param().display().zoomToFit);
-    connect(cbZoomToFit, &QCheckBox::toggled, this, &DkDisplayPreference::onZoomToFitToggled);
+    keepZoomButtons[DkSettings::zoom_always_fit] = new QRadioButton(tr("Always zoom to fit"), this);
 
     // check wrt the current settings
     keepZoomButtons[DkSettingsManager::param().display().keepZoom]->setChecked(true);
@@ -803,13 +800,14 @@ void DkDisplayPreference::createLayout()
     keepZoomButtonGroup->addButton(keepZoomButtons[DkSettings::zoom_always_keep], DkSettings::zoom_always_keep);
     keepZoomButtonGroup->addButton(keepZoomButtons[DkSettings::zoom_keep_same_size], DkSettings::zoom_keep_same_size);
     keepZoomButtonGroup->addButton(keepZoomButtons[DkSettings::zoom_never_keep], DkSettings::zoom_never_keep);
+    keepZoomButtonGroup->addButton(keepZoomButtons[DkSettings::zoom_always_fit], DkSettings::zoom_always_fit);
     connect(keepZoomButtonGroup, &QButtonGroup::idClicked, this, &DkDisplayPreference::onKeepZoomButtonClicked);
 
     auto *keepZoomGroup = new DkGroupWidget(tr("When Displaying New Images"), this);
     keepZoomGroup->addWidget(keepZoomButtons[DkSettings::zoom_always_keep]);
     keepZoomGroup->addWidget(keepZoomButtons[DkSettings::zoom_keep_same_size]);
     keepZoomGroup->addWidget(keepZoomButtons[DkSettings::zoom_never_keep]);
-    keepZoomGroup->addWidget(cbZoomToFit);
+    keepZoomGroup->addWidget(keepZoomButtons[DkSettings::zoom_always_fit]);
 
     // icon size
     auto *sbIconSize = new QSpinBox(this);
@@ -976,12 +974,6 @@ void DkDisplayPreference::onHQAntiAliasingToggled(bool checked) const
 {
     if (DkSettingsManager::param().display().highQualityAntiAliasing != checked)
         DkSettingsManager::param().display().highQualityAntiAliasing = checked;
-}
-
-void DkDisplayPreference::onZoomToFitToggled(bool checked) const
-{
-    if (DkSettingsManager::param().display().zoomToFit != checked)
-        DkSettingsManager::param().display().zoomToFit = checked;
 }
 
 void DkDisplayPreference::onTransitionCurrentIndexChanged(int index) const

--- a/ImageLounge/src/DkGui/DkPreferenceWidgets.h
+++ b/ImageLounge/src/DkGui/DkPreferenceWidgets.h
@@ -173,7 +173,6 @@ public slots:
     void onKeepZoomButtonClicked(int buttonId) const;
     void onInvertZoomToggled(bool checked) const;
     void onHQAntiAliasingToggled(bool checked) const;
-    void onZoomToFitToggled(bool checked) const;
     void onTransitionCurrentIndexChanged(int index) const;
     void onAlwaysAnimateToggled(bool checked) const;
     void onShowCropToggled(bool checked) const;

--- a/ImageLounge/src/DkGui/DkViewPort.cpp
+++ b/ImageLounge/src/DkGui/DkViewPort.cpp
@@ -621,7 +621,7 @@ void DkViewPort::updateImageMatrix()
         mWorldMatrix.translate(dx, dy);
     }
     // NOTE: this is not the same as resetView!
-    else if (DkSettingsManager::param().display().zoomToFit)
+    else if (DkSettingsManager::param().display().keepZoom == DkSettings::zoom_always_fit)
         zoomToFit();
 }
 


### PR DESCRIPTION
Always scale to fit does not work unless "never keep zoom" is also selected. This is counterintuitive and breaks always keep zoom with no apparent way to resolve it.

Fix by moving always-zoom-to-fit into keep zoom enum/group so these cannot be enabled at the same time. This is fine to do because the zoom modes are meant to be mutually exclusive.

Fixes: #1428

