### PR TITLE
macOS CI Updates

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,50 +1,65 @@
 name: macOS workflow
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master
+    paths-ignore:
+      - appveyor.yml
+      - .github/workflows/docker.yml
+      - .github/workflows/linux.yml
   pull_request:
     branches:
       - master
+    paths-ignore:
+      - appveyor.yml
+      - .github/workflows/docker.yml
+      - .github/workflows/linux.yml
 
 jobs:
   build:
     runs-on: ${{ matrix.runner.name }}
     name: build (Qt${{ matrix.qt.ver }}, ${{ matrix.config.type }}, ${{ matrix.runner.arch }})
     strategy:
+      max-parallel: 1
       matrix:
         runner:
-          - name: macos-13 # github-hosted runner name
-            arch: intel # file/log labeling
+          - name: macos-15-intel # github-hosted runner name
+            packages: googletest exiv2
+            arch: intel
             arch_flags: # cmake flags
-            cpus: 4 # vcpu allocation
             homebrew-opt: "/usr/local/opt" # root of qt_dir
-          - name: macos-14
+
+          - name: macos-15
+            packages: googletest exiv2
             arch: arm64
             arch_flags:
-            cpus: 3
             homebrew-opt: "/opt/homebrew/opt"
+
         qt:
-          # we don't try qt5 since github resources are limited
           - ver: 6
-            packages: "qt6"
+            packages: "qt5compat qtbase qtimageformats qtsvg qttools"
             flags: "-DQT_VERSION_MAJOR=6"
             cmakefiles: "qt6/lib/cmake" # root dir is runner.homebrew-opt
+
         config:
-          # this is extremely slow (~15 minutes) due to opencv and bundle, disabled for now
-          # - type: default
-          #   packages: googletest exiv2 quazip libraw opencv
-          #   flags: "-DENABLE_QUAZIP=ON"
-          #   kimageformats: true # compile kimageformats, currently requires qt6
-          #   portable: false # use the new portable bundle script
-          #   bundle: true # build portable bundle using macdeployqt
-          #   artifacts: true # upload artifacts
-          #   release: true # TODO: publish release
+          # this is extremely slow (~15 minutes) due to opencv
+          - type: quazip
+            packages: quazip libraw
+            flags: "-DENABLE_QUAZIP=ON"
+            kimageformats: true # compile kimageformat-plugins
+            opencv: true # compile a minimal opencv
+            portable: true # use the new portable bundle script
+            bundle: false # build portable bundle using macdeployqt
+            artifacts: true # upload artifacts
+            release: true # TODO: publish release
+
           - type: minimum
-            packages: googletest exiv2
+            packages:
             flags: "-DENABLE_PLUGINS=OFF -DENABLE_OPENCV=OFF -DENABLE_RAW=OFF -DENABLE_TIFF=OFF -DENABLE_QUAZIP=OFF"
-            kimageformats: true
+            kimageformats: false
+            opencv: false
             portable: true
             bundle: false
             artifacts: false
@@ -56,68 +71,105 @@ jobs:
           fetch-depth: 0 # ensure full history for git rev-parse
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      - name: Install build dependencies
+      - name: Get System Info
+        id: get_info
         run: |
-          brew install ${{ matrix.qt.packages }} ${{ matrix.config.packages }}
+          # note: our build of opencv has no external deps so compiler and commit is sufficient
+          COMPILER_ID=$(echo $(c++ --version) $(realpath $(xcrun --show-sdk-path)))
+          OPENCV_ID=$(git submodule status 3rd-party/opencv)
+          OPENCV_KEY=$(echo $COMPILER_ID $OPENCV_ID | sha256)
 
-      - name: Checkout submodules
+          echo "Compiler: $COMPILER_ID"
+          echo "OpenCV: $OPENCV_ID"
+          echo "OpenCV Cache Key: $OPENCV_KEY"
+          echo "OPENCV_KEY=${OPENCV_KEY}" >> $GITHUB_OUTPUT
+
+      - name: Setup Cache
+        run: |
+          # we must install things to /opt for packaging script to work, but cache@v4 won't write there
+          sudo mkdir /opt/opencv
+          sudo chown $USER:$(id -gn) /opt/opencv
+
+      - name: Install Packages
+        if: steps.cache_packages.outputs.cache-hit != 'true'
+        run: |
+          brew install --quiet --force-bottle ${{ matrix.runner.packages }} ${{ matrix.qt.packages }} ${{ matrix.config.packages }}
+
+      - name: Checkout Submodules
         run: |
           cd ${GITHUB_WORKSPACE}
-          git submodule init
-          git submodule update 3rd-party/imageformats ImageLounge/plugins
+          git submodule update --init --depth 1 3rd-party/imageformats
 
-      - name: CMake configure
+      - name: Cache opencv
+        id: cache_opencv
+        if: matrix.config.opencv
+        uses: actions/cache@v4
+        with:
+          path: /opt/opencv
+          key: ${{ runner.os }}-opencv-${{ steps.get_info.outputs.OPENCV_KEY }}
+
+      - name: Build opencv
+        if: matrix.config.opencv && steps.cache_opencv.outputs.cache-hit != 'true'
+        run: |
+          cd ${GITHUB_WORKSPACE}
+          # put opencv in /opt to prevent conflicts with homebrew and/or apple silicon
+          # note kimageformats is installed into qt plugins directory so it won't be a problem,
+          ./scripts/build-opencv.sh -D CMAKE_INSTALL_PREFIX=/opt/opencv
+
+      - name: Configure
         run: |
           mkdir ${GITHUB_WORKSPACE}/build
           cd ${GITHUB_WORKSPACE}/build
-          export CMAKE_PREFIX_PATH="${{ matrix.runner.homebrew-opt }}/${{ matrix.qt.cmakefiles }}"
-          cmake ${{ matrix.runner.arch_flags }} ${{ matrix.qt.flags }} ${{ matrix.config.flags }} ../ImageLounge
+          export CMAKE_PREFIX_PATH="/opt/opencv:${{ matrix.runner.homebrew-opt }}/${{ matrix.qt.cmakefiles }}"
+          cmake -G Ninja ${{ matrix.runner.arch_flags }} ${{ matrix.qt.flags }} ${{ matrix.config.flags }} ../ImageLounge
 
       - name: Get Build Version
         id: get_version
         run: |
           cd ${GITHUB_WORKSPACE}/build
-          OS=$(sw_vers -productVersion)
+          ARCH=$(uname -m)
+          OS="$(sw_vers -productName)-$(sw_vers -productVersion)"
           SHA=$(git rev-parse --short ${{ github.event.pull_request.head.sha || github.sha }})
           VERSION=$(cat DkVersion.h | grep NOMACS_VERSION_STR | sed 's/[^0-9\.]*//g')
-          echo "VERSION=${VERSION}-${SHA}-${OS}" >> $GITHUB_OUTPUT
+          echo "VERSION=${VERSION}-${SHA}-${OS}-${ARCH}" >> $GITHUB_OUTPUT
 
       - name: Build
         run: |
           cd ${GITHUB_WORKSPACE}/build
-          make -j${{ matrix.runner.cpus }}
+          ninja
 
       - name: Test
         run: |
           cd ${GITHUB_WORKSPACE}/build
-          make check
+          ninja check
 
       - name: Build kimageformats
         if: matrix.config.kimageformats
         run: |
           cd ${GITHUB_WORKSPACE}/build
           export CMAKE_PREFIX_PATH="${{ matrix.runner.homebrew-opt }}/${{ matrix.qt.cmakefiles }}"
-          make kimageformats
+          ninja kimageformats
 
-      - name: Make Portable Bundle (Fast)
+      - name: Make Portable Bundle
         if: matrix.config.portable
         run: |
           cd ${GITHUB_WORKSPACE}/build
-          make portable
+          ninja portable
+          cd portable && zip -ry nomacs.app.zip nomacs.app
 
-      - name: Make Portable Bundle
+      - name: Make Portable Bundle (Slow)
         if: matrix.config.bundle
         run: |
           cd /usr/local/lib/QtGui.framework/Versions/A
           install_name_tool -id '@rpath/QtGui.framework/Versions/A/QtGui' QtGui
           otool -L QtGui | head -2
           cd ${GITHUB_WORKSPACE}/build
-          make bundle
+          ninja bundle
 
       - name: Upload Artifacts
         if: matrix.config.artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: "nomacs-${{ steps.get_version.outputs.VERSION }}-${{ matrix.runner.arch }}-${{ matrix.config.type }}-qt${{ matrix.qt.ver}}.dmg"
-          path: build/nomacs.dmg
+          name: "nomacs-${{ steps.get_version.outputs.VERSION }}-${{ matrix.config.type }}-qt${{ matrix.qt.ver}}"
+          path: build/portable/nomacs.app.zip
           retention-days: 30

--- a/ImageLounge/macosx/filetypes.xml
+++ b/ImageLounge/macosx/filetypes.xml
@@ -1,5 +1,5 @@
 <!-- begin list-formats -->
-        <!-- ea280888, 2025-04-02, macOS Ventura (13.7) -->
+        <!-- bd555db0, 2025-11-06, custom, macOS Sequoia (15.7.2) -->
         <key>CFBundleTypeExtensions</key>
         <array>
           <string>3fr</string>
@@ -34,6 +34,7 @@
           <string>icns</string>
           <string>ico</string>
           <string>iiq</string>
+          <string>ilbm</string>
           <string>im1</string>
           <string>im24</string>
           <string>im32</string>
@@ -54,6 +55,7 @@
           <string>k25</string>
           <string>kdc</string>
           <string>kra</string>
+          <string>lbm</string>
           <string>mdc</string>
           <string>mef</string>
           <string>mng</string>

--- a/ImageLounge/macosx/make-portable.sh
+++ b/ImageLounge/macosx/make-portable.sh
@@ -126,8 +126,8 @@ process_exe()
   DYLD_PRINT_LIBRARIES_POST_LAUNCH=1 DYLD_PRINT_LIBRARIES=1 DYLD_PRINT_RPATHS=1 DYLD_PRINT_SEARCHING=1 \
     "$SRC_EXE" $ARGS 2>&1 | grep -A1 'found: dylib-from-disk:' | grep -v '^--' | sed -n 'N;s/\n/ /p' | sed 's/"//g' > "$LIBS_USED" 2>&1
   
-  # copy .dylib files from the build directory /usr/local and /opt/homebrew, excluding plugins (handled separately)
-  cat "$LIBS_USED" | grep -E "^dyld.*($PWD|/usr/local/|/opt/homebrew).*\.dylib" | \
+  # copy .dylib files from the build directory /usr/local and /opt/, excluding plugins (handled separately)
+  cat "$LIBS_USED" | grep -E "^dyld.*($PWD|/usr/local/|/opt/).*\.dylib" | \
     grep -vE "/PlugIns|plugins/" | /usr/bin/cut -w -f4 -f7 | while read -r LINE; do
 
     local import=$(echo $LINE | /usr/bin/cut -w -f1)
@@ -170,7 +170,7 @@ test_exe()
   DYLD_PRINT_LIBRARIES_POST_LAUNCH=1 DYLD_PRINT_LIBRARIES=1 DYLD_PRINT_RPATHS=1 \
       DYLD_LIBRARY_PATH= $CMD > "$LIBS_PATCHED" 2>&1
 
-  local DYLIBS=$(cat "$LIBS_PATCHED" | grep ^dyld | grep -E "(/usr/local/|/opt)" | /usr/bin/cut -w -f3)
+  local DYLIBS=$(cat "$LIBS_PATCHED" | grep ^dyld | grep -E "(/usr/local/|/opt/)" | /usr/bin/cut -w -f3)
 
   local err=0
   for DYLIB in $DYLIBS; do
@@ -207,7 +207,6 @@ rsync -auv --no-owner --no-group --copy-links \
   "$PLUGINS_SRC/iconengines" \
   "$PLUGINS_SRC/imageformats" \
   "$PLUGINS_SRC/networkinformation" \
-  "$PLUGINS_SRC/platforminputcontexts" \
   "$PLUGINS_SRC/platforms" \
   "$PLUGINS_SRC/styles" \
   "$PLUGINS_SRC/tls" \

--- a/scripts/build-opencv.sh
+++ b/scripts/build-opencv.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+# build a minimal OpenCV for nomacs
+
+set -e
+
+git submodule update --init --depth 1 3rd-party/opencv
+
+mkdir 3rd-party/opencv/build 
+
+cd 3rd-party/opencv/build
+
+cmake .. \
+  -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DBUILD_LIST=core,imgproc \
+  -DBUILD_opencv_world=OFF \
+  -DBUILD_TESTS=OFF \
+  -DBUILD_PERF_TESTS=OFF \
+  -DBUILD_EXAMPLES=OFF \
+  -DWITH_IMGCODEC_GIF=OFF \
+  -DWITH_IMGCODEC_HDR=OFF \
+  -DWITH_IMGCODEC_PFM=OFF \
+  -DWITH_IMGCODEC_PXM=OFF \
+  -DWITH_IMGCODEC_SUNRASTER=OFF \
+  -DWITH_JPEG=OFF \
+  -DWITH_JPEG2000=OFF \
+  -DWITH_JASPER=OFF \
+  -DWITH_OPENJPEG=OFF \
+  -DWITH_PNG=OFF \
+  -DWITH_TIFF=OFF \
+  -DWITH_WEBP=OFF \
+  -DWITH_OPENEXR=OFF \
+  -DWITH_GDCM=OFF \
+  -DWITH_AVIF=OFF \
+  -DWITH_FFMPEG=OFF \
+  -DWITH_GSTREAMER=OFF \
+  -DWITH_1394=OFF \
+  -DWITH_V4L=OFF \
+  -DWITH_OPENCL=OFF \
+  -DWITH_IPP=OFF \
+  -DWITH_PROTOBUF=OFF \
+  -DWITH_QT=OFF \
+  -DWITH_GTK=OFF \
+  -DWITH_GTK_2_X=OFF \
+  -DWITH_OPENGL=OFF \
+  "$@"
+   
+ninja
+
+sudo ninja install
+ 

--- a/scripts/homebrew/hash.sh
+++ b/scripts/homebrew/hash.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+# compute a reasonable cache key for a set of homebrew formulae
+# arguments: homebrew formula names separated by spaces
+
+ARCH=$(uname -m)
+MACOS_VERSION=$(sw_vers -productVersion | cut -d. -f1)
+
+if [ ${MACOS_VERSION} -ne 15 ]; then
+  echo "$0: unsupported macOS version: ${MACOS_VERSION}" >&2
+  exit 1
+fi
+
+# jq filter on formulae[].bottle.stable.files to select
+# the correct bottle for the current OS/Architecture 
+BOTTLE_FILTER=''
+
+ARCH=x86_64
+
+if [ "${ARCH}" = "arm64" ]; then
+  BOTTLE_FILTER='.arm64_sequoia // .all'
+
+elif [ "${ARCH}" = "x86_64" ]; then
+  # some 10.15/intel bottles are shared with 10.14
+  BOTTLE_FILTER='.sequoia // .sonoma // .all'
+else
+  echo "$0: unsupported ARCH: ${ARCH}" >&2
+  exit 2
+fi
+
+set -e
+
+# brew deps will warn about uninstalled formulae; in practice this
+# does not seem to matter, but could depend on the bottle selection
+echo "$@" | xargs -n 1 echo > pkgs.txt
+brew deps --full-name --union "$@" >> pkgs.txt
+
+PKGS=$(cat pkgs.txt | sort | uniq | xargs)
+echo "$0: computed deps: $PKGS" >&2
+
+brew info --json=v2 $PKGS | jq "[ .formulae[] | {name: .name, vers: .versions.stable, src: (.urls.stable | (.revision // .checksum)), tap: .tap_git_head, formula: .ruby_source_checksum.sha256, bottle: ( (.bottle.stable.files) | (${BOTTLE_FILTER}) | .sha256 )} ]" > pkgs.info.txt
+
+grep -w -B4 -A4 null pkgs.info.txt && \
+  echo "$0: null data in brew info" >&2 && \
+  exit 3
+
+PKG_COUNT=$(echo $PKGS | xargs -n 1 echo | grep -c .)
+INFO_COUNT=$(grep -c name pkgs.info.txt)
+echo "$0:  $PKG_COUNT formulae" >&2
+echo "$0:  $INFO_COUNT bottles for $BOTTLE_FILTER" >&2
+
+if [ $PKG_COUNT -ne $INFO_COUNT ]; then
+  echo "$0: package/bottle counts do not match" >&2
+  exit 4
+fi
+
+
+cat pkgs.info.txt | sha256

--- a/scripts/homebrew/init.sh
+++ b/scripts/homebrew/init.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# setup a ram disk for homebrew and compiling
+set -e 
+diskutil eraseVolume HFS+ "Scratch" `hdiutil attach -nomount ram://$((2*4096*512))`
+
+DISK=$(hdiutil attach -nomount ram://$((2*4096*512)) )
+sudo newfs_hfs -v Homebrew $DISK
+sudo mount -t hfs $DISK /usr/local
+echo ramdisk $DISK mounted @ /usr/local

--- a/scripts/homebrew/reset.sh
+++ b/scripts/homebrew/reset.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# setup or reset back to a minimum build environment
+# similar to github actions runner
+# before running, setup ramdisks with ./ramdisk.sh
+
+export NONINTERACTIVE=1 # homebrew
+export HOMEBREW_TEMP=/usr/local/tmp
+
+# with ramdisk mounted this won't touch actual /usr/local
+sudo rm -rf /usr/local/*
+sudo rm -rf /opt/opencv
+
+set -e
+
+sudo chown root:wheel /usr/local
+sudo chmod 755 /usr/local
+
+sudo mkdir $HOMEBREW_TEMP
+sudo chown root:wheel $HOMEBREW_TEMP
+sudo chmod 755 $HOMEBREW_TEMP
+
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+brew install --force-bottle act cmake pkgconfig ninja
+
+echo SETUP SUCCESSFUL

--- a/scripts/homebrew/workflow.sh
+++ b/scripts/homebrew/workflow.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# simulate github actions runner
+# run ./reset.sh first to clean the environment
+
+# homebrew doesn't like TEMP on a different filessytem
+export HOMEBREW_TEMP=/usr/local/tmp
+
+NMC_SRC=~/nfs/sw/nomacs
+RUN_DIR=/Volumes/Scratch # ramdisk
+
+set -e
+
+# brew doctor
+mkdir -p $RUN_DIR
+rsync -auv --delete $NMC_SRC $RUN_DIR/ 
+
+cd $RUN_DIR/nomacs
+
+#rm -rf ~/.cache/act
+
+# syntax check workflow; we can't run it since Docker cannot run macOS
+act -P macos-13=-self-hosted --workflows .github/workflows/macos.yml \
+  --strict --validate
+  #-s GITHUB_TOKEN=ghp_dummy
+
+brew install --force-bottle qt5compat qtbase qtimageformats qtsvg qttools \
+  googletest exiv2 libtiff libraw
+
+./scripts/build-opencv.sh -D CMAKE_INSTALL_PREFIX=/opt/opencv
+export CMAKE_PREFIX_PATH=/opt/opencv
+
+mkdir build
+cd build
+cmake -G Ninja ../ImageLounge
+
+ninja
+
+ninja check
+
+ninja kimageformats
+
+ninja portable
+
+cd portable && zip -ry nomacs.app.zip nomacs.app
+


### PR DESCRIPTION
building binaries for 3.22 rc1

I tried to cache homebrew packages in several different ways but they (github) have either made it impossible or too slow to be worthwhile. A complete backup of homebrew as configured in the runner (before we even touch it), is around 4GB which is too much (account limit is 10GB for all workflows). We actually need only around 400MB based on local testing. Removing packages to get the size down is too slow. Trying any way to reinstall homebrew is too slow. So we just have to accept it I guess.
