### PR TITLE
metadata: Add bugtracker and vcs-browser URLs

### DIFF
--- a/ImageLounge/xgd-data/org.nomacs.ImageLounge.appdata.xml.in
+++ b/ImageLounge/xgd-data/org.nomacs.ImageLounge.appdata.xml.in
@@ -26,6 +26,8 @@
 
     <launchable type="desktop-id">org.nomacs.ImageLounge.desktop</launchable>
     <url type="homepage">https://nomacs.org</url>
+    <url type="bugtracker">https://github.com/nomacs/nomacs/issues</url>
+    <url type="vcs-browser">https://github.com/nomacs/nomacs</url>
 
     <content_rating type="oars-1.1">
         <content_attribute id="drugs-alcohol">mild</content_attribute>


### PR DESCRIPTION
Add bugtracker and vcs-browser URLs to show related pages.

More information: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines#url

