### PR TITLE
fix: issue #1549 - update metadata ribbon when switching between imag…

### DIFF
--- a/ImageLounge/src/DkGui/DkMetaDataWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkMetaDataWidgets.cpp
@@ -844,10 +844,7 @@ QStringList DkMetaDataHUD::getDefaultKeys() const
 void DkMetaDataHUD::setMetaData(QSharedPointer<DkMetaDataT> metaData)
 {
     mMetaData = metaData;
-    if (isVisible()) {
-        // only update if I am visible
-        updateMetaData(mMetaData);
-    }
+    updateMetaData(mMetaData);
 }
 
 void DkMetaDataHUD::updateMetaData(const QSharedPointer<DkMetaDataT> metaData)


### PR DESCRIPTION
Fix issue #1549 where the metadata ribbon was not updated when switching from one image to another through the thumbnail view.