### PR TITLE
90-Degree Rotation Improvements

### DIFF
--- a/ImageLounge/src/DkCore/DkBasicLoader.cpp
+++ b/ImageLounge/src/DkCore/DkBasicLoader.cpp
@@ -597,7 +597,7 @@ bool DkBasicLoader::loadROH(const QString &filePath, QImage &img, QSharedPointer
         const auto *pData = (const unsigned char *)ba->constData();
         auto *buffer = new unsigned char[rohW * rohH];
 
-        if (!buffer)
+        if (!buffer || ba->size() < (2 * rohW * rohH))
             return imgLoaded;
 
         for (long long i = 0; i < (rohW * rohH); i++) {

--- a/ImageLounge/src/DkCore/DkBasicLoader.h
+++ b/ImageLounge/src/DkCore/DkBasicLoader.h
@@ -159,6 +159,21 @@ class DllCoreExport DkBasicLoader : public QObject
     Q_OBJECT
 
 public:
+    /**
+     * @brief Static information about the loaded image; must not change
+     *        after the image loaded/reloaded from file
+     */
+    enum class Flag {
+        none = 0,
+        ignored_orientation = 1, // exif orientation was ignored when loading the image
+    };
+    Q_DECLARE_FLAGS(Flags, Flag);
+
+    Flags flags() const
+    {
+        return mFlags;
+    }
+
     DkBasicLoader();
 
     ~DkBasicLoader() override
@@ -401,6 +416,7 @@ protected:
     QVector<DkEditImage> mImages;
     int mMinHistorySize = 2;
     int mImageIndex = 0;
+    Flags mFlags{Flag::none};
 
 private:
     QSharedPointer<DkMetaDataT> lastMetaDataEdit() const;

--- a/ImageLounge/src/DkCore/DkBasicLoader.h
+++ b/ImageLounge/src/DkCore/DkBasicLoader.h
@@ -49,9 +49,17 @@ class DkMetaDataT;
 class DllCoreExport DkEditImage
 {
 public:
+    enum EditType {
+        data = 1, // image data changed
+        metadata = 2, // metadata changed
+    };
+    Q_DECLARE_FLAGS(Edits, EditType);
+
     DkEditImage();
-    DkEditImage(const QImage &img, const QSharedPointer<DkMetaDataT> &metaData, const QString &editName = "");
-    DkEditImage(const QSharedPointer<DkMetaDataT> &metaData, const QImage &img, const QString &editName = "");
+    DkEditImage(const Edits &edits,
+                const QImage &img,
+                const QSharedPointer<DkMetaDataT> &metaData,
+                const QString &editName);
 
     void setImage(const QImage &img);
     QString editName() const;

--- a/ImageLounge/src/DkCore/DkBasicLoader.h
+++ b/ImageLounge/src/DkCore/DkBasicLoader.h
@@ -53,7 +53,7 @@ public:
         data = 1, // image data changed
         metadata = 2, // metadata changed
     };
-    Q_DECLARE_FLAGS(Edits, EditType);
+    Q_DECLARE_FLAGS(Edits, EditType)
 
     DkEditImage();
     DkEditImage(const Edits &edits,
@@ -167,7 +167,7 @@ public:
         none = 0,
         ignored_orientation = 1, // exif orientation was ignored when loading the image
     };
-    Q_DECLARE_FLAGS(Flags, Flag);
+    Q_DECLARE_FLAGS(Flags, Flag)
 
     Flags flags() const
     {
@@ -179,7 +179,7 @@ public:
     ~DkBasicLoader() override
     {
         release();
-    };
+    }
 
     /**
      * Get rotation value
@@ -228,12 +228,12 @@ public:
     int getNumPages() const
     {
         return mNumPages;
-    };
+    }
 
     int getPageIdx() const
     {
         return mPageIdx;
-    };
+    }
 
     /**
      * Set page index but do not load anything (loadGeneral() is required)
@@ -289,7 +289,7 @@ public:
     bool isDirty() const
     {
         return mPageIdxDirty;
-    };
+    }
 
     /**
      * Returns true if an image is currently loaded.
@@ -298,7 +298,7 @@ public:
     bool hasImage()
     {
         return !image().isNull();
-    };
+    }
 
     void undo();
     void redo();
@@ -341,16 +341,18 @@ public:
                            QSize = QSize())
     {
         return false;
-    };
+    }
     int mergeVecFiles(const QStringList &, QString &) const
     {
         return 0;
-    };
+    }
     bool readHeader(const unsigned char **, int &, int &) const
     {
         return false;
-    };
-    void getPatchSizeFromFileName(const QString &, int &, int &) const {};
+    }
+    void getPatchSizeFromFileName(const QString &, int &, int &) const
+    {
+    }
 
 #endif
     LoaderResult loadQt(const QString &filePath,

--- a/ImageLounge/src/DkCore/DkImageLoader.cpp
+++ b/ImageLounge/src/DkCore/DkImageLoader.cpp
@@ -1409,7 +1409,7 @@ void DkImageLoader::rotateImage(double angle)
             return;
 
         } catch (const Exiv2::Error &e) {
-            qWarning() << "[Exiv2] rotate metadata failed" << e.code() << e.what();
+            qWarning() << "[Exiv2] rotate metadata failed" << static_cast<int>(e.code()) << e.what();
         } catch (...) {
             qWarning() << "[Exiv2] rotate metadata failed";
         }

--- a/ImageLounge/src/DkCore/DkImageLoader.cpp
+++ b/ImageLounge/src/DkCore/DkImageLoader.cpp
@@ -983,9 +983,8 @@ void DkImageLoader::saveUserFileAs(const QImage &saveImg, bool silent)
             saveName.remove("." + saveFileInfo.suffix());
     }
 
+    bool overwriteFile = false;
     QString fileName;
-
-    int answer = QDialog::Rejected;
 
     // don't ask the user if save was hit & the file format is supported for saving
     if (silent && !selectedFilter.isEmpty() && isEdited()) {
@@ -993,13 +992,17 @@ void DkImageLoader::saveUserFileAs(const QImage &saveImg, bool silent)
         auto *msg = new DkMessageBox(QMessageBox::Question,
                                      tr("Overwrite File"),
                                      tr("Do you want to overwrite:\n%1?").arg(fileName),
-                                     (QMessageBox::Yes | QMessageBox::No),
+                                     (QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel),
                                      dialogParent);
         msg->setObjectName("overwriteDialog");
 
-        answer = msg->exec();
+        int answer = msg->exec();
+        overwriteFile = answer == QMessageBox::Yes;
+        if (answer == QDialog::Rejected || answer == QMessageBox::Cancel)
+            return;
     }
-    if (answer == QDialog::Rejected || answer == QMessageBox::No) {
+
+    if (!overwriteFile) {
         // note: basename removes the whole file name from the first dot...
         QString savePath = (!selectedFilter.isEmpty())
             ? saveFileInfo.absoluteFilePath()

--- a/ImageLounge/src/DkCore/DkImageLoader.cpp
+++ b/ImageLounge/src/DkCore/DkImageLoader.cpp
@@ -637,7 +637,7 @@ bool DkImageLoader::promptSaveBeforeUnload()
             else if (metaEdited)
                 mCurrentImage->saveMetaData();
         } else {
-            saveUserFileAs(mCurrentImage->image(), false); // we loose all metadata here - right?
+            saveUserFile(mCurrentImage->image(), false); // we loose all metadata here - right?
         }
 
         // Clear the image container to force reload so we get correct state.
@@ -950,7 +950,7 @@ void DkImageLoader::copyUserFile()
     }
 }
 
-void DkImageLoader::saveUserFileAs(const QImage &saveImg, bool silent)
+void DkImageLoader::saveUserFile(const QImage &saveImg, bool silent)
 {
     // TODO glitch if (!mCurrentImage->getMetaData()->isLoaded()); see rotateImage()
 

--- a/ImageLounge/src/DkCore/DkImageLoader.cpp
+++ b/ImageLounge/src/DkCore/DkImageLoader.cpp
@@ -1368,24 +1368,31 @@ void DkImageLoader::rotateImage(double angle)
             metaData->setOrientation(qRound(angle));
 
             // Add history item with edited metadata (exif rotation)
-            mCurrentImage->setMetaData(metaData, img, tr("Rotated")); // new edit with modified metadata
+            mCurrentImage->setMetaData(metaData, img, tr("Rotated (EXIF)")); // new edit with modified metadata
+
+            return;
 
         } catch (...) {
-            // Update the image itself, along with the history and everything
-            // In other words, the rotated image is saved to the history and the edit flag is set
-            // the exif rotation flag will be reset when adding the new image to the history (BasicLoader)
-            mCurrentImage->setImage(img, tr("Rotated")); // new edit with rotated pixmap (clears orientation)
-            setImageUpdated();
-            // TODO There's a glitch when rotating/changing the image after switching back from settings
-            // which causes the containers to be reloaded. If we call the local setImage() overload,
-            // the metadata object will be reset causing the image to be saved without modified metadata on Save.
-            // With the call above, no metadata is lost, but when navigating away, confirming save on unload
-            // and navigating back, the previous image may still appear (loaded while/before async save).
-            // TODO a) prevent metadata reset without also resetting the gui; b) send signal after save
-            // to reload the saved image (in the other container); c) don't load x while saving x ...
-            // [2022-09, pse]
+            qWarning() << "Rotation via metadata failed, perhaps the image format is unsupported";
         }
     }
+
+    // Update the image itself, along with the history and everything
+    // In other words, the rotated image is saved to the history and the edit flag is set
+    // the exif rotation flag will be reset when adding the new image to the history (BasicLoader)
+    mCurrentImage->setImage(img, tr("Rotated")); // new edit with rotated pixmap (clears orientation)
+    // setImageUpdated(); // TODO: remove this method, it just calls setEdited() and "updated" could mean anything
+    // NOTE: setImage() does not call setEdited() like setMetaData does()
+    mCurrentImage->setEdited();
+
+    // TODO There's a glitch when rotating/changing the image after switching back from settings
+    // which causes the containers to be reloaded. If we call the local setImage() overload,
+    // the metadata object will be reset causing the image to be saved without modified metadata on Save.
+    // With the call above, no metadata is lost, but when navigating away, confirming save on unload
+    // and navigating back, the previous image may still appear (loaded while/before async save).
+    // TODO a) prevent metadata reset without also resetting the gui; b) send signal after save
+    // to reload the saved image (in the other container); c) don't load x while saving x ...
+    // [2022-09, pse]
 }
 
 /**

--- a/ImageLounge/src/DkCore/DkImageLoader.h
+++ b/ImageLounge/src/DkCore/DkImageLoader.h
@@ -188,6 +188,8 @@ protected:
     bool mFolderUpdated = false;
     bool mSortingImages = false;
     bool mSortingIsDirty = false;
+    bool mOrientationWarningShown = false;
+    bool mSaveOrientationWarningShown = false;
     QFutureWatcher<QVector<QSharedPointer<DkImageContainerT>>> mCreateImageWatcher;
 };
 

--- a/ImageLounge/src/DkCore/DkImageLoader.h
+++ b/ImageLounge/src/DkCore/DkImageLoader.h
@@ -108,7 +108,13 @@ public slots:
     void changeFile(int skipIdx);
     void directoryChanged(const QString &path = QString());
     void saveFileWeb(const QImage &saveImg);
-    void saveUserFileAs(const QImage &saveImg, bool silent);
+    /**
+     * @brief Save/SaveAs dialogs
+     * @param saveImg image to save
+     * @param silent if true, the user wants "Save" and not "Save As"
+     * @note "Save" falls back to "Save As" if it is not supported
+     */
+    void saveUserFile(const QImage &saveImg, bool silent);
     void copyUserFile();
     void saveFile(const QString &filename,
                   const QImage &saveImg = QImage(),

--- a/ImageLounge/src/DkCore/DkMessageBox.cpp
+++ b/ImageLounge/src/DkCore/DkMessageBox.cpp
@@ -207,6 +207,11 @@ void DkMessageBox::setButtonText(QMessageBox::StandardButton button, const QStri
         abstractButton->setText(text);
 }
 
+void DkMessageBox::setCheckBoxText(const QString &text)
+{
+    showAgain->setText(text);
+}
+
 void DkMessageBox::buttonClicked(QAbstractButton *button)
 {
     int ret = buttonBox->standardButton(button);

--- a/ImageLounge/src/DkCore/DkMessageBox.h
+++ b/ImageLounge/src/DkCore/DkMessageBox.h
@@ -54,6 +54,7 @@ public:
     void setVisible(bool visible) override;
     void setDefaultButton(QMessageBox::StandardButton button);
     void setButtonText(QMessageBox::StandardButton button, const QString &text);
+    void setCheckBoxText(const QString &text);
 
 public slots:
     void buttonClicked(QAbstractButton *button);

--- a/ImageLounge/src/DkCore/DkMetaData.cpp
+++ b/ImageLounge/src/DkCore/DkMetaData.cpp
@@ -1329,10 +1329,6 @@ bool DkMetaDataT::setExifValue(QString key, QString taginfo)
         return false;
 
     try {
-        if (mExifImg->checkMode(Exiv2::mdExif) != Exiv2::amReadWrite
-            && mExifImg->checkMode(Exiv2::mdExif) != Exiv2::amWrite)
-            return false;
-
         Exiv2::ExifData &exifData = mExifImg->exifData();
 
         if (!exifData.empty() && getExifKeys().contains(key)) {

--- a/ImageLounge/src/DkCore/DkMetaData.cpp
+++ b/ImageLounge/src/DkCore/DkMetaData.cpp
@@ -821,7 +821,8 @@ bool DkMetaDataT::isWriteable() const
     // so we need not worry about truncating metadata
     Exiv2::AccessMode mode = mExifImg->checkMode(Exiv2::mdExif);
     if (!(mode & Exiv2::amWrite)) {
-        qInfo() << "[Exiv2] write unsupported for type:" << mExifImg->imageType() << mExifImg->mimeType().c_str();
+        qInfo() << "[Exiv2] write unsupported for type:" << static_cast<int>(mExifImg->imageType())
+                << mExifImg->mimeType().c_str();
         return false;
     }
 
@@ -830,7 +831,8 @@ bool DkMetaDataT::isWriteable() const
         auto image = Exiv2::ImageFactory::create(mExifImg->imageType());
         return true;
     } catch (...) {
-        qInfo() << "[Exiv2] create() unsupported for type:" << mExifImg->imageType() << mExifImg->mimeType().c_str();
+        qInfo() << "[Exiv2] create() unsupported for type:" << static_cast<int>(mExifImg->imageType())
+                << mExifImg->mimeType().c_str();
     }
 
     return false;

--- a/ImageLounge/src/DkCore/DkMetaData.h
+++ b/ImageLounge/src/DkCore/DkMetaData.h
@@ -132,6 +132,7 @@ public:
     QImage cleanImage(const QImage &img);
 
     bool hasMetaData() const;
+    bool isWriteable() const;
     bool isLoaded() const;
     bool isTiff() const;
     bool isJpg() const;

--- a/ImageLounge/src/DkGui/DkMetaDataWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkMetaDataWidgets.cpp
@@ -484,7 +484,7 @@ void DkMetaDataDock::setImage(QSharedPointer<DkImageContainerT> imgC)
 
     const QSize tSize = thumbImg.size();
     const qint64 tSizeBytes = thumbImg.sizeInBytes();
-    thumbImg = thumbImg.scaled(tSize.boundedTo(QSize(mTreeView->width(), mTreeView->width())), Qt::KeepAspectRatio);
+    thumbImg = thumbImg.scaledToHeight(160, Qt::SmoothTransformation);
 
     mThumbNailLabel->setPixmap(QPixmap::fromImage(thumbImg));
 

--- a/ImageLounge/src/DkGui/DkViewPort.cpp
+++ b/ImageLounge/src/DkGui/DkViewPort.cpp
@@ -820,7 +820,7 @@ void DkViewPort::saveFileAs(bool silent)
             }
         }
 
-        mLoader->saveUserFileAs(img, silent);
+        mLoader->saveUserFile(img, silent);
     }
 }
 


### PR DESCRIPTION
Fix rotation regression #1442 and try to prevent unexpected behavior like wrong thumbnails or reloading the file changes the image orientation. See commit message for details.

There is still much to be desired, like lossless rotation for RAW and TIFF (exiv2 supports this, but we cannot due to how DkMetaData and DkEditImage work). Maybe that will come later, but not for 3.22.
 
The most visible change, when orientation is ignored either because of the image format or the checkbox in settings, *and* metadata rotation will be used: 

<img width="917" height="366" alt="image" src="https://github.com/user-attachments/assets/f91f0304-51aa-4bca-ab55-9689a754dbf4" />

New dialog when orientation saving is disabled (default enabled).

<img width="917" height="366" alt="image" src="https://github.com/user-attachments/assets/f17c2df1-83e0-4aa3-a6f1-95304ceb3359" />
