### PR TITLE
fix: skip-free image navigation with high-resolution mouse wheels

### DIFF
--- a/ImageLounge/src/DkGui/DkViewPort.cpp
+++ b/ImageLounge/src/DkGui/DkViewPort.cpp
@@ -1317,10 +1317,25 @@ void DkViewPort::wheelEvent(QWheelEvent *event)
         } else {
             delta = event->angleDelta().y();
         }
-        if (delta < 0)
+
+        // accumulate deltas and only navigate on a full wheel step (120):
+        // high-resolution wheels (e.g. Logitech MX/G-series, some touchpads) report
+        // several small-delta events per notch, which skipped multiple images (#1079)
+        constexpr int wheelStep = 120; // Qt reports wheel deltas in 1/8 degree; one notch = 15 degrees
+
+        // reset the accumulator when the scroll direction changes
+        if ((delta < 0 && mWheelAccumulator > 0) || (delta > 0 && mWheelAccumulator < 0))
+            mWheelAccumulator = 0;
+
+        mWheelAccumulator += delta;
+
+        if (mWheelAccumulator <= -wheelStep) {
             loadNextFileFast();
-        if (delta > 0)
+            mWheelAccumulator = 0;
+        } else if (mWheelAccumulator >= wheelStep) {
             loadPrevFileFast();
+            mWheelAccumulator = 0;
+        }
     } else
         DkBaseViewPort::wheelEvent(event);
 

--- a/ImageLounge/src/DkGui/DkViewPort.cpp
+++ b/ImageLounge/src/DkGui/DkViewPort.cpp
@@ -1331,10 +1331,10 @@ void DkViewPort::wheelEvent(QWheelEvent *event)
 
         if (mWheelAccumulator <= -wheelStep) {
             loadNextFileFast();
-            mWheelAccumulator = 0;
+            mWheelAccumulator += wheelStep;
         } else if (mWheelAccumulator >= wheelStep) {
             loadPrevFileFast();
-            mWheelAccumulator = 0;
+            mWheelAccumulator -= wheelStep;
         }
     } else
         DkBaseViewPort::wheelEvent(event);

--- a/ImageLounge/src/DkGui/DkViewPort.h
+++ b/ImageLounge/src/DkGui/DkViewPort.h
@@ -207,6 +207,8 @@ private:
 
     QPoint mCurrentPixelPos;
 
+    int mWheelAccumulator = 0; // accumulates high-resolution wheel deltas for image navigation
+
     DkRotatingRect mCropRect;
 
     DkFadeButton *mNextButton = nullptr;


### PR DESCRIPTION
## Problem

High-resolution mouse wheels (Logitech MX / G-series, many modern mice, some touchpads) report several small-delta wheel events per physical notch instead of a single event with `angleDelta() == ±120`.

`DkViewPort::wheelEvent()` navigates one image per event regardless of the delta magnitude, so a single notch skips several images. This makes wheel navigation unusable with these devices — even in the mouse's ratchet mode.

Reported before in #1079 (closed without a fix); related: #630.

## Fix

Accumulate `angleDelta()` in a per-viewport member and only navigate once a full wheel step (120 = 15°) is reached, as recommended by the Qt docs for handling hi-res scroll events. The accumulator resets on direction change so quick back-and-forth scrolling stays responsive.

Classic wheels are unaffected: they deliver ±120 per notch, which triggers navigation immediately, exactly as before.

## Testing

- Fedora (Wayland), Qt 6, Logitech G502 X Lightspeed (hi-res wheel):
  - before: 3–5 images per notch
  - after: exactly 1 image per notch, both directions, ratchet and free-spin
- Classic ±120 wheel: unchanged behavior (1 image per notch)
- Zoom path (`Ctrl+wheel` / "zoom on wheel") untouched — only the navigation branch changed
- Builds warning-free with clang-format applied
