### PR TITLE
feat(viewport): add zoom_keep_same_size_or_fit setting

### DIFF
--- a/ImageLounge/src/DkCore/DkBaseViewPort.cpp
+++ b/ImageLounge/src/DkCore/DkBaseViewPort.cpp
@@ -787,6 +787,11 @@ void DkBaseViewPort::updateImageMatrix(std::optional<DkSettings::keepZoom> keepZ
     case DkSettings::zoom_always_fit:
         zoomToFit();
         break;
+    case DkSettings::zoom_keep_same_size_or_fit:
+        if (!isSameSize) {
+            zoomToFit();
+        }
+        break;
 
     default:
         Q_UNREACHABLE();

--- a/ImageLounge/src/DkCore/DkSettings.h
+++ b/ImageLounge/src/DkCore/DkSettings.h
@@ -146,6 +146,7 @@ public:
         zoom_keep_same_size, // keep if prev image size is the same
         zoom_never_keep, // zoom to fit, disallow scale > 100%
         zoom_always_fit, // zoom to fit, allow scale > 100%
+        zoom_keep_same_size_or_fit, // keep if same size, otherwise zoom to fit, allow scale >100%
         zoom_end,
     };
 

--- a/ImageLounge/src/DkGui/DkPreferenceWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkPreferenceWidgets.cpp
@@ -793,6 +793,9 @@ void DkDisplayPreference::createLayout()
         tr("If checked, the zoom level is only kept, if the image loaded has the same level as the previous."));
     keepZoomButtons[DkSettings::zoom_never_keep] = new QRadioButton(tr("Never keep zoom"), this);
     keepZoomButtons[DkSettings::zoom_always_fit] = new QRadioButton(tr("Always zoom to fit"), this);
+    keepZoomButtons[DkSettings::zoom_keep_same_size_or_fit] = new QRadioButton(tr("Keep zoom if the size is the same, zoom to fit if it's different"), this);
+    keepZoomButtons[DkSettings::zoom_keep_same_size_or_fit]->setToolTip(
+        tr("If the image loaded has the same size as the previous, the zoom level is kept. Otherwise, zoom to fit is used."));
 
     // check wrt the current settings
     keepZoomButtons[DkSettingsManager::param().display().keepZoom]->setChecked(true);
@@ -802,6 +805,7 @@ void DkDisplayPreference::createLayout()
     keepZoomButtonGroup->addButton(keepZoomButtons[DkSettings::zoom_keep_same_size], DkSettings::zoom_keep_same_size);
     keepZoomButtonGroup->addButton(keepZoomButtons[DkSettings::zoom_never_keep], DkSettings::zoom_never_keep);
     keepZoomButtonGroup->addButton(keepZoomButtons[DkSettings::zoom_always_fit], DkSettings::zoom_always_fit);
+    keepZoomButtonGroup->addButton(keepZoomButtons[DkSettings::zoom_keep_same_size_or_fit], DkSettings::zoom_keep_same_size_or_fit);
     connect(keepZoomButtonGroup, &QButtonGroup::idClicked, this, &DkDisplayPreference::onKeepZoomButtonClicked);
 
     auto *keepZoomGroup = new DkGroupWidget(tr("When Displaying New Images"), this);
@@ -809,6 +813,7 @@ void DkDisplayPreference::createLayout()
     keepZoomGroup->addWidget(keepZoomButtons[DkSettings::zoom_keep_same_size]);
     keepZoomGroup->addWidget(keepZoomButtons[DkSettings::zoom_never_keep]);
     keepZoomGroup->addWidget(keepZoomButtons[DkSettings::zoom_always_fit]);
+    keepZoomGroup->addWidget(keepZoomButtons[DkSettings::zoom_keep_same_size_or_fit]);
 
     mColorProfiles = new QComboBox(this);
     mColorProfiles->setToolTip(tr("Choose the color profile of the monitor"));


### PR DESCRIPTION
Add a new setting to "When Displaying New Images". It combines the logic of "Keep Zoom if the size is the same" and "Zoom to fit".


I really like "Keep zoom if the size is the same" option but it breaks down when I later load smaller images and they are not zoomed in. I ended up frequently toggling this setting. This option helps combine what is the best of both worlds. If there is no zooming going on and an image if too small, it will be fit into the viewport. But scrolling between images while zoomed in is also possible.

Please check the following before submitting a *pull request*:

- Fork [nomacs](https://github.com/nomacs/nomacs.git) and create your fix/feature branch from `master`
- Pull requests are only accepted if they pass all workflow checks. In addition: 
    - Must compile without warnings (check workflow logs)
	- Must pass clang-tidy checks (see `ImageLounge/.clang-tidy`)

Also have a look at our [CONTRIBUTING.md](https://github.com/nomacs/nomacs/blob/master/CONTRIBUTING.md) for additional coding guidelines.
