### PR TITLE
Fix build against opencv 5.0

### DIFF
--- a/ImageLounge/plugins/AffineTransformations/src/DkSkewEstimator.cpp
+++ b/ImageLounge/plugins/AffineTransformations/src/DkSkewEstimator.cpp
@@ -32,7 +32,7 @@
 #include <QRandomGenerator>
 
 #ifdef WITH_OPENCV
-#include "opencv2/imgproc/imgproc_c.h"
+#include "opencv2/imgproc/imgproc.hpp"
 #endif
 
 namespace nmp
@@ -91,7 +91,7 @@ double DkSkewEstimator::getSkewAngle()
         cv::Mat matGray;
 
         if (mMatImg.channels() > 1)
-            cv::cvtColor(mMatImg, matGray, CV_BGR2GRAY);
+            cv::cvtColor(mMatImg, matGray, cv::COLOR_BGR2GRAY);
         else
             matGray = mMatImg;
 
@@ -224,7 +224,7 @@ cv::Mat DkSkewEstimator::computeSeparability(cv::Mat integral, cv::Mat integralS
 
     // for displaying:
     // cv::normalize(separability, separability, 0, 255, NORM_MINMAX, CV_8UC1);
-    // cvtColor(separability, separability, CV_GRAY2RGB);
+    // cvtColor(separability, separability, cv::COLOR_GRAY2RGB);
 
     return separability;
 }

--- a/ImageLounge/plugins/CompositePlugin/src/SbChannelWidget.cpp
+++ b/ImageLounge/plugins/CompositePlugin/src/SbChannelWidget.cpp
@@ -14,7 +14,6 @@
 #include <QSettings>
 
 #include "opencv2/imgproc/imgproc.hpp"
-#include "opencv2/imgproc/imgproc_c.h"
 
 namespace nmc
 {
@@ -77,7 +76,7 @@ void SbChannelWidget::loadImage(QString file)
         mSrcFormat = qImg.copy(0, 0, 1, 1);
 
         mImg = DkImage::qImage2Mat(qImg);
-        cv::cvtColor(mImg, mImg, CV_RGB2GRAY);
+        cv::cvtColor(mImg, mImg, cv::COLOR_RGB2GRAY);
 
         updateThumbnail();
         QFileInfo fi(file);

--- a/ImageLounge/plugins/CompositePlugin/src/SbCompositePlugin.cpp
+++ b/ImageLounge/plugins/CompositePlugin/src/SbCompositePlugin.cpp
@@ -30,7 +30,6 @@
 #include <QSettings>
 
 #include "opencv2/imgproc/imgproc.hpp"
-#include "opencv2/imgproc/imgproc_c.h"
 
 /*******************************************************************************************************
  * SbCompositePlugin	- enter the plugin class name (e.g. DkPageExtractionPlugin)
@@ -231,9 +230,9 @@ void SbCompositePlugin::onNewAlpha(QImage _alpha)
         mAlpha = DkImage::qImage2Mat(_alpha);
         // currently it seems like qImage2Mat converts a single-channel QImage to a multi-channel Mat. so..
         if (mAlpha.channels() == 4)
-            cv::cvtColor(mAlpha, mAlpha, CV_RGBA2GRAY);
+            cv::cvtColor(mAlpha, mAlpha, cv::COLOR_RGBA2GRAY);
         else if (mAlpha.channels() == 3)
-            cv::cvtColor(mAlpha, mAlpha, CV_RGB2GRAY);
+            cv::cvtColor(mAlpha, mAlpha, cv::COLOR_RGB2GRAY);
     }
 }
 

--- a/ImageLounge/plugins/FakeMiniaturesPlugin/src/DkFakeMiniaturesDialog.cpp
+++ b/ImageLounge/plugins/FakeMiniaturesPlugin/src/DkFakeMiniaturesDialog.cpp
@@ -26,6 +26,12 @@
  *******************************************************************************************************/
 
 #include "DkFakeMiniaturesDialog.h"
+#ifdef WITH_OPENCV
+#include "opencv2/imgproc.hpp"
+#if CV_MAJOR_VERSION >= 5
+#include "opencv2/geometry.hpp"
+#endif
+#endif
 #include "DkImageStorage.h"
 
 #include <QColorSpace>

--- a/ImageLounge/plugins/PageExtractionPlugin/src/DkPageSegmentation.cpp
+++ b/ImageLounge/plugins/PageExtractionPlugin/src/DkPageSegmentation.cpp
@@ -30,7 +30,9 @@
 #include <QPainterPath>
 
 #include "opencv2/imgproc/imgproc.hpp"
-#include "opencv2/imgproc/imgproc_c.h"
+#if CV_MAJOR_VERSION >= 5
+#include "opencv2/geometry.hpp"
+#endif
 
 namespace nmp
 {
@@ -90,7 +92,7 @@ void DkPageSegmentation::compute()
         if (mScale == 1.0f && 960.0f / mImg.cols < 0.8f)
             mScale = 960.0f / mImg.cols;
 
-        cv::cvtColor(mImg, imgLab, CV_RGB2Lab); // boost colors
+        cv::cvtColor(mImg, imgLab, cv::COLOR_RGB2Lab); // boost colors
         lImg = findRectangles(mImg, mRects);
     }
 
@@ -102,7 +104,7 @@ cv::Mat DkPageSegmentation::findRectangles(const cv::Mat &img, std::vector<DkPol
     cv::Mat tImg, gray;
 
     if (mScale != 1.0f)
-        cv::resize(img, tImg, cv::Size(), mScale, mScale, CV_INTER_AREA); // inter nn -> assuming resize to be 1/(2^n)
+        cv::resize(img, tImg, cv::Size(), mScale, mScale, cv::INTER_AREA); // inter nn -> assuming resize to be 1/(2^n)
     else
         tImg = img;
 
@@ -138,7 +140,7 @@ cv::Mat DkPageSegmentation::findRectangles(const cv::Mat &img, std::vector<DkPol
             }
 
             // find contours and store them all as a list
-            findContours(gray, contours, CV_RETR_LIST, CV_CHAIN_APPROX_SIMPLE);
+            findContours(gray, contours, cv::RETR_LIST, cv::CHAIN_APPROX_SIMPLE);
 
             if (mLooseDetection) {
                 std::vector<std::vector<cv::Point>> hull;
@@ -160,7 +162,7 @@ cv::Mat DkPageSegmentation::findRectangles(const cv::Mat &img, std::vector<DkPol
 
             // DEBUG ------------------------
             // cv::Mat pImg = image.clone();
-            // cv::cvtColor(pImg, pImg, CV_Lab2RGB);
+            // cv::cvtColor(pImg, pImg, cv::COLOR_Lab2RGB);
             // DEBUG ------------------------
 
             // test each contour
@@ -196,7 +198,7 @@ cv::Mat DkPageSegmentation::findRectangles(const cv::Mat &img, std::vector<DkPol
                 }
             }
             // DEBUG ------------------------
-            // cv::cvtColor(pImg, pImg, CV_RGB2BGR);
+            // cv::cvtColor(pImg, pImg, cv::COLOR_RGB2BGR);
             // DkIP::imwrite("polyImg" + DkUtils::stringify(c) + "-" + DkUtils::stringify(l) + ".png", pImg);
             // DEBUG ------------------------
         }

--- a/ImageLounge/plugins/PageExtractionPlugin/src/DkPageSegmentationUtils.cpp
+++ b/ImageLounge/plugins/PageExtractionPlugin/src/DkPageSegmentationUtils.cpp
@@ -25,7 +25,9 @@
 #include "DkPageSegmentationUtils.h"
 
 #include "opencv2/imgproc/imgproc.hpp"
-#include "opencv2/imgproc/imgproc_c.h"
+#if CV_MAJOR_VERSION >= 5
+#include "opencv2/geometry.hpp"
+#endif
 
 #include <algorithm>
 
@@ -433,9 +435,9 @@ void PageExtractor::findPage(cv::Mat img, float scale, std::vector<DkPolyRect> &
 {
     cv::Mat gray, bw;
 
-    cv::cvtColor(img, gray, CV_RGB2GRAY);
+    cv::cvtColor(img, gray, cv::COLOR_RGB2GRAY);
     if (scale != 1.0f) {
-        cv::resize(gray, gray, cv::Size(), scale, scale, CV_INTER_AREA); // inter nn -> assuming resize to be 1/(2^n)
+        cv::resize(gray, gray, cv::Size(), scale, scale, cv::INTER_AREA); // inter nn -> assuming resize to be 1/(2^n)
     }
     const int smallerSide = std::min(gray.size().width, gray.size().height);
 

--- a/ImageLounge/src/DkCore/DkBasicLoader.cpp
+++ b/ImageLounge/src/DkCore/DkBasicLoader.cpp
@@ -50,7 +50,6 @@
 #ifdef WITH_OPENCV
 #include "opencv2/core/core.hpp"
 #include "opencv2/imgproc/imgproc.hpp"
-#include "opencv2/imgproc/imgproc_c.h"
 
 #ifdef WITH_LIBRAW
 #include <libraw/libraw.h>
@@ -835,7 +834,7 @@ bool DkBasicLoader::loadDRIF(const QString &filePath, QImage &img, QSharedPointe
         case DRIF_FMT_BGR888: {
             cv::Mat imgMat = cv::Mat((int)h, (int)w, CV_8UC3, imgBytes);
             cv::Mat rgbMat = cv::Mat((int)h, (int)w, CV_8UC3, reinterpret_cast<uint8_t *>(img.bits()));
-            cv::cvtColor(imgMat, rgbMat, CV_BGR2RGB);
+            cv::cvtColor(imgMat, rgbMat, cv::COLOR_BGR2RGB);
 
             success = true;
         } break;
@@ -869,7 +868,7 @@ bool DkBasicLoader::loadDRIF(const QString &filePath, QImage &img, QSharedPointe
         case DRIF_FMT_BGRA8888: {
             cv::Mat imgMat = cv::Mat((int)h, (int)w, CV_8UC4, imgBytes);
             cv::Mat rgbMat = cv::Mat((int)h, (int)w, CV_8UC3, reinterpret_cast<uint8_t *>(img.bits()));
-            cv::cvtColor(imgMat, rgbMat, CV_BGR2RGB, 3);
+            cv::cvtColor(imgMat, rgbMat, cv::COLOR_BGR2RGB, 3);
 
             success = true;
         } break;
@@ -877,7 +876,7 @@ bool DkBasicLoader::loadDRIF(const QString &filePath, QImage &img, QSharedPointe
         case DRIF_FMT_RGBA8888: {
             cv::Mat imgMat = cv::Mat((int)h, (int)w, CV_8UC4, imgBytes);
             cv::Mat rgbMat = cv::Mat((int)h, (int)w, CV_8UC3, reinterpret_cast<uint8_t *>(img.bits()));
-            cv::cvtColor(imgMat, rgbMat, CV_RGBA2RGB, 3);
+            cv::cvtColor(imgMat, rgbMat, cv::COLOR_RGBA2RGB, 3);
 
             success = true;
         } break;
@@ -885,7 +884,7 @@ bool DkBasicLoader::loadDRIF(const QString &filePath, QImage &img, QSharedPointe
         case DRIF_FMT_GRAY: {
             cv::Mat imgMat = cv::Mat((int)h, (int)w, CV_8UC1, imgBytes);
             cv::Mat rgbMat = cv::Mat((int)h, (int)w, CV_8UC3, reinterpret_cast<uint8_t *>(img.bits()));
-            cv::cvtColor(imgMat, rgbMat, CV_GRAY2RGB);
+            cv::cvtColor(imgMat, rgbMat, cv::COLOR_GRAY2RGB);
 
             success = true;
         } break;
@@ -893,7 +892,7 @@ bool DkBasicLoader::loadDRIF(const QString &filePath, QImage &img, QSharedPointe
         case DRIF_FMT_YUV420P: {
             cv::Mat imgMat = cv::Mat((int)h + h / 2, (int)w, CV_8UC1, imgBytes);
             cv::Mat rgbMat = cv::Mat((int)h, (int)w, CV_8UC3, reinterpret_cast<uint8_t *>(img.bits()));
-            cv::cvtColor(imgMat, rgbMat, CV_YUV2RGB_I420);
+            cv::cvtColor(imgMat, rgbMat, cv::COLOR_YUV2RGB_I420);
 
             success = true;
         } break;
@@ -901,7 +900,7 @@ bool DkBasicLoader::loadDRIF(const QString &filePath, QImage &img, QSharedPointe
         case DRIF_FMT_YVU420P: {
             cv::Mat imgMat = cv::Mat((int)h + h / 2, (int)w, CV_8UC1, imgBytes);
             cv::Mat rgbMat = cv::Mat((int)h, (int)w, CV_8UC3, reinterpret_cast<uint8_t *>(img.bits()));
-            cv::cvtColor(imgMat, rgbMat, CV_YUV2RGB_YV12);
+            cv::cvtColor(imgMat, rgbMat, cv::COLOR_YUV2RGB_YV12);
 
             success = true;
         } break;
@@ -909,7 +908,7 @@ bool DkBasicLoader::loadDRIF(const QString &filePath, QImage &img, QSharedPointe
         case DRIF_FMT_NV12: {
             cv::Mat imgMat = cv::Mat((int)h + h / 2, (int)w, CV_8UC1, imgBytes);
             cv::Mat rgbMat = cv::Mat((int)h, (int)w, CV_8UC3, reinterpret_cast<uint8_t *>(img.bits()));
-            cv::cvtColor(imgMat, rgbMat, CV_YUV2RGB_NV12);
+            cv::cvtColor(imgMat, rgbMat, cv::COLOR_YUV2RGB_NV12);
 
             success = true;
         } break;
@@ -917,7 +916,7 @@ bool DkBasicLoader::loadDRIF(const QString &filePath, QImage &img, QSharedPointe
         case DRIF_FMT_NV21: {
             cv::Mat imgMat = cv::Mat((int)h + h / 2, (int)w, CV_8UC1, imgBytes);
             cv::Mat rgbMat = cv::Mat((int)h, (int)w, CV_8UC3, reinterpret_cast<uint8_t *>(img.bits()));
-            cv::cvtColor(imgMat, rgbMat, CV_YUV2RGB_NV21);
+            cv::cvtColor(imgMat, rgbMat, cv::COLOR_YUV2RGB_NV21);
 
             success = true;
         } break;
@@ -2318,14 +2317,14 @@ cv::Mat DkRawLoader::demosaic(LibRaw &iProcessor) const
 
         // define bayer pattern
         if (type == 180) {
-            cvtColor(rawMat, rgbImg, CV_BayerBG2RGB); // bitmask  10 11 01 00  -> 3(G) 2(B) 1(G) 0(R) ->	RG RG RG
-                                                      //													GB GB GB
+            cvtColor(rawMat, rgbImg, cv::COLOR_BayerBG2RGB); // bitmask  10 11 01 00  -> 3(G) 2(B) 1(G) 0(R) ->	RG RG RG
+                                                             //													GB GB GB
         } else if (type == 30) {
-            cvtColor(rawMat, rgbImg, CV_BayerRG2RGB); // bitmask  00 01 11 10	-> 0 1 3 2
+            cvtColor(rawMat, rgbImg, cv::COLOR_BayerRG2RGB); // bitmask  00 01 11 10	-> 0 1 3 2
         } else if (type == 225) {
-            cvtColor(rawMat, rgbImg, CV_BayerGB2RGB); // bitmask  11 10 00 01
+            cvtColor(rawMat, rgbImg, cv::COLOR_BayerGB2RGB); // bitmask  11 10 00 01
         } else if (type == 75) {
-            cvtColor(rawMat, rgbImg, CV_BayerGR2RGB); // bitmask  01 00 10 11
+            cvtColor(rawMat, rgbImg, cv::COLOR_BayerGR2RGB); // bitmask  01 00 10 11
         } else {
             qWarning() << "Wrong Bayer Pattern (not BG, RG, GB, GR)\n";
             return cv::Mat();
@@ -2501,7 +2500,7 @@ void DkRawLoader::reduceColorNoise(const LibRaw &iProcessor, cv::Mat &img) const
         // revert back to 8-bit image
         img.convertTo(img, CV_8U);
 
-        cv::cvtColor(img, img, CV_RGB2YCrCb);
+        cv::cvtColor(img, img, cv::COLOR_RGB2YCrCb);
 
         std::vector<cv::Mat> imgCh;
         cv::split(img, imgCh);
@@ -2511,7 +2510,7 @@ void DkRawLoader::reduceColorNoise(const LibRaw &iProcessor, cv::Mat &img) const
         cv::medianBlur(imgCh[2], imgCh[2], winSize);
 
         cv::merge(imgCh, img);
-        cv::cvtColor(img, img, CV_YCrCb2RGB);
+        cv::cvtColor(img, img, cv::COLOR_YCrCb2RGB);
         qDebug() << "median blur takes:" << dt;
     }
 }
@@ -2527,7 +2526,7 @@ QImage DkRawLoader::raw2Img(const LibRaw &iProcessor, cv::Mat &img) const
 
     // TODO: for now - fix this!
     if (img.channels() == 1)
-        cv::cvtColor(img, img, CV_GRAY2RGB);
+        cv::cvtColor(img, img, cv::COLOR_GRAY2RGB);
 
     QImage src;
     src.setColorSpace(QColorSpace{QColorSpace::SRgb}); // for output_color=1

--- a/ImageLounge/src/DkCore/DkImageStorage.cpp
+++ b/ImageLounge/src/DkCore/DkImageStorage.cpp
@@ -50,7 +50,6 @@
 
 #ifdef WITH_OPENCV
 #include "opencv2/imgproc/imgproc.hpp"
-#include "opencv2/imgproc/imgproc_c.h"
 #endif
 
 #include <cmath>
@@ -169,22 +168,22 @@ QImage DkImage::resizeImage(const QImage &src,
         QImage inImg = correctGamma ? convertToLinear(src) : src;
 
 #if WITH_OPENCV
-        int ipl = CV_INTER_CUBIC;
+        int ipl = cv::INTER_CUBIC;
         switch (interpolation) {
         case ipl_nearest:
-            ipl = CV_INTER_NN;
+            ipl = cv::INTER_NEAREST;
             break;
         case ipl_area:
-            ipl = CV_INTER_AREA;
+            ipl = cv::INTER_AREA;
             break;
         case ipl_linear:
-            ipl = CV_INTER_LINEAR;
+            ipl = cv::INTER_LINEAR;
             break;
         case ipl_cubic:
-            ipl = CV_INTER_CUBIC;
+            ipl = cv::INTER_CUBIC;
             break;
         case ipl_lanczos:
-            ipl = CV_INTER_LANCZOS4;
+            ipl = cv::INTER_LANCZOS4;
             break;
         }
 
@@ -2181,7 +2180,7 @@ void DkImage::logPolar(const cv::Mat &src,
         }
     }
 
-    cv::remap(src, dst, mapx, mapy, CV_INTER_AREA, IPL_BORDER_REPLICATE);
+    cv::remap(src, dst, mapx, mapy, cv::INTER_AREA, cv::BORDER_REPLICATE);
 }
 
 QImage DkImage::tinyPlanet(const QImage &img, double scaleLog, double angle, const QSize &size, bool invert)
@@ -2306,7 +2305,7 @@ QImage DkImage::createThumb(const QImage &image, int maxSize, ScaleConstraint co
         try {
             const auto srcImg = DkNativeImage::fromConstImage(image);
             auto dstImg = srcImg.allocateLike(QSize{imgW, imgH});
-            cv::resize(srcImg.constMat(), dstImg.mat(), cv::Size(imgW, imgH), 0, 0, CV_INTER_AREA);
+            cv::resize(srcImg.constMat(), dstImg.mat(), cv::Size(imgW, imgH), 0, 0, cv::INTER_AREA);
             thumb = dstImg.img();
         } catch (...) {
             qWarning() << "[createThumb] exception while resizing";
@@ -2871,7 +2870,7 @@ DkImageStorage::ScaledImage DkImageStorage::scaleImage(const QImage &src,
         try {
             const auto input = DkNativeImage::fromConstImage(resizedImg);
             auto output = input.allocateLike(s);
-            cv::resize(input.constMat(), output.mat(), cv::Size(s.width(), s.height()), 0, 0, CV_INTER_AREA);
+            cv::resize(input.constMat(), output.mat(), cv::Size(s.width(), s.height()), 0, 0, cv::INTER_AREA);
             scaled = output.img();
         } catch (...) {
             qWarning() << "[ImageStorage]: OpenCV exception while resizing";

--- a/ImageLounge/src/DkGui/DkDialog.cpp
+++ b/ImageLounge/src/DkGui/DkDialog.cpp
@@ -92,7 +92,6 @@
 
 #ifdef WITH_OPENCV
 #include "opencv2/imgproc/imgproc.hpp"
-#include "opencv2/imgproc/imgproc_c.h"
 #endif
 
 #ifdef WITH_QUAZIP
@@ -3200,7 +3199,7 @@ int DkMosaicDialog::computeMosaic(const QString &filter, const QString &suffix, 
 
     mImg = mImg.rowRange(qFloor(shR), mImg.rows - qCeil(shR)).colRange(qFloor(shC), mImg.cols - qCeil(shC));
     cv::Mat mImgLab;
-    cv::cvtColor(mImg, mImgLab, CV_RGB2Lab);
+    cv::cvtColor(mImg, mImgLab, cv::COLOR_RGB2Lab);
     std::vector<cv::Mat> channels;
     cv::split(mImgLab, channels);
     cv::Mat imgL = channels[0];
@@ -3308,7 +3307,7 @@ int DkMosaicDialog::computeMosaic(const QString &filter, const QString &suffix, 
                     // debug
                     cv::Mat imgT3;
                     cv::merge(channels, imgT3);
-                    cv::cvtColor(imgT3, imgT3, CV_Lab2BGR);
+                    cv::cvtColor(imgT3, imgT3, cv::COLOR_Lab2BGR);
                     emit updateImage(DkImage::mat2QImage(imgT3, mSrcImg));
                 }
 
@@ -3426,7 +3425,7 @@ cv::Mat DkMosaicDialog::createPatch(const QImage &thumb, const QString &filePath
         img = thumb;
 
     cv::Mat cvThumb = DkImage::qImage2Mat(img);
-    cv::cvtColor(cvThumb, cvThumb, CV_RGB2Lab);
+    cv::cvtColor(cvThumb, cvThumb, cv::COLOR_RGB2Lab);
     std::vector<cv::Mat> channels;
     cv::split(cvThumb, channels);
     cvThumb = channels[0];
@@ -3446,7 +3445,7 @@ cv::Mat DkMosaicDialog::createPatch(const QImage &thumb, const QString &filePath
     if (cvThumb.rows < patchRes || cvThumb.cols < patchRes)
         qDebug() << "enlarging thumbs!!";
 
-    cv::resize(cvThumb, cvThumb, cv::Size(patchRes, patchRes), 0.0, 0.0, CV_INTER_AREA);
+    cv::resize(cvThumb, cvThumb, cv::Size(patchRes, patchRes), 0.0, 0.0, cv::INTER_AREA);
 
     return cvThumb;
 }
@@ -3553,7 +3552,7 @@ bool DkMosaicDialog::postProcessMosaic(float multiply /* = 0.3 */,
             origR = mOrigImg.clone();
             mosaicR = mMosaicMatSmall.clone();
         } else {
-            cv::resize(mOrigImg, origR, mMosaicMat.size(), 0, 0, CV_INTER_LANCZOS4);
+            cv::resize(mOrigImg, origR, mMosaicMat.size(), 0, 0, cv::INTER_LANCZOS4);
             mosaicR = mMosaicMat;
             mOrigImg.release();
         }
@@ -3592,7 +3591,7 @@ bool DkMosaicDialog::postProcessMosaic(float multiply /* = 0.3 */,
 
         // if (!computePreview)
         //	mosaicMat.release();
-        cv::cvtColor(origR, origR, CV_Lab2BGR);
+        cv::cvtColor(origR, origR, cv::COLOR_Lab2BGR);
         qDebug() << "color converted";
 
         mMosaic = DkImage::mat2QImage(origR, mSrcImg);

--- a/ImageLounge/src/DkGui/DkViewPort.cpp
+++ b/ImageLounge/src/DkGui/DkViewPort.cpp
@@ -61,7 +61,6 @@
 
 #ifdef WITH_OPENCV
 #include "opencv2/imgproc/imgproc.hpp"
-#include "opencv2/imgproc/imgproc_c.h"
 #endif
 
 #ifdef Q_OS_WIN
@@ -2365,7 +2364,7 @@ void DkViewPortContrast::setImage(const QImage &newImg)
         }
         // The first element in the vector contains the gray scale 'average' of the 3 channels:
         cv::Mat grayMat;
-        cv::cvtColor(imgUC3, grayMat, CV_BGR2GRAY);
+        cv::cvtColor(imgUC3, grayMat, cv::COLOR_BGR2GRAY);
         auto grayImg = QImage((const unsigned char *)grayMat.data,
                               (int)grayMat.cols,
                               (int)grayMat.rows,


### PR DESCRIPTION
opencv 5.0 removed the legacy C API (`opencv2/imgproc/imgproc_c.h`) and the `CV_*` / `IPL_*` constant aliases it defined, and moved the shape/contour analysis functions and the `DistanceTypes` enum into the new `geometry` module. nomacs still uses those removed names, so it no longer builds against opencv 5 (#1619).

Following @scrubbbbs's suggestion in #1619 to move off the `_c` header — which on its own isn't enough, since the removed `CV_RGB2Lab` / `CV_INTER_AREA` constants still fail to compile (as @FabioLolix hit in the issue) — this does the full port:

- Rename the removed color-conversion / interpolation / border constants to `cv::COLOR_*`, `cv::INTER_*`, `cv::BORDER_*`. These have the same numeric values as the old `CV_*` aliases, so there is no behaviour change.
- Drop the `imgproc_c.h` include (replacing it with `imgproc.hpp` only in the one file where it was the sole imgproc header).
- Include `opencv2/geometry.hpp` behind `#if CV_MAJOR_VERSION >= 5` where the relocated shape functions and `cv::DIST_C` are used, so opencv 4 keeps building against `imgproc` unchanged.

Left as-is: matrix-type constants (`CV_8U`, `CV_32F`, ...), `CV_PI`, `CV_MAJOR_VERSION`, `cvRound` (all retained by opencv 5), and the `CV_MAJOR_VERSION <= 3` fallback branches.

Built cleanly against opencv 5.0.0 with Qt 6.11 (core plus all bundled plugins); opencv 4.x is unaffected since the `geometry.hpp` includes are version-guarded and the renamed enums exist there too.

Closes #1619
