### PR TITLE
Allow comments or other metadata to be created if none exists

### DIFF
--- a/ImageLounge/src/DkCore/DkImageContainer.cpp
+++ b/ImageLounge/src/DkCore/DkImageContainer.cpp
@@ -929,6 +929,7 @@ void DkImageContainerT::setRating(int rating)
     QSharedPointer<DkMetaDataT> metaDataInfo = getMetaData();
     bool succeeded = metaDataInfo->setRating(rating);
     if (!succeeded) {
+        emit showInfoSignal(tr("Sorry, I cannot save rating on this image format."));
         return;
     }
     QString msg = (rating == 0) ? QObject::tr("Clear rating") : QObject::tr("Set rating to %1").arg(rating);

--- a/ImageLounge/src/DkCore/DkMetaData.cpp
+++ b/ImageLounge/src/DkCore/DkMetaData.cpp
@@ -1325,7 +1325,7 @@ bool DkMetaDataT::updateImageMetaData(const QImage &img, bool reset_orientation)
 
 bool DkMetaDataT::setExifValue(const QString &key, const QString &value)
 {
-    if (mExifState == not_loaded || mExifState == no_data) {
+    if (mExifState == not_loaded || !mExifImg) {
         return false;
     }
 

--- a/ImageLounge/src/DkCore/DkMetaData.cpp
+++ b/ImageLounge/src/DkCore/DkMetaData.cpp
@@ -1225,9 +1225,6 @@ void DkMetaDataT::setOrientation(int o)
 
 bool DkMetaDataT::setDescription(const QString &description)
 {
-    if (mExifState == not_loaded || mExifState == no_data)
-        return false;
-
     return setExifValue("Exif.Image.ImageDescription", description.toUtf8());
 }
 

--- a/ImageLounge/src/DkCore/DkMetaData.cpp
+++ b/ImageLounge/src/DkCore/DkMetaData.cpp
@@ -1326,12 +1326,11 @@ bool DkMetaDataT::updateImageMetaData(const QImage &img, bool reset_orientation)
     return success;
 }
 
-bool DkMetaDataT::setExifValue(QString key, QString taginfo)
+bool DkMetaDataT::setExifValue(const QString &key, const QString &value)
 {
-    bool setExifSuccessfull = false;
-
-    if (mExifState == not_loaded || mExifState == no_data)
+    if (mExifState == not_loaded || mExifState == no_data) {
         return false;
+    }
 
     try {
         Exiv2::ExifData &exifData = mExifImg->exifData();
@@ -1343,27 +1342,29 @@ bool DkMetaDataT::setExifValue(QString key, QString taginfo)
             // QByteArray ba = taginfo.toUtf8();
             // Exiv2::DataValue val((const byte*)ba.data(), taginfo.size(), Exiv2::ByteOrder::bigEndian,
             // Exiv2::TypeId::unsignedByte);
-
             // tag.setValue(&val);
-            if (!tag.setValue(taginfo.toStdString())) {
-                mExifState = dirty;
-                setExifSuccessfull = true;
+
+            if (0 != tag.setValue(value.toStdString())) {
+                qWarning() << "[Exiv2] setValue() on existing key failed" << key << value;
+                return false;
             }
         } else {
             Exiv2::ExifKey exivKey(key.toStdString());
             Exiv2::Exifdatum tag(exivKey);
-            if (!tag.setValue(taginfo.toStdString())) {
-                mExifState = dirty;
-                setExifSuccessfull = true;
+            if (0 != tag.setValue(value.toStdString())) {
+                qWarning() << "[Exiv2] setValue() on new key failed" << key << value;
+                return false;
             }
 
             exifData.add(tag);
         }
     } catch (...) {
-        setExifSuccessfull = false;
+        qWarning() << "[Exiv2] failed to set exif value" << key << value;
+        return false;
     }
 
-    return setExifSuccessfull;
+    mExifState = dirty;
+    return true;
 }
 
 QString DkMetaDataT::exiv2ToQString(std::string exifString)

--- a/ImageLounge/src/DkCore/DkMetaData.cpp
+++ b/ImageLounge/src/DkCore/DkMetaData.cpp
@@ -1239,6 +1239,10 @@ bool DkMetaDataT::setRating(int r)
         return false;
     }
 
+    if (!isWriteable()) {
+        return false;
+    }
+
     Exiv2::ExifData &exifData = mExifImg->exifData();
     Exiv2::XmpData &xmpData = mExifImg->xmpData();
 
@@ -1326,6 +1330,10 @@ bool DkMetaDataT::updateImageMetaData(const QImage &img, bool reset_orientation)
 bool DkMetaDataT::setExifValue(const QString &key, const QString &value)
 {
     if (mExifState == not_loaded || !mExifImg) {
+        return false;
+    }
+
+    if (!isWriteable()) {
         return false;
     }
 

--- a/ImageLounge/src/DkCore/DkMetaData.h
+++ b/ImageLounge/src/DkCore/DkMetaData.h
@@ -123,7 +123,7 @@ public:
     void setOrientation(int o);
     bool setRating(int r);
     bool setDescription(const QString &description);
-    bool setExifValue(QString key, QString taginfo);
+    bool setExifValue(const QString &key, const QString &value);
     bool updateImageMetaData(const QImage &img, bool reset_orientation = true);
     void setThumbnail(const QImage &thumb);
     void setQtValues(const QImage &cImg);

--- a/ImageLounge/tests/DkMetaData_test.cpp
+++ b/ImageLounge/tests/DkMetaData_test.cpp
@@ -8,9 +8,7 @@
 
 using namespace nmc;
 
-namespace
-{
-QString createEmptyMetadataPng(QTemporaryDir &tempDir)
+static QString createEmptyMetadataPng(QTemporaryDir &tempDir)
 {
     QImage img(16, 16, QImage::Format_RGB32);
     img.fill(Qt::white);
@@ -20,6 +18,54 @@ QString createEmptyMetadataPng(QTemporaryDir &tempDir)
 
     return filePath;
 }
+
+TEST(DkMetadata, SetExifValueOnEmptyMetadata)
+{
+    QTemporaryDir tempDir;
+    ASSERT_TRUE(tempDir.isValid());
+
+    const QString filePath = createEmptyMetadataPng(tempDir);
+
+    {
+        DkMetaDataT md;
+        md.readMetaData(DkFileInfo{filePath});
+
+        // allow set metadata when none is present
+        EXPECT_FALSE(md.hasMetaData());
+        EXPECT_FALSE(md.isDirty());
+        EXPECT_TRUE(md.setExifValue("Exif.Image.ImageDescription", "qwe123"));
+        EXPECT_TRUE(md.isDirty());
+        EXPECT_EQ(md.getExifValue("ImageDescription"), "qwe123");
+
+        bool force = false;
+        EXPECT_TRUE(md.saveMetaData(DkFileInfo{filePath}, force));
+    }
+
+    {
+        // check it is preserved
+        DkMetaDataT md;
+        md.readMetaData(DkFileInfo{filePath});
+        EXPECT_TRUE(md.hasMetaData());
+        EXPECT_FALSE(md.isDirty());
+        EXPECT_EQ(md.getExifValue("ImageDescription"), "qwe123");
+
+        // modify existing
+        EXPECT_TRUE(md.setExifValue("Exif.Image.ImageDescription", "123qwe"));
+        EXPECT_TRUE(md.isDirty());
+        EXPECT_EQ(md.getExifValue("ImageDescription"), "123qwe");
+
+        bool force = false;
+        EXPECT_TRUE(md.saveMetaData(DkFileInfo{filePath}, force));
+    }
+
+    {
+        // check it is preserved
+        DkMetaDataT md;
+        md.readMetaData(DkFileInfo{filePath});
+        EXPECT_TRUE(md.hasMetaData());
+        EXPECT_FALSE(md.isDirty());
+        EXPECT_EQ(md.getExifValue("ImageDescription"), "123qwe");
+    }
 }
 
 TEST(DkMetaData, RatingInitializesAndClearsEmptyMetadata)


### PR DESCRIPTION
This is a followup to #1561 that enables the same behavior for comments. I'm undecided what to do about rotation/orientation, that remains unchanged at the moment.
