### PR TITLE
Histogram panel cleanup

### DIFF
--- a/ImageLounge/src/DkCore/DkImageProc.h
+++ b/ImageLounge/src/DkCore/DkImageProc.h
@@ -511,8 +511,8 @@ protected:
 #ifdef WITH_OPENCV
 
 // helper for per-channel processing
-template<typename Format, typename Lambda>
-static void forEachChannel(cv::Mat &mat, const DkWorkRange &range, Lambda func)
+template<typename Format, typename CvMat, typename Lambda>
+static void forEachChannel(CvMat &mat, const DkWorkRange &range, Lambda func)
 {
     Q_ASSERT(Format::isCompatibleWith(mat));
     Q_ASSERT(range.isWithin(0, mat.rows));
@@ -522,7 +522,7 @@ static void forEachChannel(cv::Mat &mat, const DkWorkRange &range, Lambda func)
     constexpr int numChannels = qMin(3, Format::Channels); // skip alpha channel (use per-pixel mode for that)
 
     for (int row = range.begin; row < range.end; ++row) {
-        auto *rowPtr = mat.ptr<ChannelType>(row);
+        auto *rowPtr = mat.template ptr<ChannelType>(row);
         auto *const endPtr = rowPtr + channelsPerRow;
         for (; rowPtr < endPtr; rowPtr += Format::Channels) {
             for (int channel = 0; channel < numChannels; ++channel) {
@@ -533,8 +533,8 @@ static void forEachChannel(cv::Mat &mat, const DkWorkRange &range, Lambda func)
 }
 
 // helper for per-pixel processing
-template<typename Format, typename Lambda>
-static void forEachPixel(cv::Mat &mat, const DkWorkRange &range, Lambda func)
+template<typename Format, typename CvMat, typename Lambda>
+static void forEachPixel(CvMat &mat, const DkWorkRange &range, Lambda func)
 {
     Q_ASSERT(Format::isCompatibleWith(mat));
     Q_ASSERT(range.isWithin(0, mat.rows));
@@ -543,7 +543,7 @@ static void forEachPixel(cv::Mat &mat, const DkWorkRange &range, Lambda func)
     const int channelsPerRow = mat.cols * Format::Channels;
 
     for (int row = range.begin; row < range.end; ++row) {
-        auto *rowPtr = mat.ptr<ChannelType>(row);
+        auto *rowPtr = mat.template ptr<ChannelType>(row);
         auto *const endPtr = rowPtr + channelsPerRow;
         for (; rowPtr < endPtr; rowPtr += Format::Channels) {
             func(rowPtr);

--- a/ImageLounge/src/DkCore/DkImageStorage.cpp
+++ b/ImageLounge/src/DkCore/DkImageStorage.cpp
@@ -868,7 +868,7 @@ static auto histogram(const cv::Mat &mat, const DkWorkRange &range)
     auto mn = h.globalMin();
     auto mx = h.globalMax();
 
-    if (mx - mn == 0) {
+    if (mx - mn <= 0) {
         return h;
     }
 
@@ -882,6 +882,9 @@ static auto histogram(const cv::Mat &mat, const DkWorkRange &range)
         for (int channel = 0; channel < numChannels; ++channel) {
             ChannelType norm = (pixel[channel] - mn) / (mx - mn);
             int bucket = norm * 255 / Format::Scale;
+            if constexpr (isFloat) {
+                bucket = qBound(0, bucket, 255);
+            }
             Q_ASSERT(bucket >= 0 && bucket <= 255);
             h.bins[channel][bucket]++;
         }

--- a/ImageLounge/src/DkCore/DkImageStorage.cpp
+++ b/ImageLounge/src/DkCore/DkImageStorage.cpp
@@ -692,14 +692,16 @@ QImage DkImage::grayscaleImage(const QImage &src)
 // if input has one channel (channel 2,3 are set to default values)
 template<typename T>
 struct Histogram {
-    std::array<std::array<uint32_t, 256>, 3> bins;
-    std::array<T, 3> min, max;
+    std::array<std::array<uint32_t, kNumBins>, kNumChannels> bins;
+    std::array<T, kNumChannels> min, max;
+    int numPixels, numBlack, numWhite; // pixel counts
 
     Histogram()
     {
         bins.fill({});
         min.fill(std::numeric_limits<T>::max());
         max.fill(std::numeric_limits<T>::min());
+        numPixels = numBlack = numWhite = 0;
     }
 
     void add(const Histogram<T> &h)
@@ -714,13 +716,18 @@ struct Histogram {
         for (unsigned i = 0; i < h.bins.size(); ++i) {
             max[i] = std::max(max[i], h.max[i]);
         }
+        numPixels += h.numPixels;
+        numBlack += h.numBlack;
+        numWhite += h.numWhite;
     }
 
+    // minimum sample
     T globalMin() const
     {
         return std::min({min[0], min[1], min[2]});
     }
 
+    // maximum sample
     T globalMax() const
     {
         return std::max({max[0], max[1], max[2]});
@@ -758,23 +765,55 @@ struct Histogram {
 
 // channel 0 may be blue or red; the caller must swap values if needed
 template<typename Format>
-static auto histogram(cv::Mat &mat, const DkWorkRange &range)
+static auto histogram(const cv::Mat &mat, const DkWorkRange &range)
 {
     using ChannelType = typename Format::ChannelType;
 
     static constexpr bool isFloat = std::is_floating_point_v<ChannelType>;
     static_assert(isFloat || std::numeric_limits<ChannelType>::max() == Format::Scale);
 
+    static constexpr int numChannels = qMin(3, Format::Channels);
+
     Histogram<ChannelType> h;
 
-    forEachChannel<Format>(mat, range, [&](const ChannelType &value, int channel) {
-        h.min[channel] = std::min(value, h.min[channel]);
-        h.max[channel] = std::max(value, h.max[channel]);
-        if constexpr (!isFloat) { // float images often go beyond [0,1]
-            int bucket = value * 255 / Format::Scale;
-            Q_ASSERT(unsigned(channel) < h.bins.size());
-            Q_ASSERT(bucket >= 0 && unsigned(bucket) < h.bins[channel].size());
-            h.bins[channel][bucket]++;
+    forEachPixel<Format>(mat, range, [&](const ChannelType *pixel) {
+        if constexpr (Format::Channels == 4) {
+            if (pixel[3] == 0) { // don't count transparent pixels
+                return;
+            }
+        }
+
+        for (int channel = 0; channel < numChannels; ++channel) {
+            ChannelType value = pixel[channel];
+
+            h.min[channel] = std::min(value, h.min[channel]);
+            h.max[channel] = std::max(value, h.max[channel]);
+
+            if constexpr (!isFloat) { // float images often go beyond [0,1]
+                int bucket = value * 255 / Format::Scale;
+                Q_ASSERT(unsigned(channel) < h.bins.size());
+                Q_ASSERT(bucket >= 0 && unsigned(bucket) < h.bins[channel].size());
+                h.bins[channel][bucket]++;
+            }
+        }
+
+        h.numPixels++;
+
+        if constexpr (numChannels == 1) {
+            if (pixel[0] == 0) {
+                h.numBlack++;
+            } else if (pixel[0] == Format::Scale) {
+                h.numWhite++;
+            }
+        }
+
+        if constexpr (numChannels == 3) {
+            // the <= because HDR can be beyond [0,1]
+            if (pixel[0] <= 0 && pixel[1] <= 0 && pixel[2] <= 0) {
+                h.numBlack++;
+            } else if (pixel[0] >= Format::Scale && pixel[1] >= Format::Scale && pixel[2] >= Format::Scale) {
+                h.numWhite++;
+            }
         }
     });
 
@@ -784,25 +823,33 @@ static auto histogram(cv::Mat &mat, const DkWorkRange &range)
 
     // float types can exceed [0,1], normalize them before counting
     // TODO: for HDR we need more buckets on the ends, with log scaling probably
-    auto mn = std::min({h.min[0], h.min[1], h.min[2]});
-    auto mx = std::max({h.max[0], h.max[1], h.max[2]});
+    auto mn = h.globalMin();
+    auto mx = h.globalMax();
 
     if (mx - mn == 0) {
         return h;
     }
 
-    forEachChannel<Format>(mat, range, [&](const ChannelType &value, int channel) {
-        ChannelType norm = (value - mn) / (mx - mn);
-        int bucket = norm * 255 / Format::Scale;
-        Q_ASSERT(bucket >= 0 && bucket <= 255);
-        h.bins[channel][bucket]++;
+    forEachPixel<Format>(mat, range, [&](const ChannelType *pixel) {
+        if constexpr (Format::Channels == 4) {
+            if (pixel[3] == 0) {
+                return;
+            }
+        }
+
+        for (int channel = 0; channel < numChannels; ++channel) {
+            ChannelType norm = (pixel[channel] - mn) / (mx - mn);
+            int bucket = norm * 255 / Format::Scale;
+            Q_ASSERT(bucket >= 0 && bucket <= 255);
+            h.bins[channel][bucket]++;
+        }
     });
 
     return h;
 }
 
 template<typename Format>
-static auto histogramThreaded(cv::Mat &mat)
+static auto histogramThreaded(const cv::Mat &mat)
 {
     using HistType = Histogram<typename Format::ChannelType>;
 

--- a/ImageLounge/src/DkCore/DkImageStorage.cpp
+++ b/ImageLounge/src/DkCore/DkImageStorage.cpp
@@ -2462,7 +2462,7 @@ protected:
         const float dpr = img.devicePixelRatio();
         const int imgHeight = img.height();
 
-        const float margin = 5;
+        const float margin = 4; // even number required
         const int statsHeight = 0.25 * imgHeight / dpr;
         const int histHeight = showStats ? imgHeight / dpr - statsHeight : imgHeight / dpr - margin / 2;
 
@@ -2522,7 +2522,7 @@ protected:
 
             static constexpr QStringView styleSheet =
                 uR"(table,dt,dr { border-collapse: collapse; }
-                    td { font-size: %1px; margin:0px; padding:0px; font-family:"%2"; color:"%3"; })";
+                    td { margin:%1px; padding:0px; font-size: %2px; font-family:"%3"; color:"%4"; })";
 
             static constexpr QStringView html =
                 uR"(<table width="100%">
@@ -2554,7 +2554,11 @@ protected:
             QString systemMono = QFontDatabase::systemFont(QFontDatabase::FixedFont).family();
             QString fontColor = DkSettingsManager::param().display().hudFgdColor.name(QColor::HexArgb);
 
-            QString style = styleSheet.toString().arg(13).arg(systemMono).arg(fontColor);
+            QString style = styleSheet.toString()
+                                .arg(static_cast<int>(margin / 2.0)) // <table> margin
+                                .arg(13) // font pixel size
+                                .arg(systemMono)
+                                .arg(fontColor);
             doc.setDefaultStyleSheet(style);
 
             doc.setHtml(text);

--- a/ImageLounge/src/DkCore/DkImageStorage.cpp
+++ b/ImageLounge/src/DkCore/DkImageStorage.cpp
@@ -692,6 +692,8 @@ QImage DkImage::grayscaleImage(const QImage &src)
 // if input has one channel (channel 2,3 are set to default values)
 template<typename T>
 struct Histogram {
+    static constexpr int kNumChannels = 3;
+    static constexpr int kNumBins = 256;
     std::array<std::array<uint32_t, kNumBins>, kNumChannels> bins;
     std::array<T, kNumChannels> min, max;
     int numPixels, numBlack, numWhite; // pixel counts
@@ -758,6 +760,44 @@ struct Histogram {
         }
         Q_UNREACHABLE();
         return numBins - 1;
+    }
+
+    // empty bins coincident across channels == missing brightness level
+    int numEmptyLevels() const
+    {
+        int empty = 0;
+        for (int bin = 0; bin < kNumBins; ++bin) {
+            int sum = 0;
+            for (int channel = 0; channel < kNumChannels; ++channel) {
+                sum += bins[channel][bin];
+            }
+            if (sum == 0) {
+                empty++;
+            }
+        }
+        return empty;
+    }
+
+    // bin with the most samples
+    int maxBin(int channel) const
+    {
+        Q_ASSERT(channel >= 0 && channel < kNumChannels);
+        const auto &ch = bins[channel];
+        auto maxIt = std::max_element(ch.begin(), ch.end());
+        return std::distance(ch.begin(), maxIt);
+    }
+
+    // count of max bin from all channels
+    int maxCount() const
+    {
+        int maxCount = 0;
+        for (int channel = 0; channel < kNumChannels; ++channel) {
+            int count = bins[channel][maxBin(channel)];
+            if (count > maxCount) {
+                maxCount = count;
+            }
+        }
+        return maxCount;
     }
 };
 

--- a/ImageLounge/src/DkCore/DkImageStorage.cpp
+++ b/ImageLounge/src/DkCore/DkImageStorage.cpp
@@ -2513,18 +2513,12 @@ protected:
         }
 
         if (showStats) {
-            int numSamples = h.numPixels; // total samples, transparent pixels are not counted
-            int empty = h.numEmptyLevels(); // black bands/gaps in the histogram (including wings)
+            double blackPct = h.numBlack * 100.0 / h.numPixels;
+            double whitePct = h.numWhite * 100.0 / h.numPixels;
+            double goodPct = (h.numPixels - h.numBlack - h.numWhite) * 100.0 / h.numPixels;
 
-            int numPixels = numSamples / numChannels;
-            //  double megaPixels = numPixels * 10.0e-7;
-
-            double blackPct = h.numBlack * 100.0 / numPixels;
-            double whitePct = h.numWhite * 100.0 / numPixels;
-            double goodPct = (numSamples - h.numBlack - h.numWhite) * 100.0 / numSamples;
-
-            // relative number of brightness levels (bins with any non-zero channel value)
-            double levelPct = (numBins - empty) * 100.0 / numBins;
+            // percent of bins with zero sample count (across channels) == bands/gaps in histogram
+            double levelPct = (numBins - h.numEmptyLevels()) * 100.0 / numBins;
 
             static constexpr QStringView styleSheet =
                 uR"(table,dt,dr { border-collapse: collapse; }

--- a/ImageLounge/src/DkCore/DkImageStorage.cpp
+++ b/ImageLounge/src/DkCore/DkImageStorage.cpp
@@ -842,15 +842,15 @@ static auto histogram(const cv::Mat &mat, const DkWorkRange &range)
         h.numPixels++;
 
         if constexpr (numChannels == 1) {
-            if (pixel[0] == 0) {
+            // the <= because HDR can be beyond [0,1]
+            if (pixel[0] <= 0) {
                 h.numBlack++;
-            } else if (pixel[0] == Format::Scale) {
+            } else if (pixel[0] >= Format::Scale) {
                 h.numWhite++;
             }
         }
 
         if constexpr (numChannels == 3) {
-            // the <= because HDR can be beyond [0,1]
             if (pixel[0] <= 0 && pixel[1] <= 0 && pixel[2] <= 0) {
                 h.numBlack++;
             } else if (pixel[0] >= Format::Scale && pixel[1] >= Format::Scale && pixel[2] >= Format::Scale) {

--- a/ImageLounge/src/DkCore/DkImageStorage.cpp
+++ b/ImageLounge/src/DkCore/DkImageStorage.cpp
@@ -2463,19 +2463,84 @@ protected:
         const int imgHeight = img.height();
         const int imgWidth = img.width();
 
-        const float margin = 4; // even number required
-        const int statsHeight = 0.25 * imgHeight / dpr;
-        const int histHeight = showStats ? imgHeight / dpr - statsHeight : imgHeight / dpr - margin / 2;
-
-        const float y0 = histHeight; // bottom of bars
-        const float yScale = logScale ? float(histHeight) / std::log(static_cast<float>(maxCount)) * zoom
-                                      : float(histHeight) / maxCount * zoom;
-
         const int numChannels = qMin(3, imgChannels);
         const int numBins = h.kNumBins;
         const int numTicks = 4;
 
+        // the left/right/bottom margin is the offset to center bargraph horizontally
+        // there is no top margin so peak is easier to see
+        const float margin = (imgWidth / dpr - numBins) / 2.0;
+
         QPainter painter(&img);
+
+        int statsHeight = 0; // computed from text document
+        if (showStats) {
+            double blackPct = h.numBlack * 100.0 / h.numPixels;
+            double whitePct = h.numWhite * 100.0 / h.numPixels;
+            double goodPct = (h.numPixels - h.numBlack - h.numWhite) * 100.0 / h.numPixels;
+
+            // percent of bins with zero sample count (across channels) == bands/gaps in histogram
+            double levelPct = (numBins - h.numEmptyLevels()) * 100.0 / numBins;
+
+            static constexpr QStringView styleSheet =
+                uR"(table,td,tr { border-collapse: collapse; }
+                    table { margin:0px; padding:0px; }
+                    td { margin:1px; padding:0px; font-size: %1px; font-family:"%2"; color:"%3"; })";
+
+            QString html = QStringLiteral(
+                R"(<table width="100%">
+                <tr>
+                    <td>Min:</td> <td>%1</td>
+                    <td>Blk:</td> <td>%3%</td>
+                    <td>OK:</td>  <td>%5%</td>
+                </tr>
+                <tr>
+                    <td>Max:</td> <td>%2</td>
+                    <td>Wht:</td> <td>%4%</td>
+                    <td>Lvl:</td> <td>%6%</td>
+                </tr>
+                </table>)");
+
+            if constexpr (std::is_floating_point_v<ChannelType>) {
+                html = html.arg(h.globalMin(), 0, 'f', 2, ' ') //
+                           .arg(h.globalMax(), 0, 'f', 2, ' ');
+            } else {
+                html = html.arg(h.globalMin()) //
+                           .arg(h.globalMax());
+            }
+
+            html = html.arg(blackPct, 0, 'f', 2, ' ')
+                       .arg(whitePct, 0, 'f', 2, ' ')
+                       .arg(goodPct, 0, 'f', 1, ' ')
+                       .arg(levelPct, 0, 'f', 1, ' ');
+
+            QTextDocument doc;
+            doc.setTextWidth(img.width() / dpr);
+            doc.setDocumentMargin(0);
+
+            // monospace font to reduce jitter
+            QString systemMono = QFontDatabase::systemFont(QFontDatabase::FixedFont).family();
+            QString fontColor = DkSettingsManager::param().display().hudFgdColor.name(QColor::HexArgb);
+
+            QString style = styleSheet.toString()
+                                .arg(13) // font pixel size
+                                .arg(systemMono)
+                                .arg(fontColor);
+            doc.setDefaultStyleSheet(style);
+
+            doc.setHtml(html);
+            statsHeight = doc.size().height() + margin;
+
+            painter.save();
+            painter.translate(margin, imgHeight / dpr - statsHeight + margin / 2);
+            doc.drawContents(&painter);
+            painter.restore();
+        }
+
+        const int histHeight = showStats ? imgHeight / dpr - statsHeight : imgHeight / dpr - margin;
+        const float y0 = histHeight; // bottom of bars
+        const float yScale = logScale ? float(histHeight) / std::log(static_cast<float>(maxCount)) * zoom
+                                      : float(histHeight) / maxCount * zoom;
 
         QList<QLineF> tickMarks;
         tickMarks.reserve(numTicks);
@@ -2518,7 +2583,7 @@ protected:
 
             lines.clear();
             for (int bin = 0; bin < numBins; ++bin) {
-                float x0 = bin + margin;
+                float x0 = margin + bin;
                 int count = h.bins[channel][bin];
                 if (count == 0) {
                     continue;
@@ -2532,61 +2597,6 @@ protected:
                 lines.append(QLineF{x0, y0, x0, y1});
             }
             painter.drawLines(lines);
-        }
-
-        if (showStats) {
-            double blackPct = h.numBlack * 100.0 / h.numPixels;
-            double whitePct = h.numWhite * 100.0 / h.numPixels;
-            double goodPct = (h.numPixels - h.numBlack - h.numWhite) * 100.0 / h.numPixels;
-
-            // percent of bins with zero sample count (across channels) == bands/gaps in histogram
-            double levelPct = (numBins - h.numEmptyLevels()) * 100.0 / numBins;
-
-            static constexpr QStringView styleSheet =
-                uR"(table,dt,dr { border-collapse: collapse; }
-                    td { margin:%1px; padding:0px; font-size: %2px; font-family:"%3"; color:"%4"; })";
-
-            static constexpr QStringView html =
-                uR"(<table width="100%">
-                <tr>
-                    <td>Min:</td> <td>%1</td>
-                    <td>Blk:</td> <td>%3%</td>
-                    <td>OK:</td>  <td>%5%</td>
-                </tr>
-                <tr>
-                    <td>Max:</td> <td>%2</td>
-                    <td>Wht:</td> <td>%4%</td>
-                    <td>Lvl:</td> <td>%6%</td>
-                </tr>
-                </table>)";
-
-            QString text = html.toString()
-                               .arg(h.globalMin())
-                               .arg(h.globalMax())
-                               .arg(blackPct, 0, 'f', 2, ' ')
-                               .arg(whitePct, 0, 'f', 2, ' ')
-                               .arg(goodPct, 0, 'f', 1, ' ')
-                               .arg(levelPct, 0, 'f', 1, ' ');
-
-            QTextDocument doc;
-            doc.setTextWidth(img.width() / dpr);
-            doc.setDocumentMargin(0);
-
-            // monospace font to reduce jitter
-            QString systemMono = QFontDatabase::systemFont(QFontDatabase::FixedFont).family();
-            QString fontColor = DkSettingsManager::param().display().hudFgdColor.name(QColor::HexArgb);
-
-            QString style = styleSheet.toString()
-                                .arg(static_cast<int>(margin / 2.0)) // <table> margin
-                                .arg(13) // font pixel size
-                                .arg(systemMono)
-                                .arg(fontColor);
-            doc.setDefaultStyleSheet(style);
-
-            doc.setHtml(text);
-
-            painter.translate(margin, y0 + margin / 2.0);
-            doc.drawContents(&painter);
         }
 
         painter.end();

--- a/ImageLounge/src/DkCore/DkImageStorage.cpp
+++ b/ImageLounge/src/DkCore/DkImageStorage.cpp
@@ -2366,12 +2366,12 @@ public:
     ~DkHistogramKernel() override = default;
 
     DkHistogramKernel(const QImage &img)
-        : mImg(DkConstNativeImage::fromImage(img))
+        : mImg(DkNativeImage::fromConstImage(img))
     {
     }
 
 protected:
-    DkConstNativeImage mImg;
+    const DkNativeImage mImg;
     std::any mHistogram;
 
     template<typename Format>
@@ -2379,7 +2379,7 @@ protected:
     {
         Q_UNUSED(range)
         auto &self = *(std::any_cast<DkHistogramKernel *>(arg));
-        self.mHistogram = histogramThreaded<Format>(self.mImg.mat());
+        self.mHistogram = histogramThreaded<Format>(self.mImg.constMat());
         return true;
     }
 

--- a/ImageLounge/src/DkCore/DkImageStorage.cpp
+++ b/ImageLounge/src/DkCore/DkImageStorage.cpp
@@ -2461,6 +2461,7 @@ protected:
 
         const float dpr = img.devicePixelRatio();
         const int imgHeight = img.height();
+        const int imgWidth = img.width();
 
         const float margin = 4; // even number required
         const int statsHeight = 0.25 * imgHeight / dpr;
@@ -2472,8 +2473,29 @@ protected:
 
         const int numChannels = qMin(3, imgChannels);
         const int numBins = h.kNumBins;
+        const int numTicks = 4;
 
         QPainter painter(&img);
+
+        QList<QLineF> tickMarks;
+        tickMarks.reserve(numTicks);
+        for (int i = 0; i < numTicks; ++i) {
+            int count = (maxCount * (i + 1)) / (numTicks + 1);
+            float y1;
+            if (logScale) {
+                y1 = y0 - (std::log(static_cast<float>(count)) * yScale);
+            } else {
+                y1 = y0 - (count * yScale);
+            }
+            tickMarks.append(QLineF{1.0, y1, imgWidth - 1.0, y1});
+        }
+
+        QPen tickPen(DkSettingsManager::param().display().hudFgdColor);
+        tickPen.setWidthF(1.0 / dpr);
+        painter.setPen(tickPen);
+        painter.setOpacity(0.20);
+        painter.drawLines(tickMarks);
+        painter.setOpacity(1.0);
 
         if (imgType != ImgType::gray) {
             painter.setCompositionMode(QPainter::CompositionMode_Screen);

--- a/ImageLounge/src/DkCore/DkImageStorage.cpp
+++ b/ImageLounge/src/DkCore/DkImageStorage.cpp
@@ -2417,11 +2417,12 @@ public:
     DkHistogramRender() = delete;
     ~DkHistogramRender() override = default;
 
-    DkHistogramRender(const DkHistogramEngine &hist, QImage &img, float zoom, bool showStats)
+    DkHistogramRender(const DkHistogramEngine &hist, QImage &img, float zoom, bool showStats, bool logScale)
         : mHist(hist)
         , mImg(img)
         , mZoom(zoom)
         , mShowStats(showStats)
+        , mLogScale(logScale)
     {
     }
 
@@ -2430,6 +2431,7 @@ protected:
     QImage &mImg;
     const float mZoom;
     const bool mShowStats;
+    const bool mLogScale;
 
     // use R,G,B colors that are easier on the eyes and also
     // produce better C,M,Y colors with good contrast
@@ -2449,10 +2451,13 @@ protected:
             return false; // possible; all pixels could be fully transparent
         }
 
-        QImage &img = self.mImg;
+        const int maxCount = h.maxCount();
+        Q_ASSERT(maxCount > 0); // must be true if numPixels > 0
 
+        QImage &img = self.mImg;
         const bool showStats = self.mShowStats;
         const float zoom = self.mZoom;
+        const bool logScale = self.mLogScale;
 
         const float dpr = img.devicePixelRatio();
         const int imgHeight = img.height();
@@ -2462,7 +2467,8 @@ protected:
         const int histHeight = showStats ? imgHeight / dpr - statsHeight : imgHeight / dpr - margin / 2;
 
         const float y0 = histHeight; // bottom of bars
-        const float yScale = float(histHeight) / h.maxCount() * zoom;
+        const float yScale = logScale ? float(histHeight) / std::log(static_cast<float>(maxCount)) * zoom
+                                      : float(histHeight) / maxCount * zoom;
 
         const int numChannels = qMin(3, imgChannels);
         const int numBins = h.kNumBins;
@@ -2495,7 +2501,12 @@ protected:
                 if (count == 0) {
                     continue;
                 }
-                float y1 = y0 - (count * yScale);
+                float y1;
+                if (logScale) {
+                    y1 = y0 - (std::log(static_cast<float>(count)) * yScale);
+                } else {
+                    y1 = y0 - (count * yScale);
+                }
                 lines.append(QLineF{x0, y0, x0, y1});
             }
             painter.drawLines(lines);
@@ -2607,12 +2618,12 @@ bool DkHistogramEngine::compute(const QImage &image)
     return false;
 }
 
-void nmc::DkHistogramEngine::render(QImage &img, float zoom, bool showStats)
+void nmc::DkHistogramEngine::render(QImage &img, float zoom, bool showStats, bool logScale) const
 {
 #ifdef WITH_OPENCV
     Q_ASSERT(mData.has_value());
 
-    DkHistogramRender kernel{*this, img, zoom, showStats};
+    DkHistogramRender kernel{*this, img, zoom, showStats, logScale};
     (void)kernel.run();
 #endif
 }

--- a/ImageLounge/src/DkCore/DkImageStorage.cpp
+++ b/ImageLounge/src/DkCore/DkImageStorage.cpp
@@ -37,11 +37,13 @@
 
 #include <QColorSpace>
 #include <QFloat16>
+#include <QFontDatabase>
 #include <QIconEngine>
 #include <QPainter>
 #include <QPixmap>
 #include <QPixmapCache>
 #include <QSvgRenderer>
+#include <QTextDocument>
 #include <QtConcurrentMap>
 #include <QtConcurrentRun>
 #include <qmath.h>
@@ -2351,6 +2353,268 @@ void DkImage::unpremultiply(QImage &img)
     });
 
     img.reinterpretAsFormat(newFormat);
+}
+
+#ifdef WITH_OPENCV
+
+class DkHistogramKernel : public DkKernelBase
+{
+    friend class DkKernelBase;
+
+public:
+    DkHistogramKernel() = delete;
+    ~DkHistogramKernel() override = default;
+
+    DkHistogramKernel(const QImage &img)
+        : mImg(DkConstNativeImage::fromImage(img))
+    {
+    }
+
+protected:
+    DkConstNativeImage mImg;
+    std::any mHistogram;
+
+    template<typename Format>
+    static bool kernel(const std::any &arg, const DkWorkRange &range)
+    {
+        Q_UNUSED(range)
+        auto &self = *(std::any_cast<DkHistogramKernel *>(arg));
+        self.mHistogram = histogramThreaded<Format>(self.mImg.mat());
+        return true;
+    }
+
+    static constexpr int kCaps = cap_gray | cap_rgb_invariant | cap_serial;
+    static constexpr FmtList kFmts = listForKernelCaps(kCaps);
+    static constexpr DispatchTable kTable = makeTable<DkHistogramKernel>(kFmts);
+
+public:
+    bool run() override
+    {
+        return dispatch(kTable, kCaps, mImg.img().format(), this, {0, mImg.img().height()});
+    }
+
+    QImage result() const override
+    {
+        return {};
+    }
+
+    std::any histogram() const
+    {
+        return mHistogram;
+    }
+
+    QImage::Format nativeFormat() const // format after native image conversion
+    {
+        return mImg.img().format();
+    }
+};
+
+class DkHistogramRender : public DkKernelBase
+{
+    friend class DkKernelBase;
+
+public:
+    DkHistogramRender() = delete;
+    ~DkHistogramRender() override = default;
+
+    DkHistogramRender(const DkHistogramEngine &hist, QImage &img, float zoom, bool showStats)
+        : mHist(hist)
+        , mImg(img)
+        , mZoom(zoom)
+        , mShowStats(showStats)
+    {
+    }
+
+protected:
+    const DkHistogramEngine &mHist;
+    QImage &mImg;
+    const float mZoom;
+    const bool mShowStats;
+
+    // use R,G,B colors that are easier on the eyes and also
+    // produce better C,M,Y colors with good contrast
+    static constexpr std::array<QRgb, 3> kChannelColors = {
+        qRgb(255, 82, 82), // red softened for dark mode
+        qRgb(102, 187, 106), // emerald/light green
+        qRgb(122, 139, 255) // purple-ish blue
+    };
+
+    static constexpr std::array<int, 3> kBgrOrder{2, 1, 0};
+
+    template<typename ChannelType>
+    static bool render(DkHistogramRender &self, ImgType imgType, int imgChannels)
+    {
+        const Histogram<ChannelType> &h = std::any_cast<Histogram<ChannelType>>(self.mHist.mData);
+        if (h.numPixels <= 0) {
+            return false; // possible; all pixels could be fully transparent
+        }
+
+        QImage &img = self.mImg;
+
+        const bool showStats = self.mShowStats;
+        const float zoom = self.mZoom;
+
+        const float dpr = img.devicePixelRatio();
+        const int imgHeight = img.height();
+
+        const float margin = 5;
+        const int statsHeight = 0.25 * imgHeight / dpr;
+        const int histHeight = showStats ? imgHeight / dpr - statsHeight : imgHeight / dpr - margin / 2;
+
+        const float y0 = histHeight; // bottom of bars
+        const float yScale = float(histHeight) / h.maxCount() * zoom;
+
+        const int numChannels = qMin(3, imgChannels);
+        const int numBins = h.kNumBins;
+
+        QPainter painter(&img);
+
+        if (imgType != ImgType::gray) {
+            painter.setCompositionMode(QPainter::CompositionMode_Screen);
+        }
+
+        QList<QLineF> lines;
+        lines.reserve(numBins);
+
+        for (int i = 0; i < numChannels; ++i) {
+            int channel = i;
+            if (imgType == ImgType::bgr) { // swap rgb=>bgr
+                channel = kBgrOrder[channel];
+            }
+
+            if (imgType == ImgType::gray) {
+                painter.setPen(qRgb(240, 240, 240));
+            } else {
+                painter.setPen(kChannelColors[i]);
+            }
+
+            lines.clear();
+            for (int bin = 0; bin < numBins; ++bin) {
+                float x0 = bin + margin;
+                int count = h.bins[channel][bin];
+                if (count == 0) {
+                    continue;
+                }
+                float y1 = y0 - (count * yScale);
+                lines.append(QLineF{x0, y0, x0, y1});
+            }
+            painter.drawLines(lines);
+        }
+
+        if (showStats) {
+            int numSamples = h.numPixels; // total samples, transparent pixels are not counted
+            int empty = h.numEmptyLevels(); // black bands/gaps in the histogram (including wings)
+
+            int numPixels = numSamples / numChannels;
+            //  double megaPixels = numPixels * 10.0e-7;
+
+            double blackPct = h.numBlack * 100.0 / numPixels;
+            double whitePct = h.numWhite * 100.0 / numPixels;
+            double goodPct = (numSamples - h.numBlack - h.numWhite) * 100.0 / numSamples;
+
+            // relative number of brightness levels (bins with any non-zero channel value)
+            double levelPct = (numBins - empty) * 100.0 / numBins;
+
+            static constexpr QStringView styleSheet =
+                uR"(table,dt,dr { border-collapse: collapse; }
+                    td { font-size: %1px; margin:0px; padding:0px; font-family:"%2"; color:"%3"; })";
+
+            static constexpr QStringView html =
+                uR"(<table width="100%">
+                <tr>
+                    <td>Min:</td> <td>%1</td>
+                    <td>Blk:</td> <td>%3%</td>
+                    <td>OK:</td>  <td>%5%</td>
+                </tr>
+                <tr>
+                    <td>Max:</td> <td>%2</td>
+                    <td>Wht:</td> <td>%4%</td>
+                    <td>Lvl:</td> <td>%6%</td>
+                </tr>
+                </table>)";
+
+            QString text = html.toString()
+                               .arg(h.globalMin())
+                               .arg(h.globalMax())
+                               .arg(blackPct, 0, 'f', 2, ' ')
+                               .arg(whitePct, 0, 'f', 2, ' ')
+                               .arg(goodPct, 0, 'f', 1, ' ')
+                               .arg(levelPct, 0, 'f', 1, ' ');
+
+            QTextDocument doc;
+            doc.setTextWidth(img.width() / dpr);
+            doc.setDocumentMargin(0);
+
+            // monospace font to reduce jitter
+            QString systemMono = QFontDatabase::systemFont(QFontDatabase::FixedFont).family();
+            QString fontColor = DkSettingsManager::param().display().hudFgdColor.name(QColor::HexArgb);
+
+            QString style = styleSheet.toString().arg(13).arg(systemMono).arg(fontColor);
+            doc.setDefaultStyleSheet(style);
+
+            doc.setHtml(text);
+
+            painter.translate(margin, y0 + margin / 2.0);
+            doc.drawContents(&painter);
+        }
+
+        painter.end();
+
+        return true;
+    }
+
+    template<typename Format>
+    static bool kernel(const std::any &arg, const DkWorkRange &range)
+    {
+        Q_UNUSED(range)
+        using ChannelType = typename Format::ChannelType;
+
+        auto &self = *(std::any_cast<DkHistogramRender *>(arg));
+        return render<ChannelType>(self, Format::Type, Format::Channels);
+    }
+
+    static constexpr int kCaps = cap_gray | cap_rgb_invariant | cap_serial;
+    static constexpr FmtList kFmts = listForKernelCaps(kCaps);
+    static constexpr DispatchTable kTable = makeTable<DkHistogramRender>(kFmts);
+
+public:
+    bool run() override
+    {
+        return dispatch(kTable, kCaps, mHist.mFormat, this, {});
+    }
+
+    QImage result() const override
+    {
+        return {}; // unused
+    }
+};
+
+#endif // WITH_OPENCV
+
+bool DkHistogramEngine::compute(const QImage &image)
+{
+#ifdef WITH_OPENCV
+    mFormat = {};
+    mData.reset();
+
+    DkHistogramKernel kernel{image};
+    if (kernel.run()) {
+        mFormat = kernel.nativeFormat();
+        mData = kernel.histogram();
+        return true;
+    }
+#endif
+    return false;
+}
+
+void nmc::DkHistogramEngine::render(QImage &img, float zoom, bool showStats)
+{
+#ifdef WITH_OPENCV
+    Q_ASSERT(mData.has_value());
+
+    DkHistogramRender kernel{*this, img, zoom, showStats};
+    (void)kernel.run();
+#endif
 }
 
 // DkImageStorage --------------------------------------------------------------------

--- a/ImageLounge/src/DkCore/DkImageStorage.h
+++ b/ImageLounge/src/DkCore/DkImageStorage.h
@@ -179,7 +179,7 @@ struct DkHistogramEngine {
     bool compute(const QImage &image);
 
     // draw histogram bargraph and stats text
-    void render(QImage &img, float zoom, bool showStats);
+    void render(QImage &img, float zoom, bool showStats, bool logScale) const;
 };
 
 class DllCoreExport DkImageStorage : public QObject

--- a/ImageLounge/src/DkCore/DkImageStorage.h
+++ b/ImageLounge/src/DkCore/DkImageStorage.h
@@ -32,6 +32,7 @@
 #include <QFutureWatcher>
 #include <QImage>
 #include <QObject>
+#include <any>
 
 #ifdef WITH_OPENCV
 #include "opencv2/core/core.hpp"
@@ -165,6 +166,20 @@ public:
      */
     static QImage convertToColorSpaceInPlace(const QWidget *target, QImage &img);
     static QImage convertToColorSpaceInPlace(const QColorSpace &target, QImage &img);
+};
+
+/**
+ * @brief High-level histogram interface
+ */
+struct DkHistogramEngine {
+    QImage::Format mFormat; // pixel format used in compute() - may differ from image input
+    std::any mData; // format-specific histogram
+
+    // count pixels and collect stats
+    bool compute(const QImage &image);
+
+    // draw histogram bargraph and stats text
+    void render(QImage &img, float zoom, bool showStats);
 };
 
 class DllCoreExport DkImageStorage : public QObject

--- a/ImageLounge/src/DkCore/DkImageStorage.h
+++ b/ImageLounge/src/DkCore/DkImageStorage.h
@@ -171,10 +171,14 @@ public:
 /**
  * @brief High-level histogram interface
  */
-struct DkHistogramEngine {
+class DkHistogramEngine
+{
+    friend class DkHistogramRender;
+
     QImage::Format mFormat; // pixel format used in compute() - may differ from image input
     std::any mData; // format-specific histogram
 
+public:
     // count pixels and collect stats
     bool compute(const QImage &image);
 

--- a/ImageLounge/src/DkCore/DkSettings.cpp
+++ b/ImageLounge/src/DkCore/DkSettings.cpp
@@ -482,6 +482,7 @@ void DkSettings::load(QSettings &settings, bool defaults)
                                             .toBool();
     display_p.showCrop = settings.value("showCrop", display_p.showCrop).toBool();
     display_p.histogramStyle = settings.value("histogramStyle", display_p.histogramStyle).toInt();
+    display_p.histogramScale = settings.value("histogramScale", display_p.histogramScale).toInt();
     display_p.tpPattern = settings.value("tpPattern", display_p.tpPattern).toBool();
     display_p.showNavigation = settings.value("showNavigation", display_p.showNavigation).toBool();
     display_p.themeName = settings.value("themeName312", display_p.themeName).toString();
@@ -748,6 +749,8 @@ void DkSettings::save(QSettings &settings, bool force)
         settings.setValue("showCrop", display_p.showCrop);
     if (force || display_p.histogramStyle != display_d.histogramStyle)
         settings.setValue("histogramStyle", display_p.histogramStyle);
+    if (force || display_p.histogramScale != display_d.histogramScale)
+        settings.setValue("histogramScale", display_p.histogramScale);
     if (force || display_p.tpPattern != display_d.tpPattern)
         settings.setValue("tpPattern", display_p.tpPattern);
     if (force || display_p.showNavigation != display_d.showNavigation)
@@ -982,7 +985,8 @@ void DkSettings::setToDefaultSettings()
     display_p.antiAliasing = true;
     display_p.highQualityAntiAliasing = false;
     display_p.showCrop = false;
-    display_p.histogramStyle = 0; // DkHistogram::DisplayMode::histogram_mode_simple
+    display_p.histogramStyle = 0; // DkHistogramWidget::mode_simple
+    display_p.histogramScale = 0; // DkHistogramWidget::scale_linear
     display_p.tpPattern = false;
     display_p.showNavigation = true;
     display_p.themeName = "Light-Theme.css";

--- a/ImageLounge/src/DkCore/DkSettings.h
+++ b/ImageLounge/src/DkCore/DkSettings.h
@@ -252,6 +252,7 @@ public:
         float animationDuration;
 
         int histogramStyle;
+        int histogramScale;
         bool animateWidgets; // animate hide/show of widgets/panels/etc
 
         int targetColorSpace; // -1==auto, 0==disable, 1-49==NamedColorSpace, 50-99==custom, 100-999==user icc profile

--- a/ImageLounge/src/DkGui/DkControlWidget.cpp
+++ b/ImageLounge/src/DkGui/DkControlWidget.cpp
@@ -88,7 +88,7 @@ DkControlWidget::DkControlWidget(DkThumbLoader *thumbLoader, DkViewPort *parent,
     mWheelButton->hide();
 
     // image histogram
-    mHistogram = new DkHistogram(this);
+    mHistogram = new DkHistogramWidget(this);
 
     init();
     connectWidgets();
@@ -823,7 +823,7 @@ DkFileInfoLabel *DkControlWidget::getFileInfoLabel() const
     return mFileInfoLabel;
 }
 
-DkHistogram *DkControlWidget::getHistogram() const
+DkHistogramWidget *DkControlWidget::getHistogram() const
 {
     return mHistogram;
 }

--- a/ImageLounge/src/DkGui/DkControlWidget.h
+++ b/ImageLounge/src/DkGui/DkControlWidget.h
@@ -48,7 +48,7 @@ class DkPlayer;
 class DkFolderScrollBar;
 class DkDelayedMessage;
 class DkFileInfoLabel;
-class DkHistogram;
+class DkHistogramWidget;
 class DkLabelBg;
 class DkPluginViewPort;
 class DkOverview;
@@ -110,7 +110,7 @@ public:
     DkZoomWidget *getZoomWidget() const;
     DkPlayer *getPlayer() const;
     DkFileInfoLabel *getFileInfoLabel() const;
-    DkHistogram *getHistogram() const;
+    DkHistogramWidget *getHistogram() const;
     DkCropWidget *getCropWidget() const;
 
     void showWidgetsSettings();
@@ -186,7 +186,7 @@ protected:
     DkCommentWidget *mCommentWidget;
     DkZoomWidget *mZoomWidget;
     DkPlayer *mPlayer;
-    DkHistogram *mHistogram;
+    DkHistogramWidget *mHistogram;
 
     DkFolderScrollBar *mFolderScroll;
     DkFileInfoLabel *mFileInfoLabel;

--- a/ImageLounge/src/DkGui/DkWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkWidgets.cpp
@@ -2070,7 +2070,7 @@ void DkHistogram::paintEvent(QPaintEvent *)
     int binBottom = height() - margin - textHeight;
 
     // draw Histogram
-    if (mIsPainted && mMaxValue > 0) {
+    if (mIsValid && mMaxValue > 0) {
         for (int x = 0; x < 256; x++) {
             // get bounded values
             int rLineHeight = qMax(qMin(qRound((float)mHist[0][x] * binHeight * mScaleFactor / mMaxValue), binHeight),
@@ -2157,7 +2157,7 @@ void DkHistogram::loadSettings()
 void DkHistogram::drawHistogram(const QImage &imgQt)
 {
     if (!isVisible() || imgQt.isNull()) {
-        setPainted(false);
+        setValid(false);
         return;
     }
 
@@ -2262,7 +2262,7 @@ void DkHistogram::drawHistogram(const QImage &imgQt)
         }
     }
 
-    setPainted(true);
+    setValid(true);
     qDebug() << "drawing the histogram took me: " << dt;
     update();
 }
@@ -2272,19 +2272,19 @@ void DkHistogram::drawHistogram(const QImage &imgQt)
  **/
 void DkHistogram::clearHistogram()
 {
-    setPainted(false);
+    setValid(false);
     update();
 }
 
-void DkHistogram::setPainted(bool isPainted)
+void DkHistogram::setValid(bool isValid)
 {
-    this->mIsPainted = isPainted;
+    this->mIsValid = isValid;
 }
 
 void DkHistogram::setMaxHistogramValue(int maxValue)
 {
     if (maxValue == 0)
-        setPainted(false);
+        setValid(false);
 
     this->mMaxValue = maxValue;
 }

--- a/ImageLounge/src/DkGui/DkWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkWidgets.cpp
@@ -2038,7 +2038,12 @@ DkHistogramWidget::DkHistogramWidget(QWidget *parent)
     auto *showStats = new QAction(tr("Show Statistics"), this);
     showStats->setCheckable(true);
     showStats->setChecked(mDisplayMode == DisplayMode::mode_extended);
-    connect(showStats, &QAction::triggered, this, &DkHistogramWidget::onToggleStatsTriggered);
+    connect(showStats, &QAction::triggered, this, [&](bool checked) {
+        mDisplayMode = checked ? DisplayMode::mode_extended : DisplayMode::mode_simple;
+        DkSettingsManager::param().display().histogramStyle = static_cast<int>(mDisplayMode);
+        mIsDirty = true;
+        update();
+    });
 
     mContextMenu = new QMenu;
     mContextMenu->addAction(showStats);
@@ -2080,14 +2085,6 @@ void DkHistogramWidget::contextMenuEvent(QContextMenuEvent *event)
 
     // do not pass it on
     // DkFadeWidget::contextMenuEvent(event);
-}
-
-void DkHistogramWidget::onToggleStatsTriggered(bool show)
-{
-    mDisplayMode = (show) ? DisplayMode::mode_extended : DisplayMode::mode_simple;
-    DkSettingsManager::param().display().histogramStyle = (int)mDisplayMode;
-    mIsDirty = true;
-    update();
 }
 
 void DkHistogramWidget::loadSettings()

--- a/ImageLounge/src/DkGui/DkWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkWidgets.cpp
@@ -2040,7 +2040,7 @@ DkHistogram::DkHistogram(QWidget *parent)
     showStats->setChecked(mDisplayMode == DisplayMode::histogram_mode_extended);
     connect(showStats, &QAction::triggered, this, &DkHistogram::onToggleStatsTriggered);
 
-    mContextMenu = new QMenu(tr("Histogram Settings"));
+    mContextMenu = new QMenu;
     mContextMenu->addAction(showStats);
 }
 

--- a/ImageLounge/src/DkGui/DkWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkWidgets.cpp
@@ -2154,7 +2154,7 @@ void DkHistogram::loadSettings()
  * Goes through the image and counts pixels values. They are used to create the image histogram.
  * @param currently displayed image
  **/
-void DkHistogram::drawHistogram(QImage imgQt)
+void DkHistogram::drawHistogram(const QImage &imgQt)
 {
     if (!isVisible() || imgQt.isNull()) {
         setPainted(false);

--- a/ImageLounge/src/DkGui/DkWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkWidgets.cpp
@@ -2004,7 +2004,12 @@ void DkCropWidget::crop(bool cropToMetadata)
         QPolygonF poly = mat.map(mRect.getPoly());
         DkRotatingRect rect;
         rect.setPoly(poly);
-        emit cropImageSignal(rect, cropToolbar->getColor(), cropToMetadata);
+        // Viewport may not refresh panels that are currently hidden due
+        // to crop widget being active. Send after crop widget is hidden and
+        // presumably the viewport is shown.
+        QTimer::singleShot(0, [rect, cropToMetadata, this] {
+            emit cropImageSignal(rect, cropToolbar->getColor(), cropToMetadata);
+        });
     }
 
     setVisible(false);

--- a/ImageLounge/src/DkGui/DkWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkWidgets.cpp
@@ -2037,7 +2037,7 @@ DkHistogramWidget::DkHistogramWidget(QWidget *parent)
     // create context menu
     auto *showStats = new QAction(tr("Show Statistics"), this);
     showStats->setCheckable(true);
-    showStats->setChecked(mDisplayMode == DisplayMode::histogram_mode_extended);
+    showStats->setChecked(mDisplayMode == DisplayMode::mode_extended);
     connect(showStats, &QAction::triggered, this, &DkHistogramWidget::onToggleStatsTriggered);
 
     mContextMenu = new QMenu;
@@ -2065,7 +2065,7 @@ void DkHistogramWidget::paintEvent(QPaintEvent *)
 
         if (mIsDirty) {
             mHistImage.fill(Qt::transparent);
-            mHistogram->render(mHistImage, mScaleFactor, mDisplayMode == DisplayMode::histogram_mode_extended);
+            mHistogram->render(mHistImage, mScaleFactor, mDisplayMode == DisplayMode::mode_extended);
             mIsDirty = false;
         }
 
@@ -2084,7 +2084,7 @@ void DkHistogramWidget::contextMenuEvent(QContextMenuEvent *event)
 
 void DkHistogramWidget::onToggleStatsTriggered(bool show)
 {
-    mDisplayMode = (show) ? DisplayMode::histogram_mode_extended : DisplayMode::histogram_mode_simple;
+    mDisplayMode = (show) ? DisplayMode::mode_extended : DisplayMode::mode_simple;
     DkSettingsManager::param().display().histogramStyle = (int)mDisplayMode;
     mIsDirty = true;
     update();
@@ -2092,12 +2092,11 @@ void DkHistogramWidget::onToggleStatsTriggered(bool show)
 
 void DkHistogramWidget::loadSettings()
 {
-    int styleSetting = DkSettingsManager::param().display().histogramStyle;
-    auto maybeMode = static_cast<DisplayMode>(styleSetting);
-    if (maybeMode == DisplayMode::histogram_mode_simple || maybeMode == DisplayMode::histogram_mode_extended) {
-        mDisplayMode = maybeMode;
+    int mode = DkSettingsManager::param().display().histogramStyle;
+    if (mode >= 0 && mode < mode_end) {
+        mDisplayMode = static_cast<DisplayMode>(mode);
     } else {
-        mDisplayMode = DisplayMode::histogram_mode_simple;
+        mDisplayMode = mode_simple;
     }
 }
 

--- a/ImageLounge/src/DkGui/DkWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkWidgets.cpp
@@ -2043,7 +2043,7 @@ DkHistogramWidget::DkHistogramWidget(QWidget *parent)
     auto *showStats = new QAction(tr("Show Statistics"), this);
     showStats->setCheckable(true);
     showStats->setChecked(mDisplayMode == DisplayMode::mode_extended);
-    connect(showStats, &QAction::triggered, this, [&](bool checked) {
+    connect(showStats, &QAction::triggered, this, [this](bool checked) {
         mDisplayMode = checked ? DisplayMode::mode_extended : DisplayMode::mode_simple;
         DkSettingsManager::param().display().histogramStyle = static_cast<int>(mDisplayMode);
         mIsDirty = true;
@@ -2053,7 +2053,7 @@ DkHistogramWidget::DkHistogramWidget(QWidget *parent)
     auto *logScale = new QAction(tr("Log Scale"), this);
     logScale->setCheckable(true);
     logScale->setChecked(mLogScale);
-    connect(logScale, &QAction::triggered, this, [&](bool checked) {
+    connect(logScale, &QAction::triggered, this, [this](bool checked) {
         mLogScale = checked;
         mIsDirty = true;
         DkSettingsManager::param().display().histogramScale = mLogScale ? scale_log : scale_linear;

--- a/ImageLounge/src/DkGui/DkWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkWidgets.cpp
@@ -2025,7 +2025,7 @@ void DkCropWidget::setVisible(bool visible)
 }
 
 // Image histogram  -------------------------------------------------------------------
-DkHistogram::DkHistogram(QWidget *parent)
+DkHistogramWidget::DkHistogramWidget(QWidget *parent)
     : DkFadeWidget(parent)
 {
     setObjectName("DkHistogram");
@@ -2038,18 +2038,18 @@ DkHistogram::DkHistogram(QWidget *parent)
     auto *showStats = new QAction(tr("Show Statistics"), this);
     showStats->setCheckable(true);
     showStats->setChecked(mDisplayMode == DisplayMode::histogram_mode_extended);
-    connect(showStats, &QAction::triggered, this, &DkHistogram::onToggleStatsTriggered);
+    connect(showStats, &QAction::triggered, this, &DkHistogramWidget::onToggleStatsTriggered);
 
     mContextMenu = new QMenu;
     mContextMenu->addAction(showStats);
 }
 
-DkHistogram::~DkHistogram() = default;
+DkHistogramWidget::~DkHistogramWidget() = default;
 
 /**
  * Paints the image histogram
  **/
-void DkHistogram::paintEvent(QPaintEvent *)
+void DkHistogramWidget::paintEvent(QPaintEvent *)
 {
     QPainter painter(this);
     painter.fillRect(1, 1, width(), height(), DkSettingsManager::param().display().hudBgColor);
@@ -2123,7 +2123,7 @@ void DkHistogram::paintEvent(QPaintEvent *)
     }
 }
 
-void DkHistogram::contextMenuEvent(QContextMenuEvent *event)
+void DkHistogramWidget::contextMenuEvent(QContextMenuEvent *event)
 {
     mContextMenu->exec(event->globalPos());
     event->accept();
@@ -2132,14 +2132,14 @@ void DkHistogram::contextMenuEvent(QContextMenuEvent *event)
     // DkFadeWidget::contextMenuEvent(event);
 }
 
-void DkHistogram::onToggleStatsTriggered(bool show)
+void DkHistogramWidget::onToggleStatsTriggered(bool show)
 {
     mDisplayMode = (show) ? DisplayMode::histogram_mode_extended : DisplayMode::histogram_mode_simple;
     DkSettingsManager::param().display().histogramStyle = (int)mDisplayMode;
     update();
 }
 
-void DkHistogram::loadSettings()
+void DkHistogramWidget::loadSettings()
 {
     int styleSetting = DkSettingsManager::param().display().histogramStyle;
     auto maybeMode = static_cast<DisplayMode>(styleSetting);
@@ -2154,7 +2154,7 @@ void DkHistogram::loadSettings()
  * Goes through the image and counts pixels values. They are used to create the image histogram.
  * @param currently displayed image
  **/
-void DkHistogram::drawHistogram(const QImage &imgQt)
+void DkHistogramWidget::drawHistogram(const QImage &imgQt)
 {
     if (!isVisible() || imgQt.isNull()) {
         setValid(false);
@@ -2270,18 +2270,18 @@ void DkHistogram::drawHistogram(const QImage &imgQt)
 /**
  * Clears the histogram panel
  **/
-void DkHistogram::clearHistogram()
+void DkHistogramWidget::clearHistogram()
 {
     setValid(false);
     update();
 }
 
-void DkHistogram::setValid(bool isValid)
+void DkHistogramWidget::setValid(bool isValid)
 {
     this->mIsValid = isValid;
 }
 
-void DkHistogram::setMaxHistogramValue(int maxValue)
+void DkHistogramWidget::setMaxHistogramValue(int maxValue)
 {
     if (maxValue == 0)
         setValid(false);
@@ -2293,7 +2293,7 @@ void DkHistogram::setMaxHistogramValue(int maxValue)
  * Updates histogram values.
  * @param values to be copied
  **/
-void DkHistogram::updateHistogramValues(int histValues[][256])
+void DkHistogramWidget::updateHistogramValues(int histValues[][256])
 {
     for (int i = 0; i < 256; i++) {
         this->mHist[0][i] = histValues[0][i];
@@ -2305,14 +2305,14 @@ void DkHistogram::updateHistogramValues(int histValues[][256])
 /**
  * Mouse events for scaling the histogram - enlarge the histogram between the bottom axis and the cursor position
  **/
-void DkHistogram::mousePressEvent(QMouseEvent *event)
+void DkHistogramWidget::mousePressEvent(QMouseEvent *event)
 {
     // always propagate mouse events
     if (event->buttons() != Qt::LeftButton)
         DkFadeWidget::mousePressEvent(event);
 }
 
-void DkHistogram::mouseMoveEvent(QMouseEvent *event)
+void DkHistogramWidget::mouseMoveEvent(QMouseEvent *event)
 {
     if (event->buttons() == Qt::LeftButton) {
         float cp = (float)(height() - event->pos().y());
@@ -2325,7 +2325,7 @@ void DkHistogram::mouseMoveEvent(QMouseEvent *event)
         DkFadeWidget::mouseMoveEvent(event);
 }
 
-void DkHistogram::mouseReleaseEvent(QMouseEvent *event)
+void DkHistogramWidget::mouseReleaseEvent(QMouseEvent *event)
 {
     mScaleFactor = 1;
     update();

--- a/ImageLounge/src/DkGui/DkWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkWidgets.cpp
@@ -2045,8 +2045,18 @@ DkHistogramWidget::DkHistogramWidget(QWidget *parent)
         update();
     });
 
-    mContextMenu = new QMenu;
+    auto *logScale = new QAction(tr("Log Scale"), this);
+    logScale->setCheckable(true);
+    connect(logScale, &QAction::triggered, this, [&](bool checked) {
+        // DkSettingsManager::param().display().histogramLogScale=checked;
+        mLogScale = checked;
+        mIsDirty = true;
+        update();
+    });
+
+    mContextMenu = new QMenu(this);
     mContextMenu->addAction(showStats);
+    mContextMenu->addAction(logScale);
 }
 
 DkHistogramWidget::~DkHistogramWidget() = default;
@@ -2070,7 +2080,7 @@ void DkHistogramWidget::paintEvent(QPaintEvent *)
 
         if (mIsDirty) {
             mHistImage.fill(Qt::transparent);
-            mHistogram->render(mHistImage, mScaleFactor, mDisplayMode == DisplayMode::mode_extended);
+            mHistogram->render(mHistImage, mScaleFactor, mDisplayMode == DisplayMode::mode_extended, mLogScale);
             mIsDirty = false;
         }
 

--- a/ImageLounge/src/DkGui/DkWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkWidgets.cpp
@@ -2052,74 +2052,24 @@ DkHistogramWidget::~DkHistogramWidget() = default;
 void DkHistogramWidget::paintEvent(QPaintEvent *)
 {
     QPainter painter(this);
-    painter.fillRect(1, 1, width(), height(), DkSettingsManager::param().display().hudBgColor);
+    painter.fillRect(rect(), DkSettingsManager::param().display().hudBgColor);
 
-    int numTextLines;
-    if (mDisplayMode == DisplayMode::histogram_mode_simple) {
-        numTextLines = 0;
-    } else {
-        // histogram_mode_extended has 2 lines of text
-        numTextLines = 2;
-    }
+    if (mIsValid) {
+        const float dpr = devicePixelRatio();
+        QSize sz = size() * dpr;
 
-    const int margin = 5;
-    const int TEXT_SIZE = 12 + 1; // FIXME just guessed
-    const int textHeight = numTextLines * TEXT_SIZE + margin;
-
-    int binHeight = height() - margin * 2 - textHeight;
-    int binBottom = height() - margin - textHeight;
-
-    // draw Histogram
-    if (mIsValid && mMaxValue > 0) {
-        for (int x = 0; x < 256; x++) {
-            // get bounded values
-            int rLineHeight = qMax(qMin(qRound((float)mHist[0][x] * binHeight * mScaleFactor / mMaxValue), binHeight),
-                                   0);
-            int gLineHeight = qMax(qMin(qRound((float)mHist[1][x] * binHeight * mScaleFactor / mMaxValue), binHeight),
-                                   0);
-            int bLineHeight = qMax(qMin(qRound((float)mHist[2][x] * binHeight * mScaleFactor / mMaxValue), binHeight),
-                                   0);
-            int maxLineHeight = qMax(qMax(rLineHeight, gLineHeight), bLineHeight);
-
-            painter.setCompositionMode(QPainter::CompositionMode_Clear);
-            painter.setPen(Qt::black);
-            painter.drawLine(QPoint(x + margin, binBottom), QPoint(x + margin, binBottom - maxLineHeight));
-
-            painter.setCompositionMode(QPainter::CompositionMode_Screen);
-            painter.setPen(Qt::red);
-            painter.drawLine(QPoint(x + margin, binBottom), QPoint(x + margin, binBottom - rLineHeight));
-            painter.setPen(Qt::green);
-            painter.drawLine(QPoint(x + margin, binBottom), QPoint(x + margin, binBottom - gLineHeight));
-            painter.setPen(Qt::blue);
-            painter.drawLine(QPoint(x + margin, binBottom), QPoint(x + margin, binBottom - bLineHeight));
+        if (mHistImage.size() != sz) {
+            mHistImage = QImage(sz, DkImage::targetFormat());
+            mHistImage.setDevicePixelRatio(dpr);
         }
-    }
 
-    if (mDisplayMode == DisplayMode::histogram_mode_extended) {
-        // draw histogram text
-        double megaPixels = (double)mNumPixels * 10.0e-7;
-        painter.setPen(QColor(255, 255, 255, 200));
-
-        QString histText1("Pixels: %1\tMPix: %2");
-        painter.drawText(QPoint(margin, height() - 2 * TEXT_SIZE + margin),
-                         histText1.arg(mNumPixels, 10, 10).arg(megaPixels, 10, 'f', 2));
-
-        if (mMinBinValue < 256) {
-            // gray image statistics
-            QString histText2("Min: %1\tMax: %2\tValue Count: %3");
-            painter
-                .drawText(QPoint(margin, height() - 1 * TEXT_SIZE + margin),
-                          histText2.arg(mMinBinValue, 5, 10).arg(mMaxBinValue, 5, 10).arg(mNumDistinctValues, 5, 10));
-        } else {
-            // color image statistics
-            double blackPct = 100.0 * (double)mNumZeroPixels / (double)mNumPixels;
-            double whitePct = 100.0 * (double)mNumSaturatedPixels / (double)mNumPixels;
-            double goodPct = 100.0 * (double)(mNumPixels - mNumZeroPixels - mNumSaturatedPixels) / (double)mNumPixels;
-
-            QString histText2("Black:  %1\tGood: %3\tWhite: %2");
-            painter.drawText(QPoint(margin, height() - 1 * TEXT_SIZE + margin),
-                             histText2.arg(blackPct, 5, 'f', 1).arg(whitePct, 5, 'f', 1).arg(goodPct, 5, 'f', 1));
+        if (mIsDirty) {
+            mHistImage.fill(Qt::transparent);
+            mHistogram->render(mHistImage, mScaleFactor, mDisplayMode == DisplayMode::histogram_mode_extended);
+            mIsDirty = false;
         }
+
+        painter.drawImage(QPointF{}, mHistImage);
     }
 }
 
@@ -2136,6 +2086,7 @@ void DkHistogramWidget::onToggleStatsTriggered(bool show)
 {
     mDisplayMode = (show) ? DisplayMode::histogram_mode_extended : DisplayMode::histogram_mode_simple;
     DkSettingsManager::param().display().histogramStyle = (int)mDisplayMode;
+    mIsDirty = true;
     update();
 }
 
@@ -2160,110 +2111,11 @@ void DkHistogramWidget::drawHistogram(const QImage &imgQt)
         setValid(false);
         return;
     }
-
-    DkTimer dt;
-
-    // clear histogram values
-    mNumZeroPixels = 0;
-    mNumSaturatedPixels = 0;
-    mMaxBinValue = -1;
-    mMinBinValue = 256;
-    mMaxValue = 0;
-    mNumPixels = imgQt.width() * imgQt.height();
-
-    for (int idx = 0; idx < 256; idx++) {
-        mHist[0][idx] = 0;
-        mHist[1][idx] = 0;
-        mHist[2][idx] = 0;
+    if (!mHistogram) {
+        mHistogram = std::make_unique<DkHistogramEngine>();
     }
-
-    // count pixel- and total values, for
-    // 8 bit images
-    if (imgQt.depth() == 8) {
-        qDebug() << "8 bit histogram -------------------";
-
-        for (int rIdx = 0; rIdx < imgQt.height(); rIdx++) {
-            const unsigned char *pixel = imgQt.constScanLine(rIdx);
-
-            for (int cIdx = 0; cIdx < imgQt.width(); cIdx++, pixel++) {
-                mHist[0][*pixel]++;
-                mHist[1][*pixel]++;
-                mHist[2][*pixel]++;
-
-                if (*pixel == 255)
-                    mNumSaturatedPixels++;
-                if (*pixel < mMinBinValue)
-                    mMinBinValue = *pixel;
-                if (*pixel > mMaxBinValue)
-                    mMaxBinValue = *pixel;
-            }
-        }
-    }
-    // 24 bit images
-    else if (imgQt.depth() == 24) {
-        for (int rIdx = 0; rIdx < imgQt.height(); rIdx++) {
-            const unsigned char *pixel = imgQt.constScanLine(rIdx);
-            for (int cIdx = 0; cIdx < imgQt.width(); cIdx++) {
-                // If I understood the api correctly, the first bits are 0 if we have 24bpp & < 8 bits per channel
-                unsigned char pixR = *pixel;
-                mHist[0][*pixel]++;
-                pixel++;
-                unsigned char pixG = *pixel;
-                mHist[1][*pixel]++;
-                pixel++;
-                unsigned char pixB = *pixel;
-                mHist[2][*pixel]++;
-                pixel++;
-
-                if (pixR == 0 && pixG == 0 && pixB == 0) {
-                    mNumZeroPixels++;
-                } else if (pixR == 255 && pixG == 255 && pixB == 255) {
-                    mNumSaturatedPixels++;
-                }
-            }
-        }
-    }
-    // 32 bit images
-    else if (imgQt.depth() == 32) {
-        for (int rIdx = 0; rIdx < imgQt.height(); rIdx++) {
-            const QRgb *pixel = (QRgb *)(imgQt.constScanLine(rIdx));
-
-            for (int cIdx = 0; cIdx < imgQt.width(); cIdx++, pixel++) {
-                auto pixR = static_cast<size_t>(qRed(*pixel));
-                auto pixG = static_cast<size_t>(qGreen(*pixel));
-                auto pixB = static_cast<size_t>(qBlue(*pixel));
-
-                mHist[0][pixR]++;
-                mHist[1][pixG]++;
-                mHist[2][pixB]++;
-
-                if (pixR == 0 && pixG == 0 && pixB == 0) {
-                    mNumZeroPixels++;
-                } else if (pixR == 255 && pixG == 255 && pixB == 255) {
-                    mNumSaturatedPixels++;
-                }
-            }
-        }
-    }
-
-    // determine extreme values from the histogram
-    mNumDistinctValues = 0;
-
-    for (int idx = 0; idx < 256; idx++) {
-        if (mHist[0][idx] > mMaxValue)
-            mMaxValue = mHist[0][idx];
-        if (mHist[1][idx] > mMaxValue)
-            mMaxValue = mHist[1][idx];
-        if (mHist[2][idx] > mMaxValue)
-            mMaxValue = mHist[2][idx];
-
-        if (mHist[0][idx] || mHist[1][idx] || mHist[2][idx]) {
-            mNumDistinctValues++;
-        }
-    }
-
-    setValid(true);
-    qDebug() << "drawing the histogram took me: " << dt;
+    mIsDirty = mHistogram->compute(imgQt);
+    setValid(mIsDirty);
     update();
 }
 
@@ -2278,28 +2130,7 @@ void DkHistogramWidget::clearHistogram()
 
 void DkHistogramWidget::setValid(bool isValid)
 {
-    this->mIsValid = isValid;
-}
-
-void DkHistogramWidget::setMaxHistogramValue(int maxValue)
-{
-    if (maxValue == 0)
-        setValid(false);
-
-    this->mMaxValue = maxValue;
-}
-
-/**
- * Updates histogram values.
- * @param values to be copied
- **/
-void DkHistogramWidget::updateHistogramValues(int histValues[][256])
-{
-    for (int i = 0; i < 256; i++) {
-        this->mHist[0][i] = histValues[0][i];
-        this->mHist[1][i] = histValues[1][i];
-        this->mHist[2][i] = histValues[2][i];
-    }
+    mIsValid = isValid;
 }
 
 /**
@@ -2319,6 +2150,7 @@ void DkHistogramWidget::mouseMoveEvent(QMouseEvent *event)
 
         if (cp > 0) {
             mScaleFactor = height() / cp;
+            mIsDirty = true;
             update();
         }
     } else
@@ -2328,6 +2160,7 @@ void DkHistogramWidget::mouseMoveEvent(QMouseEvent *event)
 void DkHistogramWidget::mouseReleaseEvent(QMouseEvent *event)
 {
     mScaleFactor = 1;
+    mIsDirty = true;
     update();
 
     if (event->buttons() != Qt::LeftButton)

--- a/ImageLounge/src/DkGui/DkWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkWidgets.cpp
@@ -2052,10 +2052,11 @@ DkHistogramWidget::DkHistogramWidget(QWidget *parent)
 
     auto *logScale = new QAction(tr("Log Scale"), this);
     logScale->setCheckable(true);
+    logScale->setChecked(mLogScale);
     connect(logScale, &QAction::triggered, this, [&](bool checked) {
-        // DkSettingsManager::param().display().histogramLogScale=checked;
         mLogScale = checked;
         mIsDirty = true;
+        DkSettingsManager::param().display().histogramScale = mLogScale ? scale_log : scale_linear;
         update();
     });
 
@@ -2110,6 +2111,8 @@ void DkHistogramWidget::loadSettings()
     } else {
         mDisplayMode = mode_simple;
     }
+
+    mLogScale = DkSettingsManager::param().display().histogramScale == scale_log;
 }
 
 /**

--- a/ImageLounge/src/DkGui/DkWidgets.h
+++ b/ImageLounge/src/DkGui/DkWidgets.h
@@ -54,6 +54,7 @@ namespace nmc
 {
 class DkCropToolBar;
 class DkViewPort;
+class DkHistogramEngine;
 
 class DkButton : public QPushButton
 {
@@ -593,8 +594,6 @@ private slots:
     void onToggleStatsTriggered(bool show);
 
 private:
-    void setMaxHistogramValue(int maxValue);
-    void updateHistogramValues(int histValues[][256]);
     void setValid(bool isValid);
 
     void mousePressEvent(QMouseEvent *event) override;
@@ -605,16 +604,11 @@ private:
 
     void loadSettings();
 
-    int mHist[3][256]; /// 3 channels 256 bin. channels duplicated when gray
-    int mNumPixels = 0; /// image pixel count
-    int mNumDistinctValues = 0; /// number of distinct values
-    int mNumZeroPixels = 0; /// pixels with zero value
-    int mNumSaturatedPixels = 0; /// pixels saturating RGB 8bit
-    int mNumValues = 0; /// number of distinct histogram values
-    int mMinBinValue = 256; /// (gray-only) minimum intensity value
-    int mMaxBinValue = -1; /// (gray-only) maximum intensity value
-    int mMaxValue = 20; /// maximum count over all bins
+    std::unique_ptr<DkHistogramEngine> mHistogram;
+    QImage mHistImage;
+
     bool mIsValid = false; /// if true a histogram and stats are computed
+    bool mIsDirty = false; // if true histogram needs to be re-rendered
     float mScaleFactor = 1;
     DisplayMode mDisplayMode = DisplayMode::histogram_mode_simple; /// determins shown histogram type
 

--- a/ImageLounge/src/DkGui/DkWidgets.h
+++ b/ImageLounge/src/DkGui/DkWidgets.h
@@ -595,7 +595,7 @@ private slots:
 private:
     void setMaxHistogramValue(int maxValue);
     void updateHistogramValues(int histValues[][256]);
-    void setPainted(bool isPainted);
+    void setValid(bool isValid);
 
     void mousePressEvent(QMouseEvent *event) override;
     void mouseMoveEvent(QMouseEvent *event) override;
@@ -614,7 +614,7 @@ private:
     int mMinBinValue = 256; /// (gray-only) minimum intensity value
     int mMaxBinValue = -1; /// (gray-only) maximum intensity value
     int mMaxValue = 20; /// maximum count over all bins
-    bool mIsPainted = false;
+    bool mIsValid = false; /// if true a histogram and stats are computed
     float mScaleFactor = 1;
     DisplayMode mDisplayMode = DisplayMode::histogram_mode_simple; /// determins shown histogram type
 

--- a/ImageLounge/src/DkGui/DkWidgets.h
+++ b/ImageLounge/src/DkGui/DkWidgets.h
@@ -572,7 +572,7 @@ protected:
 };
 
 // Image histogram display
-class DkHistogram : public DkFadeWidget
+class DkHistogramWidget : public DkFadeWidget
 {
     Q_OBJECT
 
@@ -583,8 +583,8 @@ public:
         histogram_mode_end = 2,
     };
 
-    explicit DkHistogram(QWidget *parent);
-    ~DkHistogram() override;
+    explicit DkHistogramWidget(QWidget *parent);
+    ~DkHistogramWidget() override;
 
     void drawHistogram(const QImage &img);
     void clearHistogram();

--- a/ImageLounge/src/DkGui/DkWidgets.h
+++ b/ImageLounge/src/DkGui/DkWidgets.h
@@ -583,6 +583,10 @@ public:
         mode_extended = 1, // shows histogram and data
         mode_end = 2,
     };
+    enum ScaleMode {
+        scale_linear = 0,
+        scale_log = 1
+    };
 
     explicit DkHistogramWidget(QWidget *parent);
     ~DkHistogramWidget() override;

--- a/ImageLounge/src/DkGui/DkWidgets.h
+++ b/ImageLounge/src/DkGui/DkWidgets.h
@@ -586,7 +586,7 @@ public:
     explicit DkHistogram(QWidget *parent);
     ~DkHistogram() override;
 
-    void drawHistogram(QImage img);
+    void drawHistogram(const QImage &img);
     void clearHistogram();
 
 private slots:

--- a/ImageLounge/src/DkGui/DkWidgets.h
+++ b/ImageLounge/src/DkGui/DkWidgets.h
@@ -578,10 +578,10 @@ class DkHistogramWidget : public DkFadeWidget
     Q_OBJECT
 
 public:
-    enum class DisplayMode {
-        histogram_mode_simple = 0, /// shows just the histogram
-        histogram_mode_extended = 1, /// shows histogram and data
-        histogram_mode_end = 2,
+    enum DisplayMode {
+        mode_simple = 0, // shows just the histogram
+        mode_extended = 1, // shows histogram and data
+        mode_end = 2,
     };
 
     explicit DkHistogramWidget(QWidget *parent);
@@ -607,10 +607,11 @@ private:
     std::unique_ptr<DkHistogramEngine> mHistogram;
     QImage mHistImage;
 
-    bool mIsValid = false; /// if true a histogram and stats are computed
+    bool mIsValid = false; // if true a histogram and stats are computed
     bool mIsDirty = false; // if true histogram needs to be re-rendered
+
     float mScaleFactor = 1;
-    DisplayMode mDisplayMode = DisplayMode::histogram_mode_simple; /// determins shown histogram type
+    DisplayMode mDisplayMode = DisplayMode::mode_simple;
 
     QMenu *mContextMenu = nullptr;
 };

--- a/ImageLounge/src/DkGui/DkWidgets.h
+++ b/ImageLounge/src/DkGui/DkWidgets.h
@@ -609,6 +609,7 @@ private:
 
     float mScaleFactor = 1;
     DisplayMode mDisplayMode = DisplayMode::mode_simple;
+    bool mLogScale = false;
 
     QMenu *mContextMenu = nullptr;
 };

--- a/ImageLounge/src/DkGui/DkWidgets.h
+++ b/ImageLounge/src/DkGui/DkWidgets.h
@@ -588,14 +588,15 @@ public:
 
     void drawHistogram(QImage img);
     void clearHistogram();
+
+private slots:
+    void onToggleStatsTriggered(bool show);
+
+private:
     void setMaxHistogramValue(int maxValue);
     void updateHistogramValues(int histValues[][256]);
     void setPainted(bool isPainted);
 
-public slots:
-    void onToggleStatsTriggered(bool show);
-
-protected:
     void mousePressEvent(QMouseEvent *event) override;
     void mouseMoveEvent(QMouseEvent *event) override;
     void mouseReleaseEvent(QMouseEvent *event) override;
@@ -604,7 +605,6 @@ protected:
 
     void loadSettings();
 
-private:
     int mHist[3][256]; /// 3 channels 256 bin. channels duplicated when gray
     int mNumPixels = 0; /// image pixel count
     int mNumDistinctValues = 0; /// number of distinct values

--- a/ImageLounge/src/DkGui/DkWidgets.h
+++ b/ImageLounge/src/DkGui/DkWidgets.h
@@ -590,9 +590,6 @@ public:
     void drawHistogram(const QImage &img);
     void clearHistogram();
 
-private slots:
-    void onToggleStatsTriggered(bool show);
-
 private:
     void setValid(bool isValid);
 


### PR DESCRIPTION
Summary:
- All image formats supported
- Fast rendering (threaded histogram compute,  render cache)
- Nice colors (less harsh, good contrast for C,M,Y mix)
- Fixed stats text layout, values properly scaled/displayed
- Don't count transparent pixels  
- Logarithmic scale option
  
<img width="1355" height="823" alt="image" src="https://github.com/user-attachments/assets/f129dab2-f079-46b7-80bb-a0e6b0394665" />
