### PR TITLE
feat(viewport) Add a fallback setting for "Keep zoom if size is the same"

### DIFF
--- a/ImageLounge/src/DkCore/DkBaseViewPort.cpp
+++ b/ImageLounge/src/DkCore/DkBaseViewPort.cpp
@@ -777,7 +777,17 @@ void DkBaseViewPort::updateImageMatrix(std::optional<DkSettings::keepZoom> keepZ
         break;
     case DkSettings::zoom_keep_same_size: {
         if (!isSameSize) {
-            mWorldMatrix.reset();
+            switch (static_cast<DkSettings::keepZoomKeepSameSizeFallback>(
+                DkSettingsManager::param().display().keepZoomKeepSameSizeFallback)) {
+            case DkSettings::kzkss_fallback_fit_bigger_or_reset:
+                mWorldMatrix.reset();
+                break;
+            case DkSettings::kzkss_fallback_always_fit:
+                zoomToFit();
+                break;
+            default:
+                Q_UNREACHABLE();
+            }
         }
         break;
     }

--- a/ImageLounge/src/DkCore/DkSettings.cpp
+++ b/ImageLounge/src/DkCore/DkSettings.cpp
@@ -455,6 +455,8 @@ void DkSettings::load(QSettings &settings, bool defaults)
     settings.beginGroup("DisplaySettings");
 
     display_p.keepZoom = settings.value("keepZoom", display_p.keepZoom).toInt();
+    display_p.keepZoomKeepSameSizeFallback = settings.value("keepZoomFallback", display_p.keepZoomKeepSameSizeFallback)
+                                                 .toInt();
     display_p.invertZoom = settings.value("invertZoom", display_p.invertZoom).toBool();
     display_p.highlightColor = QColor::fromRgba(
         settings.value("highlightColorRGBA", display_p.highlightColor.rgba()).toInt());
@@ -765,6 +767,8 @@ void DkSettings::save(QSettings &settings, bool force)
 
     if (force || display_p.keepZoom != display_d.keepZoom)
         settings.setValue("keepZoom", display_p.keepZoom);
+    if (force || display_p.keepZoomKeepSameSizeFallback != display_d.keepZoomKeepSameSizeFallback)
+        settings.setValue("keepZoomFallback", display_p.keepZoomKeepSameSizeFallback);
     if (force || display_p.invertZoom != display_d.invertZoom)
         settings.setValue("invertZoom", display_p.invertZoom);
     if (force || display_p.highlightColor != display_d.highlightColor)
@@ -1043,6 +1047,7 @@ void DkSettings::setToDefaultSettings()
 #endif
 
     display_p.keepZoom = zoom_keep_same_size;
+    display_p.keepZoomKeepSameSizeFallback = kzkss_fallback_fit_bigger_or_reset;
     display_p.invertZoom = false;
     display_p.highlightColor = QColor(0, 204, 255);
     display_p.hudBgColor = QColor(0, 0, 0, 100);

--- a/ImageLounge/src/DkCore/DkSettings.h
+++ b/ImageLounge/src/DkCore/DkSettings.h
@@ -149,6 +149,12 @@ public:
         zoom_end,
     };
 
+    enum keepZoomKeepSameSizeFallback {
+        kzkss_fallback_fit_bigger_or_reset,
+        kzkss_fallback_always_fit,
+        kzkss_fallback_end,
+    };
+
     enum TransitionMode {
         trans_appear,
         trans_fade,
@@ -209,6 +215,7 @@ public:
 
     struct Display {
         int keepZoom;
+        int keepZoomKeepSameSizeFallback;
         bool invertZoom;
         bool tpPattern;
         bool showNavigation;

--- a/ImageLounge/src/DkGui/DkPreferenceWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkPreferenceWidgets.cpp
@@ -829,8 +829,42 @@ void DkDisplayPreference::createLayout()
     auto *keepZoomGroup = new DkGroupWidget(tr("When Displaying New Images"), this);
     keepZoomGroup->addWidget(keepZoomButtons[DkSettings::zoom_always_keep]);
     keepZoomGroup->addWidget(keepZoomButtons[DkSettings::zoom_keep_same_size]);
+
+    QVector<QRadioButton *> keepZoomKeepSameSizeFallbackButtons;
+    keepZoomKeepSameSizeFallbackButtons.resize(DkSettings::kzkss_fallback_end);
+    keepZoomKeepSameSizeFallbackButtons
+        [DkSettings::kzkss_fallback_fit_bigger_or_reset] = new QRadioButton(tr("Zoom to fit if image is bigger than "
+                                                                               "viewport, otherwise reset to 100%"),
+                                                                            this);
+    keepZoomKeepSameSizeFallbackButtons
+        [DkSettings::kzkss_fallback_always_fit] = new QRadioButton(tr("Always zoom to fit"), this);
+    keepZoomKeepSameSizeFallbackButtons[DkSettingsManager::param().display().keepZoomKeepSameSizeFallback]->setChecked(
+        true);
+
+    auto *keepZoomKeepSameSizeFallBackButtonGroup = new QButtonGroup(this);
+    keepZoomKeepSameSizeFallBackButtonGroup
+        ->addButton(keepZoomKeepSameSizeFallbackButtons[DkSettings::kzkss_fallback_fit_bigger_or_reset],
+                    DkSettings::kzkss_fallback_fit_bigger_or_reset);
+    keepZoomKeepSameSizeFallBackButtonGroup
+        ->addButton(keepZoomKeepSameSizeFallbackButtons[DkSettings::kzkss_fallback_always_fit],
+                    DkSettings::kzkss_fallback_always_fit);
+    connect(keepZoomKeepSameSizeFallBackButtonGroup,
+            &QButtonGroup::idClicked,
+            this,
+            &DkDisplayPreference::onKeepZoomKeepSameSizeFallbackButtonClicked);
+
+    mKeepZoomKeepSameSizeFallbackWidget = new QWidget(this);
+    auto *keepZoomKeepSameSizeLayout = new QVBoxLayout(mKeepZoomKeepSameSizeFallbackWidget);
+    keepZoomKeepSameSizeLayout->setContentsMargins(20, 0, 0, 0);
+    keepZoomKeepSameSizeLayout->addWidget(new QLabel(tr("If the size is different"), this));
+    keepZoomKeepSameSizeLayout->addWidget(
+        keepZoomKeepSameSizeFallbackButtons[DkSettings::kzkss_fallback_fit_bigger_or_reset]);
+    keepZoomKeepSameSizeLayout->addWidget(keepZoomKeepSameSizeFallbackButtons[DkSettings::kzkss_fallback_always_fit]);
+
+    keepZoomGroup->addWidget(mKeepZoomKeepSameSizeFallbackWidget);
     keepZoomGroup->addWidget(keepZoomButtons[DkSettings::zoom_never_keep]);
     keepZoomGroup->addWidget(keepZoomButtons[DkSettings::zoom_always_fit]);
+    updateKeepZoomKeepSameSizeFallbackEnabled();
 
     mColorProfiles = new QComboBox(this);
     mColorProfiles->setToolTip(tr("Choose the color profile of the monitor"));
@@ -1003,6 +1037,20 @@ void DkDisplayPreference::onKeepZoomButtonClicked(int buttonId) const
 {
     if (DkSettingsManager::param().display().keepZoom != buttonId)
         DkSettingsManager::param().display().keepZoom = buttonId;
+
+    updateKeepZoomKeepSameSizeFallbackEnabled();
+}
+
+void DkDisplayPreference::onKeepZoomKeepSameSizeFallbackButtonClicked(int buttonId) const
+{
+    if (DkSettingsManager::param().display().keepZoomKeepSameSizeFallback != buttonId)
+        DkSettingsManager::param().display().keepZoomKeepSameSizeFallback = buttonId;
+}
+
+void DkDisplayPreference::updateKeepZoomKeepSameSizeFallbackEnabled() const
+{
+    const int keepZoomMode = DkSettingsManager::param().display().keepZoom;
+    mKeepZoomKeepSameSizeFallbackWidget->setEnabled(keepZoomMode == DkSettings::zoom_keep_same_size);
 }
 
 void DkDisplayPreference::onInvertZoomToggled(bool checked) const

--- a/ImageLounge/src/DkGui/DkPreferenceWidgets.h
+++ b/ImageLounge/src/DkGui/DkPreferenceWidgets.h
@@ -172,6 +172,7 @@ public slots:
     void onDisplayTimeBoxValueChanged(double value) const;
     void onShowPlayerToggled(bool checked) const;
     void onKeepZoomButtonClicked(int buttonId) const;
+    void onKeepZoomKeepSameSizeFallbackButtonClicked(int buttonId) const;
     void onInvertZoomToggled(bool checked) const;
     void onHQAntiAliasingToggled(bool checked) const;
     void onAlwaysAnimateToggled(bool checked) const;
@@ -189,8 +190,10 @@ signals:
 protected:
     void createLayout();
     void paintEvent(QPaintEvent *ev) override;
+    void updateKeepZoomKeepSameSizeFallbackEnabled() const;
 
     QWidget *mZoomLevels = nullptr;
+    QWidget *mKeepZoomKeepSameSizeFallbackWidget = nullptr;
     QLineEdit *mZoomLevelsEdit = nullptr;
     QComboBox *mColorProfiles = nullptr;
 };


### PR DESCRIPTION
I went based off this suggestion
<img width="1559" height="423" alt="image" src="https://github.com/user-attachments/assets/c553af54-07a7-496c-a387-941579cfe4f2" />
but since the option only really applies to "Keep zoom if the size is the same", I put it under that setting and made it disabled if another option is selected. Also, I named the version that matches behavior of "Never keep zoom" "Zoom to fit if image is bigger than view port, otherwise reset to 100%", since that's what describes what really is going on. Without such a description I think it's really hard for user to figure out how this works.


<img width="603" height="256" alt="image" src="https://github.com/user-attachments/assets/bc927da6-bc56-4a12-9675-de22bde07f79" />
<img width="676" height="246" alt="image" src="https://github.com/user-attachments/assets/02ba2ce7-77e9-48c2-8b7a-c33a72dae755" />
