### PR TITLE
Copy file paths as text from the thumbnail grid

### DIFF
--- a/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
+++ b/ImageLounge/src/DkGui/DkThumbsWidgets.cpp
@@ -1751,6 +1751,7 @@ void DkThumbScene::copySelected() const
 
     auto *mimeData = new QMimeData();
     mimeData->setUrls(urls);
+    mimeData->setText(fileList.join("\n"));
 
     QApplication::clipboard()->setMimeData(mimeData);
 }


### PR DESCRIPTION
## What

`DkThumbScene::copySelected()` (thumbnail grid → *Copy* / `Ctrl+C`) put the selected files on the clipboard only as URLs. This also adds the file paths as newline-separated plain text, so a grid selection can be pasted into a terminal, an editor, or any text target.

## Why

The viewport *Copy* already copies the file path as text (since "change edit/copy to always copy the file path"), but the thumbnail grid did not — pasting a grid selection into a plain-text target produced nothing. This aligns the grid with the viewport.

## Change

One line in `ImageLounge/src/DkGui/DkThumbsWidgets.cpp`, in `copySelected()`:

```cpp
mimeData->setUrls(urls);
mimeData->setText(fileList.join("\n"));   // added
```

The URLs are unchanged, so pasting the selection as files (Explorer, mail, and nomacs' own paste handler, which reads `hasUrls()`) keeps working; the added text is only used by targets that want text.

## Testing

Built and run on Windows (MSVC 2022, Qt 6.11.1). Selecting images in the thumbnail view and pressing `Ctrl+C` now places the newline-separated file paths on the clipboard as text (verified by reading the clipboard back), in addition to the file URLs. As noted in review, this is worth checking on other file managers / OSes and against nomacs' own paste handlers.
